### PR TITLE
Avoid divide-by-zero in raw encoding (OSX RealVNC)

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -1936,7 +1936,10 @@ HandleRFBServerMessage(rfbClient* client)
 	int y=rect.r.y, h=rect.r.h;
 
 	bytesPerLine = rect.r.w * client->format.bitsPerPixel / 8;
-	linesToRead = RFB_BUFFER_SIZE / bytesPerLine;
+	/* RealVNC 4.x-5.x on OSX can induce bytesPerLine==0, 
+	   usually during GPU accel. */
+	/* Regardless of cause, do not divide by zero. */
+	linesToRead = bytesPerLine ? (RFB_BUFFER_SIZE / bytesPerLine) : 0;
 
 	while (h > 0) {
 	  if (linesToRead > h)


### PR DESCRIPTION
OS X RealVNC server crashes out Remmina because the server can provoke
bytesPerLine to be zero. Assume this is coding for zero lines.

The condition could be checked before the calculation of bytesPerLine.
I don’t understand the preconditions of this code to say one way or the
other.