### PR TITLE
websockets: Check RFB signature in webSocketCheck

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -237,7 +237,7 @@ webSocketsCheck (rfbClientPtr cl)
 
     ret = rfbPeekExactTimeout(cl, bbuf, 4,
                                    WEBSOCKETS_CLIENT_CONNECT_WAIT_MS);
-    if ((ret < 0) && (errno == ETIMEDOUT)) {
+    if (((ret < 0) && (errno == ETIMEDOUT)) || strncmp(bbuf, "RFB ", 4) == 0) {
       rfbLog("Normal socket connection\n");
       return TRUE;
     } else if (ret <= 0) {


### PR DESCRIPTION
Client tools vinagre 3.22.0-1.fc25 and virt-manager from src upstream
after TCP handshake send TCP packet with "RFB 003.008" and 
it caused an error "webSocketsHandshake: invalid client header".
In webSocketsCheck() we receive this packet and deside that
it should contain "GET " otherwise it's invalid webSocket handshake header.
We should regard this case as "Normal socket connection".