### PR TITLE
x11vnc: adjust blackout region coordinates to the clipping region

### DIFF
--- a/x11vnc/xinerama.c
+++ b/x11vnc/xinerama.c
@@ -98,6 +98,13 @@ static void initialize_blackouts(char *list) {
 		if (y > Y) {
 			t = Y; Y = y; y = t;
 		}
+
+		/* take clipping region into account */
+		x = nfix(x - coff_x, wdpy_x);
+		X = nfix(X - coff_x, wdpy_x);
+		y = nfix(y - coff_y, wdpy_y);
+		Y = nfix(Y - coff_y, wdpy_y);
+
 		if (x < 0 || x > dpy_x || y < 0 || y > dpy_y ||
 		    X < 0 || X > dpy_x || Y < 0 || Y > dpy_y ||
 		    x == X || y == Y) {


### PR DESCRIPTION
I think I found a bug in the x11vnc server - it seems that the blackout array initialized in `initialize_blackouts()` (x11vnc/xinerama.c:67) uses absolute coordinates, but rest of the code assumes they are relative to the clipping region. In some cases that prevents valid desktop parts from being streamed correctly.

Screenshot (main output: 1920x1080+0+0, virtual output: 2000x2000+1920+0 - VNC'd to the visible client):
![screenshot from 2014-05-13 19 25 19](https://cloud.githubusercontent.com/assets/1735012/2961161/c2a62fde-dac3-11e3-9e3d-a48484fd033f.png)

Steps to reproduce:
1. Have a second X11 output (let's call it Out2) placed right of the main one (Out1). The height of Out2 needs to be greater than the height of the Out1.
2. Run x11vnc server with clipping region set to the entire Out2.
3. Connect to the started server - there should be a black rectangle `Out1.width` pixels wide, starting at offset `0, Out1.height` relative to the streamed region.

Exact commands I use to reproduce this bug on an Ubuntu laptop with intel video card and intel-virtual-output enabled:

```
$ xrandr --newmode my_video_mode `cvt 2000 2000 | awk '/^Modeline/ { print substr($0, index($0, $3)) }'`
$ xrandr --addmode VIRTUAL1 my_video_mode
$ xrandr --output VIRTUAL1 --mode my_video_mode --pos 1920x0
$ x11vnc -clip "2000x2000+1920+0"
```

(on another terminal)

```
$ vncviewer 127.0.0.1
```

Attached code seems to fix the issue :-)
