### PR TITLE
use namespaced vnc_max macro (issue #102)

### DIFF
--- a/libvncclient/listen.c
+++ b/libvncclient/listen.c
@@ -30,9 +30,6 @@
 #ifdef WIN32
 #define close closesocket
 #include <winsock2.h>
-#ifdef _MINGW32
-#undef max
-#endif // #ifdef _MINGW32
 #else // #ifdef WIN32
 #include <sys/wait.h>
 #include <sys/utsname.h>
@@ -99,7 +96,7 @@ listenForIncomingConnections(rfbClient* client)
     if(listen6Socket >= 0)
       FD_SET(listen6Socket, &fds);
 
-    r = select(max(listenSocket, listen6Socket)+1, &fds, NULL, NULL, NULL);
+    r = select(rfbMax(listenSocket, listen6Socket)+1, &fds, NULL, NULL, NULL);
 
     if (r > 0) {
       if (FD_ISSET(listenSocket, &fds))
@@ -195,9 +192,9 @@ listenForIncomingConnectionsNoFork(rfbClient* client, int timeout)
     FD_SET(client->listen6Sock, &fds);
 
   if (timeout < 0)
-    r = select(max(client->listenSock, client->listen6Sock) +1, &fds, NULL, NULL, NULL);
+    r = select(rfbMax(client->listenSock, client->listen6Sock) +1, &fds, NULL, NULL, NULL);
   else
-    r = select(max(client->listenSock, client->listen6Sock) +1, &fds, NULL, NULL, &to);
+    r = select(rfbMax(client->listenSock, client->listen6Sock) +1, &fds, NULL, NULL, &to);
 
   if (r > 0)
     {

--- a/libvncserver/httpd.c
+++ b/libvncserver/httpd.c
@@ -192,7 +192,7 @@ rfbHttpCheckFds(rfbScreenInfoPtr rfbScreen)
     }
     tv.tv_sec = 0;
     tv.tv_usec = 0;
-    nfds = select(max(rfbScreen->httpListen6Sock, max(rfbScreen->httpSock,rfbScreen->httpListenSock)) + 1, &fds, NULL, NULL, &tv);
+    nfds = select(rfbMax(rfbScreen->httpListen6Sock, rfbMax(rfbScreen->httpSock,rfbScreen->httpListenSock)) + 1, &fds, NULL, NULL, &tv);
     if (nfds == 0) {
 	return;
     }

--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -369,7 +369,7 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
       }
 
       FD_SET(sock,&(rfbScreen->allFds));
-		rfbScreen->maxFd = max(sock,rfbScreen->maxFd);
+		rfbScreen->maxFd = rfbMax(sock,rfbScreen->maxFd);
 
       INIT_MUTEX(cl->outputMutex);
       INIT_MUTEX(cl->refCountMutex);

--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -193,7 +193,7 @@ rfbInitSockets(rfbScreenInfoPtr rfbScreen)
 
         rfbLog("Autoprobing selected TCP6 port %d\n", rfbScreen->ipv6port);
 	FD_SET(rfbScreen->listen6Sock, &(rfbScreen->allFds));
-	rfbScreen->maxFd = max((int)rfbScreen->listen6Sock,rfbScreen->maxFd);
+	rfbScreen->maxFd = rfbMax((int)rfbScreen->listen6Sock,rfbScreen->maxFd);
 #endif
     }
     else
@@ -220,7 +220,7 @@ rfbInitSockets(rfbScreenInfoPtr rfbScreen)
       rfbLog("Listening for VNC connections on TCP6 port %d\n", rfbScreen->ipv6port);  
 	
       FD_SET(rfbScreen->listen6Sock, &(rfbScreen->allFds));
-      rfbScreen->maxFd = max((int)rfbScreen->listen6Sock,rfbScreen->maxFd);
+      rfbScreen->maxFd = rfbMax((int)rfbScreen->listen6Sock,rfbScreen->maxFd);
 	    }
 #endif
 
@@ -236,7 +236,7 @@ rfbInitSockets(rfbScreenInfoPtr rfbScreen)
 	rfbLog("Listening for VNC connections on TCP port %d\n", rfbScreen->port);  
 
 	FD_SET(rfbScreen->udpSock, &(rfbScreen->allFds));
-	rfbScreen->maxFd = max((int)rfbScreen->udpSock,rfbScreen->maxFd);
+	rfbScreen->maxFd = rfbMax((int)rfbScreen->udpSock,rfbScreen->maxFd);
     }
 }
 
@@ -563,7 +563,7 @@ rfbConnect(rfbScreenInfoPtr rfbScreen,
 
     /* AddEnabledDevice(sock); */
     FD_SET(sock, &rfbScreen->allFds);
-    rfbScreen->maxFd = max(sock,rfbScreen->maxFd);
+    rfbScreen->maxFd = rfbMax(sock,rfbScreen->maxFd);
 
     return sock;
 }

--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -93,8 +93,8 @@
 #define strncasecmp _strnicmp
 #endif
 
+#define rfbMax(a,b) (((a)>(b))?(a):(b))
 #if !defined(WIN32) || defined(__MINGW32__)
-#define max(a,b) (((a)>(b))?(a):(b))
 #ifdef LIBVNCSERVER_HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
Not using generic 'max', avoids conflicts with stl_algobase.h

The macro was previously not used on WIN32/MINGW32 apparently , so someone with more experience with building for those platforms may want to double-check this.