### PR TITLE
font: Fix a small resource leak in a failure case in rfbLoadConsoleFont()

### DIFF
--- a/libvncserver/font.c
+++ b/libvncserver/font.c
@@ -174,6 +174,7 @@ rfbFontDataPtr rfbLoadConsoleFont(char *filename)
   if(1!=fread(p->data,4096,1,f)) {
     free(p->data);
     free(p);
+    fclose(f);
     return NULL;
   }
   fclose(f);


### PR DESCRIPTION
Fixes a tiny leak case. The file handle wouldn't be closed in this instance.