### PR TITLE
libvncclient/tls_gnutls.c: Add hooks to WriteToTLS() for optional protection by mutex. (Squashed)

### DIFF
--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -220,6 +220,8 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->subAuthScheme = 0;
   client->GetCredential = NULL;
   client->tlsSession = NULL;
+  client->LockWriteToTLS = NULL;
+  client->UnlockWriteToTLS = NULL;
   client->sock = -1;
   client->listenSock = -1;
   client->listenAddress = NULL;

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -182,6 +182,8 @@ typedef void (*BellProc)(struct _rfbClient* client);
 */
 typedef void (*GotCursorShapeProc)(struct _rfbClient* client, int xhot, int yhot, int width, int height, int bytesPerPixel);
 typedef void (*GotCopyRectProc)(struct _rfbClient* client, int src_x, int src_y, int w, int h, int dest_x, int dest_y);
+typedef rfbBool (*LockWriteToTLSProc)(struct _rfbClient* client);
+typedef rfbBool (*UnlockWriteToTLSProc)(struct _rfbClient* client);
 
 typedef struct _rfbClient {
 	uint8_t* frameBuffer;
@@ -360,6 +362,10 @@ typedef struct _rfbClient {
 
         /* Output Window ID. When set, client application enables libvncclient to perform direct rendering in its window */
         unsigned long outputWindow;
+
+	/** Hooks for optional protection WriteToTLS() by mutex */
+	LockWriteToTLSProc LockWriteToTLS;
+	UnlockWriteToTLSProc UnlockWriteToTLS;
 
 } rfbClient;
 


### PR DESCRIPTION
Fix upstream issue #100

Squashed commit of the pull request #101 :
commit 1c7e01e81862bc46508e675e83c74cc6d63224b0
commit 1e749b094d6696380d3f0540a00138d7e3427874