### PR TITLE
Fix winsock2 compatibility for libvncserver

### DIFF
--- a/libvncserver/httpd.c
+++ b/libvncserver/httpd.c
@@ -53,6 +53,8 @@
 #define ssize_t SSIZE_T
 #define read _read /* Prevent POSIX deprecation warnings */
 #endif
+#define read(sock,buf,len) recv(sock,buf,len,0)
+#define write(sock,buf,len) send(sock,buf,len,0)
 #else
 #ifdef LIBVNCSERVER_HAVE_SYS_TIME_H
 #include <sys/time.h>

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -14,7 +14,7 @@
  *                     Johannes E. Schindelin <johannes.schindelin@gmx.de>
  *  Copyright (C) 2002 RealVNC Ltd.
  *  OSXvnc Copyright (C) 2001 Dan McGuirk <mcguirk@incompleteness.net>.
- *  Original Xvnc code Copyright (C) 1999 AT&T Laboratories Cambridge.  
+ *  Original Xvnc code Copyright (C) 1999 AT&T Laboratories Cambridge.
  *  All Rights Reserved.
  *
  *  This is free software; you can redistribute it and/or modify
@@ -751,13 +751,13 @@ extern int rfbReadExactTimeout(rfbClientPtr cl, char *buf, int len,int timeout);
 extern int rfbPeekExactTimeout(rfbClientPtr cl, char *buf, int len,int timeout);
 extern int rfbWriteExact(rfbClientPtr cl, const char *buf, int len);
 extern int rfbCheckFds(rfbScreenInfoPtr rfbScreen,long usec);
-extern int rfbConnect(rfbScreenInfoPtr rfbScreen, char* host, int port);
-extern int rfbConnectToTcpAddr(char* host, int port);
-extern int rfbListenOnTCPPort(int port, in_addr_t iface);
-extern int rfbListenOnTCP6Port(int port, const char* iface);
-extern int rfbListenOnUDPPort(int port, in_addr_t iface);
+extern SOCKET rfbConnect(rfbScreenInfoPtr rfbScreen, char* host, int port);
+extern SOCKET rfbConnectToTcpAddr(char* host, int port);
+extern SOCKET rfbListenOnTCPPort(int port, in_addr_t iface);
+extern SOCKET rfbListenOnTCP6Port(int port, const char* iface);
+extern SOCKET rfbListenOnUDPPort(int port, in_addr_t iface);
 extern int rfbStringToAddr(char* string,in_addr_t* addr);
-extern rfbBool rfbSetNonBlocking(int sock);
+extern rfbBool rfbSetNonBlocking(SOCKET sock);
 
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
 /* websockets.c */


### PR DESCRIPTION
Replacing the data type for socket descriptors. Use the data type of the SOCKET to represent socket descriptors. Conditions for checking socket descriptors have been fixed in accordance with https://msdn.microsoft.com/ru-ru/library/windows/desktop/ms740516(v=vs.85).aspx . This fixes the bug #165 . 
![libvnc-win32](https://cloud.githubusercontent.com/assets/27832825/26786090/0c8b4546-4a0e-11e7-9d2c-791624a656d7.png)
Note: IPv6 is disabled on Windows XP, so didn't create the IPv6 socket.
Note: You must add a firewall exception for port 5900. (Start -> Command palette -> Windows Firewall -> Exceptions)
