### PR TITLE
Fix memory access error in camera.c example

### DIFF
--- a/examples/camera.c
+++ b/examples/camera.c
@@ -104,7 +104,7 @@ int TakePicture(unsigned char *buffer)
    */
   gettimeofday(&now,NULL);
   line = now.tv_usec / (1000000/HEIGHT);
-  if (line>HEIGHT) line=HEIGHT-1;
+  if (line>=HEIGHT) line=HEIGHT-1;
   memset(&buffer[(WIDTH * BPP) * line], 0, (WIDTH * BPP));
 
   /* frames per second (informational only) */


### PR DESCRIPTION
The camera.c example application would sometimes crash due to a memset outside the allocated memory.