### PR TITLE
Allow clients to send RFB directly on connection

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -163,6 +163,11 @@ webSocketsCheck (rfbClientPtr cl)
         scheme = "ws";
     }
 
+    if (strncmp(bbuf, "RFB ", 4) == 0) {
+        rfbLog("Normal socket connection\n");
+        return TRUE;
+    }
+
     if (strncmp(bbuf, "GET ", 4) != 0) {
       rfbErr("webSocketsHandshake: invalid client header\n");
       return FALSE;


### PR DESCRIPTION
As of gtk-vnc 0.7.0, clients now send the initial "RFB " string before the server has sent its greeting (see [this commit](https://git.gnome.org/browse/gtk-vnc/commit/?id=7f4f2fe)), and libvncserver interprets that as an invalid websocket connection, blocking these clients from connecting (see [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1421785))

This patch fixes that by checking whether the initial four bytes are "RFB ", and accepting it as a normal socket connection if they are.

Signed-off-by: Jonathan Dieter <jdieter@lesbg.com>