### PR TITLE
test/Makefile: use check_PROGRAMS

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,7 +1,8 @@
+check_PROGRAMS =
 
 if HAVE_LIBJPEG
 # TurboJPEG wrapper tests
-noinst_PROGRAMS=tjunittest tjbench
+check_PROGRAMS += tjunittest tjbench
 tjunittest_SOURCES=tjunittest.c ../common/turbojpeg.c ../common/turbojpeg.h \
 	tjutil.c tjutil.h
 tjbench_SOURCES=tjbench.c ../common/turbojpeg.c ../common/turbojpeg.h \
@@ -19,7 +20,7 @@ endif
 
 copyrecttest_LDADD=$(LDADD) -lm
 
-check_PROGRAMS=$(ENCODINGS_TEST) cargstest copyrecttest $(BACKGROUND_TEST) \
+check_PROGRAMS += $(ENCODINGS_TEST) cargstest copyrecttest $(BACKGROUND_TEST) \
 	cursortest
 
 test: encodingstest$(EXEEXT) cargstest$(EXEEXT) copyrecttest$(EXEEXT)


### PR DESCRIPTION
The new jpeg tests were added to noinst when they should have been
under check like all the other programs in here.