### PR TITLE
prevent segfaults due to uninitialized memory

### DIFF
--- a/libvncserver/rfbssl_gnutls.c
+++ b/libvncserver/rfbssl_gnutls.c
@@ -109,6 +109,8 @@ struct rfbssl_ctx *rfbssl_init_global(char *key, char *cert)
 	gnutls_global_set_log_function(rfbssl_log_func);
 	gnutls_global_set_log_level(1);
 	gnutls_certificate_set_dh_params(ctx->x509_cred, ctx->dh_params);
+	//newly allocated memory should be initialized, at least where it is important
+	ctx->peekstart = ctx->peeklen = 0;
 	return ctx;
     }
 

--- a/libvncserver/rfbssl_gnutls.c
+++ b/libvncserver/rfbssl_gnutls.c
@@ -109,7 +109,7 @@ struct rfbssl_ctx *rfbssl_init_global(char *key, char *cert)
 	gnutls_global_set_log_function(rfbssl_log_func);
 	gnutls_global_set_log_level(1);
 	gnutls_certificate_set_dh_params(ctx->x509_cred, ctx->dh_params);
-	//newly allocated memory should be initialized, at least where it is important
+	/* newly allocated memory should be initialized, at least where it is important */
 	ctx->peekstart = ctx->peeklen = 0;
 	return ctx;
     }

--- a/libvncserver/tight.c
+++ b/libvncserver/tight.c
@@ -163,7 +163,11 @@ void rfbTightCleanup (rfbScreenInfoPtr screen)
         tightAfterBufSize = 0;
         tightAfterBuf = NULL;
     }
-    if (j) tjDestroy(j);
+	if (j) {
+		tjDestroy(j);
+		//Set freed resource handle to 0!
+		j = 0;
+	}
 }
 
 

--- a/libvncserver/tight.c
+++ b/libvncserver/tight.c
@@ -165,7 +165,7 @@ void rfbTightCleanup (rfbScreenInfoPtr screen)
     }
 	if (j) {
 		tjDestroy(j);
-		//Set freed resource handle to 0!
+		/* Set freed resource handle to 0! */
 		j = 0;
 	}
 }


### PR DESCRIPTION
When using gnutls to provide TLS for websockets, it's likely to crash in function rfbssl_gc_peekbuf. Also if tight encoding is used and rfbTightCleanup is called, which seems to happen when a client disconnects, the next attempt to use tight encoding will fail, cause j is not reinitialized again.
