### PR TITLE
configure: add sys/uio.h check for websockets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -386,6 +386,7 @@ if test "x$HAVE_B64" != "xtrue"; then
 	with_websockets=""
 fi
 if test "x$with_websockets" = "xyes"; then
+	AC_CHECK_HEADERS([sys/uio.h])
 	LIBS="$LIBS $RESOLV_LIB $SSL_LIBS"
 	AC_DEFINE(WITH_WEBSOCKETS)
 fi


### PR DESCRIPTION
Commit 37f293d added the check for <sys/uio.h> when building with
websockets in cmake, this commit adds the same check for autotools.
