### PR TITLE
Moved undef of REALBPP down

### DIFF
--- a/libvncclient/zrle.c
+++ b/libvncclient/zrle.c
@@ -420,8 +420,8 @@ static int HandleZRLETile(rfbClient* client,
 #undef HandleZRLE
 #undef HandleZRLETile
 #undef UncompressCPixel
-#undef REALBPP
 
 #endif
 
 #undef UNCOMP
+#undef REALBPP


### PR DESCRIPTION
If zlib is not available (probably should be available but...) we get issue #214 

This PR simply moves the undef of REALBPP outside of the ifdef that checks for zlib causing it to properly undefine.