### PR TITLE
Fixed crash that occurs when IPv6 is disabled on the system.

### DIFF
--- a/libvncserver/httpd.c
+++ b/libvncserver/httpd.c
@@ -208,7 +208,7 @@ rfbHttpCheckFds(rfbScreenInfoPtr rfbScreen)
 	httpProcessInput(rfbScreen);
     }
 
-    if (FD_ISSET(rfbScreen->httpListenSock, &fds) || FD_ISSET(rfbScreen->httpListen6Sock, &fds)) {
+    if (FD_ISSET(rfbScreen->httpListenSock, &fds) || (rfbScreen->httpListen6Sock > -1 && FD_ISSET(rfbScreen->httpListen6Sock, &fds))) {
 	if (rfbScreen->httpSock >= 0) close(rfbScreen->httpSock);
 
 	if(FD_ISSET(rfbScreen->httpListenSock, &fds)) {
@@ -217,7 +217,7 @@ rfbHttpCheckFds(rfbScreenInfoPtr rfbScreen)
 	      return;
 	    }
 	}
-	else if(FD_ISSET(rfbScreen->httpListen6Sock, &fds)) {
+	else if(rfbScreen->httpListen6Sock > -1 && FD_ISSET(rfbScreen->httpListen6Sock, &fds)) {
 	    if ((rfbScreen->httpSock = accept(rfbScreen->httpListen6Sock, (struct sockaddr *)&addr, &addrlen)) < 0) {
 	      rfbLogPerror("httpCheckFds: accept");
 	      return;


### PR DESCRIPTION
I'm using libvncserver with x11vnc.  When attempting to establish an HTTP connection with x11vnc on a system where IPv6 is disabled, a crash occurs.
The problem is that in this scenario, the IPv6 socket initialization fails and part of the code is using the socket without first checking its validity.
The crash is not prevented when disabling IPv6 from libvncserver at compile or run time.
This crash can also be reproduced by forcing (via the -httpportv6 option) the IPv6 HTTP port to a value like -1.