### PR TITLE
websockets: Ensure compatibility with gtk-vnc 0.7.0+

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -245,7 +245,10 @@ webSocketsCheck (rfbClientPtr cl)
       return FALSE;
     }
 
-    if (strncmp(bbuf, "<", 1) == 0) {
+    if (strncmp(bbuf, "RFB ", 4) == 0) {
+        rfbLog("Normal socket connection\n");
+        return TRUE;
+    } else if (strncmp(bbuf, "<", 1) == 0) {
         rfbLog("Got Flash policy request, sending response\n");
         if (rfbWriteExact(cl, FLASH_POLICY_RESPONSE,
                           SZ_FLASH_POLICY_RESPONSE) < 0) {


### PR DESCRIPTION
gtk-vnc 0.7.0 ships with a little [trick](https://git.gnome.org/browse/gtk-vnc/commit/?id=7f4f2fe8da72ed9fef5dd4319e19feb2b4f3d62e) that prevents erroneous connections from VNC clients to SPICE servers from hanging indefinitely.  The trick is to send 4 out of 12 bytes comprising the [*ProtocolVersion Handshake*](https://tools.ietf.org/html/rfc6143#section-7.1.1) without waiting for the server to send anything and only send the remaining 8 bytes after receiving the *ProtocolVersion Handshake* from the server.  However, if libvncserver asserts there is data waiting to be read from a connected socket before it sends its *ProtocolVersion Handshake*, it assumes it is not a normal VNC connection and attempts to detect what it is talking to.  As `"RFB "` is not among the options it checks, all connections from clients using this trick are immediately dropped with the following log message:

    webSocketsHandshake: invalid client header

This pull request adds `"RFB "` to the list of strings libvncserver checks for when data is received from the client before the *ProtocolVersion Handshake* is sent, thus enabling clients using gtk-vnc 0.7.0+ to successfully connect.
