### PR TITLE
Fixing two more security issues (remote server crash)

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -2491,6 +2491,13 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
           rfbCloseClient(cl);
           return;
       }
+
+      if (msg.ssc.scale == 0) {
+          rfbLogPerror("rfbProcessClientNormalMessage: will not accept a scale factor of zero");
+          rfbCloseClient(cl);
+          return;
+      }
+
       rfbStatRecordMessageRcvd(cl, msg.type, sz_rfbSetScaleMsg, sz_rfbSetScaleMsg);
       rfbLog("rfbSetScale(%d)\n", msg.ssc.scale);
       rfbScalingSetup(cl,cl->screen->width/msg.ssc.scale, cl->screen->height/msg.ssc.scale);
@@ -2507,6 +2514,13 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
           rfbCloseClient(cl);
           return;
       }
+
+      if (msg.ssc.scale == 0) {
+          rfbLogPerror("rfbProcessClientNormalMessage: will not accept a scale factor of zero");
+          rfbCloseClient(cl);
+          return;
+      }
+
       rfbStatRecordMessageRcvd(cl, msg.type, sz_rfbSetScaleMsg, sz_rfbSetScaleMsg);
       rfbLog("rfbSetScale(%d)\n", msg.ssc.scale);
       rfbScalingSetup(cl,cl->screen->width/msg.ssc.scale, cl->screen->height/msg.ssc.scale);


### PR DESCRIPTION
Those 2 commits fix the following issues:

1/ ClientCutText message allows up to 2**32-1 bytes of text to be transferred. malloc() of such a large value is likely to fail on server-side, resulting in a server crash (NULL pointer dereference) if malloc() return value is not checked.

Note: this issue affects other VNC implementations
http://cross-site-scripting.blogspot.ch/2010/05/realvnc-vnc-server-free-edition-413.html

2/ SetScale message allows to setup a scale ratio of zero, which will obviously result in a "divide by zero" issue and server crash.
