### PR TITLE
Avoid calling SSL_pending when connection is already closed

### DIFF
--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -394,7 +394,7 @@ rfbCheckFds(rfbScreenInfoPtr rfbScreen,long usec)
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
                     do {
                         rfbProcessClientMessage(cl);
-                    } while (webSocketsHasDataInBuffer(cl));
+                    } while (cl->sock > 0 && webSocketsHasDataInBuffer(cl));
 #else
                     rfbProcessClientMessage(cl);
 #endif


### PR DESCRIPTION
Avoid calling SSL_pending when connection is already closed, calling SSL_pending with connection already closed is crashing. 
To reproduce, open a secure websocket binay protocol connection with libvncserver compiled with OpenSSL, and when libvncserver is waiting for rfbProcessClientProtocolVersion send any invalid char, it will fail and call rfbCloseClient whith destroy all SSL context, calling SSL_pending after that will generate a invalid access.