### PR TITLE
x11vnc: fix double X_UNLOCK on xrandr events

### DIFF
--- a/x11vnc/xrandr.c
+++ b/x11vnc/xrandr.c
@@ -268,6 +268,7 @@ int check_xrandr_event(char *msg) {
 			/* under do_change caller normally returns before its X_UNLOCK */
 			X_UNLOCK;
 			handle_xrandr_change(rev->width, rev->height);
+			X_LOCK;
 		}
 		if (qout) {
 			return do_change;


### PR DESCRIPTION
check_xrandr_event() assumes X_LOCK is taken before it is called, and currently calls X_UNLOCK on behalf of the caller. But in practice, all callers assume that the lock is still held after check_xrandr_event() returns. In particular, this leads to a double-unlock and crash in check_xevents() on any xrandr resize event.

Steps to Reproduce:
1. Run x11vnc, eg `x11vnc -rfbport 5901 -display :0 -localhost`. It doesn't make any difference whether you pass an '-xrandr' option or not. There is also no need to connect a client.
2. Resize your display, eg from GNOME Settings -> Displays

For a stacktrace, see [this Fedora bug report](https://bugzilla.redhat.com/show_bug.cgi?id=1118353).

I've not tested this fix extensively, but it does seem to work. I don't run x11vnc with `-threads` so I guess there's a whole class of potential bugs I might be avoiding. :)
