### PR TITLE
Update README and add client library connect/auth hooks

### DIFF
--- a/README
+++ b/README
@@ -116,7 +116,7 @@ drawn the cursor everytime an update is sent. LibVNCServer handles
 all the details. Just set the cursor and don't bother any more.
 
 To set the mouse coordinates (or emulate mouse clicks), call
-  defaultPtrAddEvent(buttonMask,x,y,cl);
+  rfbDefaultPtrAddEvent(buttonMask,x,y,cl);
 IMPORTANT: do this at the end of your function, because this actually draws
 the cursor if no cursor encoding is active.
 
@@ -182,7 +182,7 @@ kbdReleaseAllKeys(rfbClientPtr cl)
 ptrAddEvent(int buttonMask,int x,int y,rfbClientPtr cl)
   is called when the mouse moves or a button is pressed.
   WARNING: if you want to have proper cursor handling, call
-	defaultPtrAddEvent(buttonMask,x,y,cl)
+	rfbDefaultPtrAddEvent(buttonMask,x,y,cl)
   in your own function. This sets the coordinates of the cursor.
 setXCutText(char* str,int len,rfbClientPtr cl)
   is called when the selection changes.

--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -173,6 +173,8 @@ ReadFromRFBServer(rfbClient* client, char *out, unsigned int n)
 	    return FALSE;
 	  }
 	} else {
+          if (client->NetworkStatus)
+            client->NetworkStatus(client, rfbNetworkConnectionClosed);
 	  if (errorMessageOnReadFailure) {
 	    rfbClientLog("VNC server closed connection\n");
 	  }
@@ -212,6 +214,8 @@ ReadFromRFBServer(rfbClient* client, char *out, unsigned int n)
 	    return FALSE;
 	  }
 	} else {
+          if (client->NetworkStatus)
+            client->NetworkStatus(client, rfbNetworkConnectionClosed);
 	  if (errorMessageOnReadFailure) {
 	    rfbClientLog("VNC server closed connection\n");
 	  }

--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -250,10 +250,16 @@ static rfbBool rfbInitConnection(rfbClient* client)
     }
   }
 
+  if (client->NetworkStatus)
+    client->NetworkStatus(client, rfbNetworkConnectionSuccess);
+
   /* Initialise the VNC connection, including reading the password */
 
   if (!InitialiseRFBConnection(client))
     return FALSE;
+
+  if (client->NetworkStatus)
+    client->NetworkStatus(client, rfbNetworkRFBConnectionSuccess);
 
   client->width=client->si.framebufferWidth;
   client->height=client->si.framebufferHeight;

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -445,7 +445,6 @@ clientOutput(void *data)
     rfbClientPtr cl = (rfbClientPtr)data;
     rfbBool haveUpdate;
     sraRegion* updateRegion;
-    cl->onHold = FALSE;
 
     while (1) {
         haveUpdate = false;

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -445,6 +445,7 @@ clientOutput(void *data)
     rfbClientPtr cl = (rfbClientPtr)data;
     rfbBool haveUpdate;
     sraRegion* updateRegion;
+    cl->onHold = FALSE;
 
     while (1) {
         haveUpdate = false;

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -169,6 +169,8 @@ typedef void (*SoftCursorUnlockScreenProc)(struct _rfbClient* client);
 typedef void (*GotFrameBufferUpdateProc)(struct _rfbClient* client, int x, int y, int w, int h);
 typedef void (*FinishedFrameBufferUpdateProc)(struct _rfbClient* client);
 typedef char* (*GetPasswordProc)(struct _rfbClient* client);
+typedef void (*AuthenticationResultsProc)(struct _rfbClient* client, uint32_t authResult);
+typedef void (*NetworkStatusProc)(struct _rfbClient* client, uint32_t errorCode);
 typedef rfbCredential* (*GetCredentialProc)(struct _rfbClient* client, int credentialType);
 typedef rfbBool (*MallocFrameBufferProc)(struct _rfbClient* client);
 typedef void (*GotXCutTextProc)(struct _rfbClient* client, const char *text, int textlen);
@@ -292,6 +294,8 @@ typedef struct _rfbClient {
 	GotFrameBufferUpdateProc GotFrameBufferUpdate;
 	/** the pointer returned by GetPassword will be freed after use! */
 	GetPasswordProc GetPassword;
+	AuthenticationResultsProc AuthenticationResults;
+	NetworkStatusProc NetworkStatus;
 	MallocFrameBufferProc MallocFrameBuffer;
 	GotXCutTextProc GotXCutText;
 	BellProc Bell;

--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -125,6 +125,14 @@ typedef uint32_t in_addr_t;
 
 #define MAX_ENCODINGS 21
 
+#define rfbNetworkConnectionSuccess 0
+#define rfbNetworkRFBConnectionSuccess 1
+#define rfbNetworkConnectionClosed 2
+#define rfbNetworkConnectionFailed 3
+#define rfbNetworkNameResolutionFailed 4
+#define rfbNetworkRFBServerNotValid 5
+#define rfbNetworkRFBProtocolFailure 6
+
 /*****************************************************************************
  *
  * Structures used in several messages


### PR DESCRIPTION
This fixes Issue #52 and also fixes a problem noted in testing with the threaded server build, whereby if newClientHook() returned RFB_CLIENT_ON_HOLD there was no way to release the hold when the server became ready.
