### PR TITLE
Added support for X509 server certificate verification

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -18,6 +18,7 @@
  */
 
 #include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
 #include <rfb/rfbclient.h>
 #include <errno.h>
 #ifdef WIN32
@@ -39,6 +40,101 @@ static gnutls_dh_params_t rfbDHParams;
 
 static rfbBool rfbTLSInitialized = FALSE;
 
+static int
+verify_certificate_callback (gnutls_session_t session)
+{
+  unsigned int status;
+  const gnutls_datum_t *cert_list;
+  unsigned int cert_list_size;
+  int ret;
+  gnutls_x509_crt_t cert;
+  rfbClient *sptr;
+  char *hostname;
+
+  sptr = (rfbClient *)gnutls_session_get_ptr(session);
+  if (!sptr) {
+    rfbClientLog("Failed to validate certificate - missing client data\n");
+    return GNUTLS_E_CERTIFICATE_ERROR;
+  }
+
+  hostname = sptr->serverHost;
+  if (!hostname) {
+      rfbClientLog("No server hostname found for client\n");
+      return GNUTLS_E_CERTIFICATE_ERROR;
+  }
+
+  /* This verification function uses the trusted CAs in the credentials
+   * structure. So you must have installed one or more CA certificates.
+   */
+  ret = gnutls_certificate_verify_peers2 (session, &status);
+  if (ret < 0)
+    {
+      rfbClientLog ("Certificate validation call failed\n");
+      return GNUTLS_E_CERTIFICATE_ERROR;
+    }
+
+  if (status & GNUTLS_CERT_INVALID)
+    rfbClientLog("The certificate is not trusted.\n");
+
+  if (status & GNUTLS_CERT_SIGNER_NOT_FOUND)
+    rfbClientLog("The certificate hasn't got a known issuer.\n");
+
+  if (status & GNUTLS_CERT_REVOKED)
+    rfbClientLog("The certificate has been revoked.\n");
+
+  if (status & GNUTLS_CERT_EXPIRED)
+    rfbClientLog("The certificate has expired\n");
+
+  if (status & GNUTLS_CERT_NOT_ACTIVATED)
+    rfbClientLog("The certificate is not yet activated\n");
+
+  if (status)
+    return GNUTLS_E_CERTIFICATE_ERROR;
+
+  /* Up to here the process is the same for X.509 certificates and
+   * OpenPGP keys. From now on X.509 certificates are assumed. This can
+   * be easily extended to work with openpgp keys as well.
+   */
+  if (gnutls_certificate_type_get (session) != GNUTLS_CRT_X509) {
+    rfbClientLog("The certificate was not X509\n");
+    return GNUTLS_E_CERTIFICATE_ERROR;
+  }
+
+  if (gnutls_x509_crt_init (&cert) < 0)
+    {
+      rfbClientLog("Error initialising certificate structure\n");
+      return GNUTLS_E_CERTIFICATE_ERROR;
+    }
+
+  cert_list = gnutls_certificate_get_peers (session, &cert_list_size);
+  if (cert_list == NULL)
+    {
+      rfbClientLog("No certificate was found!\n");
+      return GNUTLS_E_CERTIFICATE_ERROR;
+    }
+
+  /* This is not a real world example, since we only check the first 
+   * certificate in the given chain.
+   */
+  if (gnutls_x509_crt_import (cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
+    {
+      rfbClientLog("Error parsing certificate\n");
+      return GNUTLS_E_CERTIFICATE_ERROR;
+    }
+
+  if (!gnutls_x509_crt_check_hostname (cert, hostname))
+    {
+      rfbClientLog("The certificate's owner does not match hostname '%s'\n",
+              hostname);
+      return GNUTLS_E_CERTIFICATE_ERROR;
+    }
+
+  gnutls_x509_crt_deinit (cert);
+
+  /* notify gnutls to continue handshake normally */
+  return 0;
+}
+
 static rfbBool
 InitializeTLS(void)
 {
@@ -52,7 +148,7 @@ InitializeTLS(void)
     rfbClientLog("Failed to initialized GnuTLS: %s.\n", gnutls_strerror(ret));
     return FALSE;
   }
-  rfbClientLog("GnuTLS initialized.\n");
+  rfbClientLog("GnuTLS version %s initialized.\n", gnutls_check_version(NULL));
   rfbTLSInitialized = TRUE;
   return TRUE;
 }
@@ -200,21 +296,7 @@ HandshakeTLS(rfbClient* client)
       continue;
     }
     rfbClientLog("TLS handshake failed: %s.\n", gnutls_strerror(ret));
-    if (ret == GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR) {
-        gnutls_datum_t out;
-        unsigned status;
-        int type;
 
-        type = gnutls_certificate_type_get((gnutls_session_t)client->tlsSession);
-        status = gnutls_session_get_verify_cert_status((gnutls_session_t)client->tlsSession);
-
-        if (gnutls_certificate_verification_status_print(status, type, &out, 0))
-            rfbClientLog("Certificate verification failed but could not determine reason");
-        else {
-            rfbClientLog("Certificate verification failed: %s\n", out.data);
-            gnutls_free(out.data);
-        }
-    }
     FreeTLS(client);
     return FALSE;
   }
@@ -227,11 +309,6 @@ HandshakeTLS(rfbClient* client)
   }
 
   rfbClientLog("TLS handshake done.\n");
-  char *desc;
-  desc = gnutls_session_get_desc((gnutls_session_t)client->tlsSession);
-  rfbClientLog("Session info: %s\n", desc);
-  gnutls_free(desc);
-
   return TRUE;
 }
 
@@ -469,13 +546,16 @@ HandleVeNCryptAuth(rfbClient* client)
   }
   else
   {
+    /* Set the certificate verification callback. */
+    gnutls_certificate_set_verify_function (x509_cred, verify_certificate_callback);
+    gnutls_session_set_ptr ((gnutls_session_t)client->tlsSession, (void *)client);
+
     if ((ret = gnutls_credentials_set((gnutls_session_t)client->tlsSession, GNUTLS_CRD_CERTIFICATE, x509_cred)) < 0)
     {
       rfbClientLog("Cannot set x509 credential: %s.\n", gnutls_strerror(ret));
       FreeTLS(client);
       return FALSE;
     }
-    gnutls_session_set_verify_cert((gnutls_session_t)client->tlsSession, client->serverHost, 0);
   }
 
   if (!HandshakeTLS(client)) return FALSE;

--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -113,9 +113,6 @@ verify_certificate_callback (gnutls_session_t session)
       return GNUTLS_E_CERTIFICATE_ERROR;
     }
 
-  /* This is not a real world example, since we only check the first 
-   * certificate in the given chain.
-   */
   if (gnutls_x509_crt_import (cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
     {
       rfbClientLog("Error parsing certificate\n");


### PR DESCRIPTION
This is a simple change that implements server X509 certificate verification in libvncclient when built with GNU TLS.  It was left TODO in the original implementation.   The approach taken is to integrate the verification into the handshake process so that success or failure of the negotiation and the decision to continue is in one place in the code rather than scattered.

The change has been tested with a few failure scenarios including a server that doesn't match the certificate it provides, and an untrusted certificate chain.