### PR TITLE
Initialize padding in SetFormatAndEncodings' rfbSetPixelFormatMsg.

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -1288,6 +1288,8 @@ SetFormatAndEncodings(rfbClient* client)
   if (!SupportsClient2Server(client, rfbSetPixelFormat)) return TRUE;
 
   spf.type = rfbSetPixelFormat;
+  spf.pad1 = 0;
+  spf.pad2 = 0;
   spf.format = client->format;
   spf.format.redMax = rfbClientSwap16IfLE(spf.format.redMax);
   spf.format.greenMax = rfbClientSwap16IfLE(spf.format.greenMax);


### PR DESCRIPTION
This makes valgrind happy, and per [RFC 6143](http://tools.ietf.org/html/rfc6143#section-7):

> For maximum compatibility, messages should be generated with padding set to zero [...]
