### PR TITLE
Fix use-after-free and concurrent access segmentation fault

### DIFF
--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <fcntl.h>
 #endif
 
 #include <signal.h>
@@ -533,6 +534,7 @@ clientInput(void *data)
 
 	FD_ZERO(&rfds);
 	FD_SET(cl->sock, &rfds);
+	FD_SET(cl->pipe_notify_client_thread[0], &rfds);
 	FD_ZERO(&efds);
 	FD_SET(cl->sock, &efds);
 
@@ -541,9 +543,13 @@ clientInput(void *data)
 	if ((cl->fileTransfer.fd!=-1) && (cl->fileTransfer.sending==1))
 	    FD_SET(cl->sock, &wfds);
 
+	int nfds = cl->pipe_notify_client_thread[0] > cl->sock ? cl->pipe_notify_client_thread[0] : cl->sock;
+	
 	tv.tv_sec = 60; /* 1 minute */
 	tv.tv_usec = 0;
-	n = select(cl->sock + 1, &rfds, &wfds, &efds, &tv);
+
+	n = select(nfds + 1, &rfds, &wfds, &efds, &tv);
+
 	if (n < 0) {
 	    rfbLogPerror("ReadExact: select");
 	    break;
@@ -557,6 +563,13 @@ clientInput(void *data)
         /* We have some space on the transmit queue, send some data */
         if (FD_ISSET(cl->sock, &wfds))
             rfbSendFileTransferChunk(cl);
+
+	if (FD_ISSET(cl->pipe_notify_client_thread[0], &rfds))
+	{
+	    // Reset the pipe
+	    char buf;
+	    while (read(cl->pipe_notify_client_thread[0], &buf, sizeof(buf)) == sizeof(buf));
+	}
 
         if (FD_ISSET(cl->sock, &rfds) || FD_ISSET(cl->sock, &efds))
         {
@@ -628,8 +641,12 @@ rfbStartOnHoldClient(rfbClientPtr cl)
 {
     cl->onHold = FALSE;
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
-    if(cl->screen->backgroundLoop)
-	pthread_create(&cl->client_thread, NULL, clientInput, (void *)cl);
+    if(cl->screen->backgroundLoop) {
+        pipe(cl->pipe_notify_client_thread);
+        fcntl(cl->pipe_notify_client_thread[0], F_SETFL, O_NONBLOCK);
+
+        pthread_create(&cl->client_thread, NULL, clientInput, (void *)cl);
+    }
 #endif
 }
 
@@ -1091,7 +1108,13 @@ void rfbShutdownServer(rfbScreenInfoPtr screen,rfbBool disconnectClients) {
         rfbCloseClient(currentCl);
       }
 
+#ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+      // Notify the thread and join it
+      write(currentCl->pipe_notify_client_thread[1], "\x00", 1);
+      pthread_join(currentCl->client_thread, NULL);
+#else
       rfbClientConnectionGone(currentCl);
+#endif
 
       currentCl = nextCl;
     }

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -1081,15 +1081,21 @@ void rfbInitServer(rfbScreenInfoPtr screen)
 
 void rfbShutdownServer(rfbScreenInfoPtr screen,rfbBool disconnectClients) {
   if(disconnectClients) {
-    rfbClientPtr cl;
     rfbClientIteratorPtr iter = rfbGetClientIterator(screen);
-    while( (cl = rfbClientIteratorNext(iter)) ) {
-      if (cl->sock > -1) {
-       /* we don't care about maxfd here, because the server goes away */
-       rfbCloseClient(cl);
-       rfbClientConnectionGone(cl);
+    rfbClientPtr nextCl, currentCl = rfbClientIteratorNext(iter);
+
+    while(currentCl) {
+      nextCl = rfbClientIteratorNext(iter);
+      if (currentCl->sock > -1) {
+        /* we don't care about maxfd here, because the server goes away */
+        rfbCloseClient(currentCl);
       }
+
+      rfbClientConnectionGone(currentCl);
+
+      currentCl = nextCl;
     }
+
     rfbReleaseClientIterator(iter);
   }
 

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -642,7 +642,10 @@ rfbStartOnHoldClient(rfbClientPtr cl)
     cl->onHold = FALSE;
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
     if(cl->screen->backgroundLoop) {
-        pipe(cl->pipe_notify_client_thread);
+        if (pipe(cl->pipe_notify_client_thread) == -1) {
+            cl->pipe_notify_client_thread[0] = -1;
+            cl->pipe_notify_client_thread[1] = -1;
+        }
         fcntl(cl->pipe_notify_client_thread[0], F_SETFL, O_NONBLOCK);
 
         pthread_create(&cl->client_thread, NULL, clientInput, (void *)cl);

--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -621,6 +621,11 @@ rfbClientConnectionGone(rfbClientPtr cl)
     UNLOCK(cl->sendMutex);
     TINI_MUTEX(cl->sendMutex);
 
+#ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+    close(cl->pipe_notify_client_thread[0]);
+    close(cl->pipe_notify_client_thread[1]);
+#endif
+
     rfbPrintStats(cl);
     rfbResetStats(cl);
 

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -465,6 +465,7 @@ typedef struct _rfbClientRec {
     int protocolMinorVersion;
 
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+    int pipe_notify_client_thread[2];
     pthread_t client_thread;
 #endif
 


### PR DESCRIPTION
 - Correctly iterate over the clients without using freed memory. (See #211)
 - Fix a concurrent issue between the thread doing the shutdown that will free the client and the thread of `clientOutput` that will access it.

See #212 for more informations.

**PS:** It's really hard to make a tiny PR because of the indentation issues everywhere, you should probably do something about that :)