### PR TITLE
Enable AF_UNIX socket: ignore setsockopt TCP_NODELAY failure.

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -363,9 +363,7 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
 
       if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		     (char *)&one, sizeof(one)) < 0) {
-	rfbLogPerror("setsockopt failed");
-	close(sock);
-	return NULL;
+	rfbLogPerror("setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
       }
 
       FD_SET(sock,&(rfbScreen->allFds));

--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -146,8 +146,7 @@ rfbInitSockets(rfbScreenInfoPtr rfbScreen)
 
 	if (setsockopt(rfbScreen->inetdSock, IPPROTO_TCP, TCP_NODELAY,
 		       (char *)&one, sizeof(one)) < 0) {
-	    rfbLogPerror("setsockopt");
-	    return;
+	    rfbLogPerror("setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
 	}
 
     	FD_ZERO(&(rfbScreen->allFds));
@@ -453,9 +452,7 @@ rfbProcessNewConnection(rfbScreenInfoPtr rfbScreen)
 
     if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		   (char *)&one, sizeof(one)) < 0) {
-      rfbLogPerror("rfbCheckFds: setsockopt");
-      closesocket(sock);
-      return FALSE;
+      rfbLogPerror("rfbCheckFds: setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
     }
 
 #ifdef USE_LIBWRAP
@@ -556,9 +553,7 @@ rfbConnect(rfbScreenInfoPtr rfbScreen,
 
     if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		   (char *)&one, sizeof(one)) < 0) {
-	rfbLogPerror("setsockopt failed");
-	closesocket(sock);
-	return -1;
+	rfbLogPerror("setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
     }
 
     /* AddEnabledDevice(sock); */


### PR DESCRIPTION
I am bulding a docker vncterm using libvncserver, works with openstack nova-docker driver.

Due to the firewall access control list, I can only listen on a single port. So I use a proxy in front of docker vncterms. The proxy connects to vncterms using AF_UNIX socket (In each compute node, we runs over 1000+ containers, and multiple vncservers can be launched for each container. It may requires lots of TCP ports. It's much easier to use AF_UNIX socket, I just create a unique path, I don't needs to probe and auto allocate TCP ports).

Checking setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one) and exit prevents it from working, so I ignore the errors.

