### PR TITLE
Fix buffer overflow when applying client encodings

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -1492,7 +1492,8 @@ SetFormatAndEncodings(rfbClient* client)
     if(e->encodings) {
       int* enc;
       for(enc = e->encodings; *enc; enc++)
-	encs[se->nEncodings++] = rfbClientSwap32IfLE(*enc);
+        if(se->nEncodings < MAX_ENCODINGS)
+          encs[se->nEncodings++] = rfbClientSwap32IfLE(*enc);
     }
 
   len = sz_rfbSetEncodingsMsg + se->nEncodings * 4;


### PR DESCRIPTION
Whenever as a result of encodings passed in the client extensions the overall number of encodings exceeded MAX_ENCODINGS, a buffer overflow would occur.