### PR TITLE
httpd: disallow directory traversal

### DIFF
--- a/libvncserver/httpd.c
+++ b/libvncserver/httpd.c
@@ -423,6 +423,14 @@ httpProcessInput(rfbScreenInfoPtr rfbScreen)
        }
     }
 
+    /* Basic protection against directory traversal outside webroot */
+
+    if (strstr(fname, "..")) {
+        rfbErr("httpd: URL should not contain '..'\n");
+        rfbWriteExact(&cl, NOT_FOUND_STR, strlen(NOT_FOUND_STR));
+        httpCloseSock(rfbScreen);
+        return;
+    }
 
     /* If we were asked for '/', actually read the file index.vnc */
 


### PR DESCRIPTION
Do not process HTTP requests that have .. in the URL.
Provides very basic protection against directory traversal outside of webroot.


In the long run, it might be better to add a more sophisticated check than this.
But that will likely require platform specific code.