### PR TITLE
Tight: export SendCompressedData and SendTightHeader functions

### DIFF
--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -895,6 +895,8 @@ extern rfbBool rfbTightDisableGradient;
 extern int rfbNumCodedRectsTight(rfbClientPtr cl, int x,int y,int w,int h);
 
 extern rfbBool rfbSendRectEncodingTight(rfbClientPtr cl, int x,int y,int w,int h);
+extern rfbBool rfbSendTightHeader(rfbClientPtr cl, int x, int y, int w, int h);
+extern rfbBool rfbSendCompressedDataTight(rfbClientPtr cl, char *buf, int compressedLen);
 
 #if defined(LIBVNCSERVER_HAVE_LIBPNG)
 extern rfbBool rfbSendRectEncodingTightPng(rfbClientPtr cl, int x,int y,int w,int h);


### PR DESCRIPTION
These functions can be used to send already compressed jpegs to a
client, circumventing the usual rect/region update methods which
operate on a raw rgb framebuffer. Rename the functions with the usual
rfb prefix and add the prototypes in rfb.h.