### PR TITLE
Initialize libgcrypt before use

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -857,6 +857,16 @@ HandleARDAuth(rfbClient *client)
   rfbCredential *cred = NULL;
   rfbBool result = FALSE;
 
+  if (!gcry_control(GCRYCTL_INITIALIZATION_FINISHED_P))
+  {
+    /* Application did not initialize gcrypt, so we should */
+    if (!gcry_check_version(GCRYPT_VERSION))
+    {
+      /* Older version of libgcrypt is installed on system than compiled against */
+      rfbClientLog("libgcrypt version mismatch.\n");
+    }
+  }
+
   while (1)
   {
     if (!ReadFromRFBServer(client, (char *)gen, 2))


### PR DESCRIPTION
https://www.gnupg.org/documentation/manuals/gcrypt/Initializing-the-library.html

```Before the library can be used, it must initialize itself.
This is achieved by invoking the function gcry_check_version```

Closes issue #45
Tested with krdc + libgcrypt 1.6.1 (libgcrypt20-dev Ubuntu package)
connecting to a Mac Mini.

Signed-off-by: Floris Bos <bos@je-eigen-domein.nl>