### PR TITLE
tls_openssl.c: define _XOPEN_SOURCE for extra POSIX functionality

### DIFF
--- a/libvncclient/tls_openssl.c
+++ b/libvncclient/tls_openssl.c
@@ -18,6 +18,10 @@
  *  USA.
  */
 
+#ifndef _MSC_VER
+#define _XOPEN_SOURCE 500
+#endif
+
 #include <rfb/rfbclient.h>
 #include <errno.h>
 


### PR DESCRIPTION
On some systems pthread_mutexattr_settype() and PTHREAD_MUTEX_RECURSIVE are
not available by default.
Either _XOPEN_SOURCE or _POSIX_C_SOURCE needs to be set to to the right level
before including any system include file in order to have them exposed.

Fixes the following compile error, which occurs if you use buildroot to build a rootfs, and have the threading model set to linuxthreads instead of NPTL.

```
tls_openssl.c: In function 'dyn_create_function':
tls_openssl.c:91:2: warning: implicit declaration of function 'pthread_mutexattr_settype' [-Wimplicit-function-declaration]
  MUTEX_INIT(value->mutex);
  ^
tls_openssl.c:42:40: error: 'PTHREAD_MUTEX_RECURSIVE' undeclared (first use in this function)
  pthread_mutexattr_settype(&mutexAttr, PTHREAD_MUTEX_RECURSIVE);\
                                        ^
tls_openssl.c:91:2: note: in expansion of macro 'MUTEX_INIT'
  MUTEX_INIT(value->mutex);
  ^
tls_openssl.c:42:40: note: each undeclared identifier is reported only once for each function it appears in
  pthread_mutexattr_settype(&mutexAttr, PTHREAD_MUTEX_RECURSIVE);\
                                        ^
tls_openssl.c:91:2: note: in expansion of macro 'MUTEX_INIT'
  MUTEX_INIT(value->mutex);
  ^
tls_openssl.c: In function 'InitializeTLS':
tls_openssl.c:42:40: error: 'PTHREAD_MUTEX_RECURSIVE' undeclared (first use in this function)
  pthread_mutexattr_settype(&mutexAttr, PTHREAD_MUTEX_RECURSIVE);\
                                        ^
tls_openssl.c:156:5: note: in expansion of macro 'MUTEX_INIT'
     MUTEX_INIT(mutex_buf[i]);
     ^
tls_openssl.c: In function 'ssl_verify':
tls_openssl.c:177:7: warning: variable 'err' set but not used [-Wunused-but-set-variable]
   int err, i;
       ^
tls_openssl.c:176:14: warning: variable 'client' set but not used [-Wunused-but-set-variable]
   rfbClient *client;
              ^
make[3]: *** [tls_openssl.lo] Error 1
```

Signed-off-by: Floris Bos <bos@je-eigen-domein.nl>