### PR TITLE
Fix .gitignore for recent CMake versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ examples/storepasswd
 examples/vncev
 libtool
 libvncclient/libvncclient.la
+libvncclient.a
 libvncserver/libvncserver.la
+libvncserver.a
 test/blooptest
 test/cargstest
 test/copyrecttest
@@ -77,6 +79,7 @@ vncterm/example
 x11vnc.spec
 x11vnc/x11vnc
 CMakeCache.txt
+CTestTestfile.cmake
 cmake_install.cmake
 /CMakeFiles
 /rfbproto.pdf


### PR DESCRIPTION
Recent CMake test versions create a new file called `CTestTestfile.cmake`.
Additionally, when building static libraries, those were not contained in the gitignore.