### PR TITLE
X509 certificate verification for OpenSSL

### DIFF
--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -136,6 +136,7 @@ typedef union _rfbCredential
     char *x509CACrlFile;
     char *x509ClientCertFile;
     char *x509ClientKeyFile;
+    uint8_t x509CrlVerifyMode; /* Only required for OpenSSL - see meanings below */
   } x509Credential;
   /** Plain (VeNCrypt), MSLogon (UltraVNC) */
   struct
@@ -147,6 +148,13 @@ typedef union _rfbCredential
 
 #define rfbCredentialTypeX509 1
 #define rfbCredentialTypeUser 2
+
+/* When using OpenSSL, CRLs can be included in both the x509CACrlFile and appended
+   to the x509CACertFile as is common with OpenSSL.  When rfbX509CrlVerifyAll is
+   specified the CRL list must include CRLs for all certificates in the chain */
+#define rfbX509CrlVerifyNone   0    /* No CRL checking is performed */
+#define rfbX509CrlVerifyClient 1    /* Only the leaf server certificate is checked */
+#define rfbX509CrlVerifyAll    2    /* All certificates in the server chain are checked */
 
 struct _rfbClient;
 


### PR DESCRIPTION
This change adds X509 certificate validation to libvncclient when built with OpenSSL.  It's basically the OpenSSL equivalent of pull request 175 and supports the following:

1. Verification of server certificate against either a specified CA or the CA certificates in the default directory.
2. Sending a client certificate or chain to the server for checking
3. Specification of a CRL either in a separate file (as per the existing callback) or appended to the CA file as is the norm for OpenSSL, or in the default directory.
4. A new field in the callback specifying whether all certificates in the server chain will be checked or only the server certificate itself.  This is useful with OpenSSL because, unlike GnuTLS, if the whole chain is to be checked it requires a CRL for every certificate (an empty CRL is fine but it must be valid).