### PR TITLE
Use platform-specific type for socket FDs

### DIFF
--- a/examples/repeater.c
+++ b/examples/repeater.c
@@ -49,7 +49,7 @@ int main(int argc,char** argv)
   server->ipv6port = -1; /* do not listen on any port */
 
   sock = rfbConnectToTcpAddr(repeaterHost, repeaterPort);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
     perror("connect to repeater");
     return 1;
   }

--- a/libvncclient/listen.c
+++ b/libvncclient/listen.c
@@ -54,14 +54,14 @@ listenForIncomingConnections(rfbClient* client)
   rfbClientErr("listenForIncomingConnections on MinGW32 NOT IMPLEMENTED\n");
   return;
 #else
-  int listenSocket, listen6Socket = -1;
+  int listenSocket = RFB_INVALID_SOCKET, listen6Socket = RFB_INVALID_SOCKET;
   fd_set fds;
 
   client->listenSpecified = TRUE;
 
   listenSocket = ListenAtTcpPortAndAddress(client->listenPort, client->listenAddress);
 
-  if ((listenSocket < 0))
+  if (listenSocket == RFB_INVALID_SOCKET)
     return;
 
   rfbClientLog("%s -listen: Listening on port %d\n",
@@ -71,11 +71,11 @@ listenForIncomingConnections(rfbClient* client)
 
 #ifdef LIBVNCSERVER_IPv6 /* only try that if we're IPv6-capable, otherwise we may try to bind to the same port which would make all that listening fail */ 
   /* only do IPv6 listen of listen6Port is set */
-  if (client->listen6Port > 0)
+  if (client->listen6Port != RFB_INVALID_SOCKET)
     {
       listen6Socket = ListenAtTcpPortAndAddress(client->listen6Port, client->listen6Address);
 
-      if (listen6Socket < 0)
+      if (listen6Socket == RFB_INVALID_SOCKET)
 	return;
 
       rfbClientLog("%s -listen: Listening on IPV6 port %d\n",
@@ -95,9 +95,9 @@ listenForIncomingConnections(rfbClient* client)
 
     FD_ZERO(&fds); 
 
-    if(listenSocket >= 0)
+    if(listenSocket != RFB_INVALID_SOCKET)
       FD_SET(listenSocket, &fds);  
-    if(listen6Socket >= 0)
+    if(listen6Socket != RFB_INVALID_SOCKET)
       FD_SET(listen6Socket, &fds);
 
     r = select(rfbMax(listenSocket, listen6Socket)+1, &fds, NULL, NULL, NULL);
@@ -108,7 +108,7 @@ listenForIncomingConnections(rfbClient* client)
       else if (FD_ISSET(listen6Socket, &fds))
 	client->sock = AcceptTcpConnection(client->listen6Sock);
 
-      if (client->sock < 0)
+      if (client->sock == RFB_INVALID_SOCKET)
 	return;
       if (!SetNonBlocking(client->sock))
 	return;
@@ -159,11 +159,11 @@ listenForIncomingConnectionsNoFork(rfbClient* client, int timeout)
 
   client->listenSpecified = TRUE;
 
-  if (client->listenSock < 0)
+  if (client->listenSock == RFB_INVALID_SOCKET)
     {
       client->listenSock = ListenAtTcpPortAndAddress(client->listenPort, client->listenAddress);
 
-      if (client->listenSock < 0)
+      if (client->listenSock == RFB_INVALID_SOCKET)
 	return -1;
 
       rfbClientLog("%s -listennofork: Listening on port %d\n",
@@ -174,11 +174,11 @@ listenForIncomingConnectionsNoFork(rfbClient* client, int timeout)
 
 #ifdef LIBVNCSERVER_IPv6 /* only try that if we're IPv6-capable, otherwise we may try to bind to the same port which would make all that listening fail */ 
   /* only do IPv6 listen of listen6Port is set */
-  if (client->listen6Port > 0 && client->listen6Sock < 0)
+  if (client->listen6Port != RFB_INVALID_SOCKET && client->listen6Sock == RFB_INVALID_SOCKET)
     {
       client->listen6Sock = ListenAtTcpPortAndAddress(client->listen6Port, client->listen6Address);
 
-      if (client->listen6Sock < 0)
+      if (client->listen6Sock == RFB_INVALID_SOCKET)
 	return -1;
 
       rfbClientLog("%s -listennofork: Listening on IPV6 port %d\n",
@@ -190,9 +190,9 @@ listenForIncomingConnectionsNoFork(rfbClient* client, int timeout)
 
   FD_ZERO(&fds);
 
-  if(client->listenSock >= 0)
+  if(client->listenSock != RFB_INVALID_SOCKET)
     FD_SET(client->listenSock, &fds);
-  if(client->listen6Sock >= 0)
+  if(client->listen6Sock != RFB_INVALID_SOCKET)
     FD_SET(client->listen6Sock, &fds);
 
   if (timeout < 0)
@@ -207,18 +207,18 @@ listenForIncomingConnectionsNoFork(rfbClient* client, int timeout)
       else if (FD_ISSET(client->listen6Sock, &fds))
 	client->sock = AcceptTcpConnection(client->listen6Sock);
 
-      if (client->sock < 0)
+      if (client->sock == RFB_INVALID_SOCKET)
 	return -1;
       if (!SetNonBlocking(client->sock))
 	return -1;
 
-      if(client->listenSock >= 0) {
+      if(client->listenSock != RFB_INVALID_SOCKET) {
 	close(client->listenSock);
-	client->listenSock = -1;
+	client->listenSock = RFB_INVALID_SOCKET;
       }
-      if(client->listen6Sock >= 0) {
+      if(client->listen6Sock != RFB_INVALID_SOCKET) {
 	close(client->listen6Sock);
-	client->listen6Sock = -1;
+	client->listen6Sock = RFB_INVALID_SOCKET;
       }
       return r;
     }

--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -37,7 +37,6 @@
 #include <errno.h>
 #include <rfb/rfbclient.h>
 #ifdef WIN32
-#undef SOCKET
 #undef socklen_t
 #endif
 #ifdef LIBVNCSERVER_HAVE_LIBZ
@@ -320,7 +319,7 @@ ConnectToRFBServer(rfbClient* client,const char *hostname, int port)
       fclose(rec->file);
       return FALSE;
     }
-    client->sock = -1;
+    client->sock = RFB_INVALID_SOCKET;
     return TRUE;
   }
 
@@ -333,7 +332,7 @@ ConnectToRFBServer(rfbClient* client,const char *hostname, int port)
   {
 #ifdef LIBVNCSERVER_IPv6
     client->sock = ConnectClientToTcpAddr6(hostname, port);
-    if (client->sock == -1)
+    if (client->sock == RFB_INVALID_SOCKET)
 #endif
     {
       unsigned int host;
@@ -347,7 +346,7 @@ ConnectToRFBServer(rfbClient* client,const char *hostname, int port)
     }
   }
 
-  if (client->sock < 0) {
+  if (client->sock == RFB_INVALID_SOCKET) {
     rfbClientLog("Unable to connect to VNC server\n");
     return FALSE;
   }
@@ -382,7 +381,7 @@ rfbBool ConnectToRFBRepeater(rfbClient* client,const char *repeaterHost, int rep
     client->sock = ConnectClientToTcpAddr(host, repeaterPort);
   }
 
-  if (client->sock < 0) {
+  if (client->sock == RFB_INVALID_SOCKET) {
     rfbClientLog("Unable to connect to VNC repeater\n");
     return FALSE;
   }

--- a/libvncclient/sasl.c
+++ b/libvncclient/sasl.c
@@ -39,7 +39,6 @@
 #include <rfb/rfbclient.h>
 
 #ifdef WIN32
-#undef SOCKET
 #include <winsock2.h>
 #ifdef EWOULDBLOCK
 #undef EWOULDBLOCK

--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -38,7 +38,6 @@
 #include <assert.h>
 #include <rfb/rfbclient.h>
 #ifdef WIN32
-#undef SOCKET
 #include <winsock2.h>
 #ifdef EWOULDBLOCK
 #undef EWOULDBLOCK
@@ -350,57 +349,57 @@ static int initSockets() {
  * ConnectToTcpAddr connects to the given TCP port.
  */
 
-int
+rfbSocket
 ConnectClientToTcpAddr(unsigned int host, int port)
 {
-  int sock;
+  rfbSocket sock;
   struct sockaddr_in addr;
   int one = 1;
 
   if (!initSockets())
-	  return -1;
+	  return RFB_INVALID_SOCKET;
 
   addr.sin_family = AF_INET;
   addr.sin_port = htons(port);
   addr.sin_addr.s_addr = host;
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
 #ifdef WIN32
     errno=WSAGetLastError();
 #endif
     rfbClientErr("ConnectToTcpAddr: socket (%s)\n",strerror(errno));
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     rfbClientErr("ConnectToTcpAddr: connect\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		 (char *)&one, sizeof(one)) < 0) {
     rfbClientErr("ConnectToTcpAddr: setsockopt\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   return sock;
 }
 
-int
+rfbSocket
 ConnectClientToTcpAddr6(const char *hostname, int port)
 {
 #ifdef LIBVNCSERVER_IPv6
-  int sock;
+  rfbSocket sock;
   int n;
   struct addrinfo hints, *res, *ressave;
   char port_s[10];
   int one = 1;
 
   if (!initSockets())
-	  return -1;
+	  return RFB_INVALID_SOCKET;
 
   snprintf(port_s, 10, "%d", port);
   memset(&hints, 0, sizeof(struct addrinfo));
@@ -409,36 +408,36 @@ ConnectClientToTcpAddr6(const char *hostname, int port)
   if ((n = getaddrinfo(hostname, port_s, &hints, &res)))
   {
     rfbClientErr("ConnectClientToTcpAddr6: getaddrinfo (%s)\n", gai_strerror(n));
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   ressave = res;
-  sock = -1;
+  sock = RFB_INVALID_SOCKET;
   while (res)
   {
     sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sock >= 0)
+    if (sock != RFB_INVALID_SOCKET)
     {
       if (connect(sock, res->ai_addr, res->ai_addrlen) == 0)
         break;
       close(sock);
-      sock = -1;
+      sock = RFB_INVALID_SOCKET;
     }
     res = res->ai_next;
   }
   freeaddrinfo(ressave);
 
-  if (sock == -1)
+  if (sock == RFB_INVALID_SOCKET)
   {
     rfbClientErr("ConnectClientToTcpAddr6: connect\n");
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		 (char *)&one, sizeof(one)) < 0) {
     rfbClientErr("ConnectToTcpAddr: setsockopt\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   return sock;
@@ -446,37 +445,37 @@ ConnectClientToTcpAddr6(const char *hostname, int port)
 #else
 
   rfbClientErr("ConnectClientToTcpAddr6: IPv6 disabled\n");
-  return -1;
+  return RFB_INVALID_SOCKET;
 
 #endif
 }
 
-int
+rfbSocket
 ConnectClientToUnixSock(const char *sockFile)
 {
 #ifdef WIN32
   rfbClientErr("Windows doesn't support UNIX sockets\n");
-  return -1;
+  return RFB_INVALID_SOCKET;
 #else
-  int sock;
+  rfbSocket sock;
   struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;
   if(strlen(sockFile) + 1 > sizeof(addr.sun_path)) {
       rfbClientErr("ConnectToUnixSock: socket file name too long\n");
-      return -1;
+      return RFB_INVALID_SOCKET;
   }
   strcpy(addr.sun_path, sockFile);
 
   sock = socket(AF_UNIX, SOCK_STREAM, 0);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
     rfbClientErr("ConnectToUnixSock: socket (%s)\n",strerror(errno));
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (connect(sock, (struct sockaddr *)&addr, sizeof(addr.sun_family) + strlen(addr.sun_path)) < 0) {
     rfbClientErr("ConnectToUnixSock: connect\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   return sock;
@@ -493,7 +492,8 @@ ConnectClientToUnixSock(const char *sockFile)
 int
 FindFreeTcpPort(void)
 {
-  int sock, port;
+  rfbSocket sock;
+  int port;
   struct sockaddr_in addr;
 
   addr.sin_family = AF_INET;
@@ -503,7 +503,7 @@ FindFreeTcpPort(void)
     return -1;
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
     rfbClientErr(": FindFreeTcpPort: socket\n");
     return 0;
   }
@@ -525,7 +525,7 @@ FindFreeTcpPort(void)
  * ListenAtTcpPort starts listening at the given TCP port.
  */
 
-int
+rfbSocket
 ListenAtTcpPort(int port)
 {
   return ListenAtTcpPortAndAddress(port, NULL);
@@ -538,10 +538,10 @@ ListenAtTcpPort(int port)
  * the given IP address
  */
 
-int
+rfbSocket
 ListenAtTcpPortAndAddress(int port, const char *address)
 {
-  int sock;
+  rfbSocket sock = RFB_INVALID_SOCKET;
   int one = 1;
 #ifndef LIBVNCSERVER_IPv6
   struct sockaddr_in addr;
@@ -555,25 +555,25 @@ ListenAtTcpPortAndAddress(int port, const char *address)
   }
 
   if (!initSockets())
-    return -1;
+    return RFB_INVALID_SOCKET;
 
   sock = socket(AF_INET, SOCK_STREAM, 0);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
     rfbClientErr("ListenAtTcpPort: socket\n");
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
 		 (const char *)&one, sizeof(one)) < 0) {
     rfbClientErr("ListenAtTcpPort: setsockopt\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     rfbClientErr("ListenAtTcpPort: bind\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
 #else
@@ -589,16 +589,16 @@ ListenAtTcpPortAndAddress(int port, const char *address)
   hints.ai_flags = AI_PASSIVE; /* fill in wildcard address if address == NULL */
 
   if (!initSockets())
-    return -1;
+    return RFB_INVALID_SOCKET;
 
   if ((rv = getaddrinfo(address, port_str, &hints, &servinfo)) != 0) {
     rfbClientErr("ListenAtTcpPortAndAddress: error in getaddrinfo: %s\n", gai_strerror(rv));
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   /* loop through all the results and bind to the first we can */
   for(p = servinfo; p != NULL; p = p->ai_next) {
-    if ((sock = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) < 0) {
+    if ((sock = socket(p->ai_family, p->ai_socktype, p->ai_protocol)) == RFB_INVALID_SOCKET) {
       continue;
     }
 
@@ -608,7 +608,7 @@ ListenAtTcpPortAndAddress(int port, const char *address)
       rfbClientErr("ListenAtTcpPortAndAddress: error in setsockopt IPV6_V6ONLY: %s\n", strerror(errno));
       close(sock);
       freeaddrinfo(servinfo);
-      return -1;
+      return RFB_INVALID_SOCKET;
     }
 #endif
 
@@ -616,7 +616,7 @@ ListenAtTcpPortAndAddress(int port, const char *address)
       rfbClientErr("ListenAtTcpPortAndAddress: error in setsockopt SO_REUSEADDR: %s\n", strerror(errno));
       close(sock);
       freeaddrinfo(servinfo);
-      return -1;
+      return RFB_INVALID_SOCKET;
     }
 
     if (bind(sock, p->ai_addr, p->ai_addrlen) < 0) {
@@ -629,7 +629,7 @@ ListenAtTcpPortAndAddress(int port, const char *address)
 
   if (p == NULL)  {
     rfbClientErr("ListenAtTcpPortAndAddress: error in bind: %s\n", strerror(errno));
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   /* all done with this structure now */
@@ -639,7 +639,7 @@ ListenAtTcpPortAndAddress(int port, const char *address)
   if (listen(sock, 5) < 0) {
     rfbClientErr("ListenAtTcpPort: listen\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   return sock;
@@ -650,25 +650,25 @@ ListenAtTcpPortAndAddress(int port, const char *address)
  * AcceptTcpConnection accepts a TCP connection.
  */
 
-int
-AcceptTcpConnection(int listenSock)
+rfbSocket
+AcceptTcpConnection(rfbSocket listenSock)
 {
-  int sock;
+  rfbSocket sock;
   struct sockaddr_in addr;
   socklen_t addrlen = sizeof(addr);
   int one = 1;
 
   sock = accept(listenSock, (struct sockaddr *) &addr, &addrlen);
-  if (sock < 0) {
+  if (sock == RFB_INVALID_SOCKET) {
     rfbClientErr("AcceptTcpConnection: accept\n");
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
 		 (char *)&one, sizeof(one)) < 0) {
     rfbClientErr("AcceptTcpConnection: setsockopt\n");
     close(sock);
-    return -1;
+    return RFB_INVALID_SOCKET;
   }
 
   return sock;
@@ -680,7 +680,7 @@ AcceptTcpConnection(int listenSock)
  */
 
 rfbBool
-SetNonBlocking(int sock)
+SetNonBlocking(rfbSocket sock)
 {
 #ifdef WIN32
   unsigned long block=1;
@@ -703,7 +703,7 @@ SetNonBlocking(int sock)
  */
 
 rfbBool
-SetDSCP(int sock, int dscp)
+SetDSCP(rfbSocket sock, int dscp)
 {
 #ifdef WIN32
   rfbClientErr("Setting of QoS IP DSCP not implemented for Windows\n");
@@ -766,7 +766,7 @@ StringToIPAddr(const char *str, unsigned int *addr)
     return TRUE;
 
   if (!initSockets())
-	  return -1;
+	  return FALSE;
 
   hp = gethostbyname(str);
 
@@ -784,7 +784,7 @@ StringToIPAddr(const char *str, unsigned int *addr)
  */
 
 rfbBool
-SameMachine(int sock)
+SameMachine(rfbSocket sock)
 {
   struct sockaddr_in peeraddr, myaddr;
   socklen_t addrlen = sizeof(struct sockaddr_in);

--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -22,7 +22,6 @@
 #include <rfb/rfbclient.h>
 #include <errno.h>
 #ifdef WIN32
-#undef SOCKET
 #include <windows.h>           /* for Sleep() */
 #define sleep(X) Sleep(1000*X) /* MinGW32 has no sleep() */
 #include <winsock2.h>

--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -22,7 +22,6 @@
  */
 
 #ifdef WIN32
-#undef SOCKET
 #include <winsock2.h>
 #endif
 
@@ -343,10 +342,10 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->tlsSession = NULL;
   client->LockWriteToTLS = NULL;
   client->UnlockWriteToTLS = NULL;
-  client->sock = -1;
-  client->listenSock = -1;
+  client->sock = RFB_INVALID_SOCKET;
+  client->listenSock = RFB_INVALID_SOCKET;
   client->listenAddress = NULL;
-  client->listen6Sock = -1;
+  client->listen6Sock = RFB_INVALID_SOCKET;
   client->listen6Address = NULL;
   client->clientAuthSchemes = NULL;
 
@@ -533,9 +532,9 @@ void rfbClientCleanup(rfbClient* client) {
     client->clientData = next;
   }
 
-  if (client->sock >= 0)
+  if (client->sock != RFB_INVALID_SOCKET)
     close(client->sock);
-  if (client->listenSock >= 0)
+  if (client->listenSock != RFB_INVALID_SOCKET)
     close(client->listenSock);
   free(client->desktopName);
   free(client->serverHost);

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -459,7 +459,7 @@ clientOutput(void *data)
     while (1) {
         haveUpdate = false;
         while (!haveUpdate) {
-		if (cl->sock == -1) {
+		if (cl->sock == RFB_INVALID_SOCKET) {
 			/* Client has disconnected. */
 			return NULL;
 		}
@@ -527,7 +527,7 @@ clientInput(void *data)
 	struct timeval tv;
 	int n;
 
-	if (cl->sock == -1) {
+	if (cl->sock == RFB_INVALID_SOCKET) {
 	  /* Client has disconnected. */
             break;
         }
@@ -609,9 +609,9 @@ listenerRun(void *data)
     while (1) {
         client_fd = -1;
         FD_ZERO(&listen_fds);
-	if(screen->listenSock >= 0) 
+	if(screen->listenSock != RFB_INVALID_SOCKET)
 	  FD_SET(screen->listenSock, &listen_fds);
-	if(screen->listen6Sock >= 0) 
+	if(screen->listen6Sock != RFB_INVALID_SOCKET)
 	  FD_SET(screen->listen6Sock, &listen_fds);
 
         if (select(screen->maxFd+1, &listen_fds, NULL, NULL, NULL) == -1) {
@@ -889,16 +889,16 @@ rfbScreenInfoPtr rfbGetScreen(int* argc,char** argv,
    screen->socketState=RFB_SOCKET_INIT;
 
    screen->inetdInitDone = FALSE;
-   screen->inetdSock=-1;
+   screen->inetdSock=RFB_INVALID_SOCKET;
 
-   screen->udpSock=-1;
+   screen->udpSock=RFB_INVALID_SOCKET;
    screen->udpSockConnected=FALSE;
    screen->udpPort=0;
    screen->udpClient=NULL;
 
    screen->maxFd=0;
-   screen->listenSock=-1;
-   screen->listen6Sock=-1;
+   screen->listenSock=RFB_INVALID_SOCKET;
+   screen->listen6Sock=RFB_INVALID_SOCKET;
 
    screen->fdQuota = 0.5;
 
@@ -907,9 +907,9 @@ rfbScreenInfoPtr rfbGetScreen(int* argc,char** argv,
    screen->httpPort=0;
    screen->http6Port=0;
    screen->httpDir=NULL;
-   screen->httpListenSock=-1;
-   screen->httpListen6Sock=-1;
-   screen->httpSock=-1;
+   screen->httpListenSock=RFB_INVALID_SOCKET;
+   screen->httpListen6Sock=RFB_INVALID_SOCKET;
+   screen->httpSock=RFB_INVALID_SOCKET;
 
    screen->desktopName = "LibVNCServer";
    screen->alwaysShared = FALSE;
@@ -1137,7 +1137,7 @@ void rfbShutdownServer(rfbScreenInfoPtr screen,rfbBool disconnectClients) {
 
     while(currentCl) {
       nextCl = rfbClientIteratorNext(iter);
-      if (currentCl->sock > -1) {
+      if (currentCl->sock != RFB_INVALID_SOCKET) {
         /* we don't care about maxfd here, because the server goes away */
         rfbCloseClient(currentCl);
       }
@@ -1202,7 +1202,7 @@ rfbProcessEvents(rfbScreenInfoPtr screen,long usec)
     result = rfbUpdateClient(cl);
     clPrev=cl;
     cl=rfbClientIteratorNext(i);
-    if(clPrev->sock==-1) {
+    if(clPrev->sock==RFB_INVALID_SOCKET) {
       rfbClientConnectionGone(clPrev);
       result=TRUE;
     }
@@ -1219,7 +1219,7 @@ rfbUpdateClient(rfbClientPtr cl)
   rfbBool result=FALSE;
   rfbScreenInfoPtr screen = cl->screen;
 
-  if (cl->sock >= 0 && !cl->onHold && FB_UPDATE_PENDING(cl) &&
+  if (cl->sock != RFB_INVALID_SOCKET && !cl->onHold && FB_UPDATE_PENDING(cl) &&
         !sraRgnEmpty(cl->requestedRegion)) {
       result=TRUE;
       if(screen->deferUpdateTime == 0) {

--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -253,7 +253,7 @@ rfbReleaseClientIterator(rfbClientIteratorPtr iterator)
 
 void
 rfbNewClientConnection(rfbScreenInfoPtr rfbScreen,
-                       int sock)
+                       rfbSocket sock)
 {
     rfbNewClient(rfbScreen,sock);
 }
@@ -269,7 +269,7 @@ rfbReverseConnection(rfbScreenInfoPtr rfbScreen,
                      char *host,
                      int port)
 {
-    int sock;
+    rfbSocket sock;
     rfbClientPtr cl;
 
     if ((sock = rfbConnect(rfbScreen, host, port)) < 0)
@@ -306,7 +306,7 @@ rfbSetProtocolVersion(rfbScreenInfoPtr rfbScreen, int major_, int minor_)
 
 static rfbClientPtr
 rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
-                     int sock,
+                     rfbSocket sock,
                      rfbBool isUDP)
 {
     rfbProtocolVersionMsg pv;
@@ -522,7 +522,7 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
 
 rfbClientPtr
 rfbNewClient(rfbScreenInfoPtr rfbScreen,
-             int sock)
+             rfbSocket sock)
 {
   return(rfbNewTCPOrUDPClient(rfbScreen,sock,FALSE));
 }
@@ -3760,7 +3760,7 @@ static unsigned char ptrAcceleration = 50;
 
 void
 rfbNewUDPConnection(rfbScreenInfoPtr rfbScreen,
-                    int sock)
+                    rfbSocket sock)
 {
   if (write(sock, (char*) &ptrAcceleration, 1) < 0) {
 	rfbLogPerror("rfbNewUDPConnection: write");

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -53,7 +53,6 @@ extern "C"
 #endif
 
 #ifdef WIN32
-#undef SOCKET
 typedef UINT32 in_addr_t;
 #include <winsock2.h>
 #ifdef LIBVNCSERVER_HAVE_WS2TCPIP_H
@@ -268,7 +267,7 @@ typedef struct _rfbScreenInfo
 
     rfbBool autoPort;
     int port;
-    SOCKET listenSock;
+    rfbSocket listenSock;
     int maxSock;
     int maxFd;
 #ifdef WIN32
@@ -278,11 +277,11 @@ typedef struct _rfbScreenInfo
 #endif
 
     enum rfbSocketState socketState;
-    SOCKET inetdSock;
+    rfbSocket inetdSock;
     rfbBool inetdInitDone;
 
     int udpPort;
-    SOCKET udpSock;
+    rfbSocket udpSock;
     struct _rfbClientRec* udpClient;
     rfbBool udpSockConnected;
     struct sockaddr_in udpRemoteAddr;
@@ -294,8 +293,8 @@ typedef struct _rfbScreenInfo
     rfbBool httpEnableProxyConnect;
     int httpPort;
     char* httpDir;
-    SOCKET httpListenSock;
-    SOCKET httpSock;
+    rfbSocket httpListenSock;
+    rfbSocket httpSock;
 
     rfbPasswordCheckProcPtr passwordCheck;
     void* authPasswdData;
@@ -388,9 +387,9 @@ typedef struct _rfbScreenInfo
     /* We have an additional IPv6 listen socket since there are systems that
        don't support dual binding sockets under *any* circumstances, for
        instance OpenBSD */
-    SOCKET listen6Sock;
+    rfbSocket listen6Sock;
     int http6Port;
-    SOCKET httpListen6Sock;
+    rfbSocket httpListen6Sock;
     /** hook to let client set resolution */
     rfbSetDesktopSizeHookPtr setDesktopSizeHook;
     /** Optional hooks to query ExtendedDesktopSize screen information.
@@ -472,7 +471,7 @@ typedef struct _rfbClientRec {
     void* clientData;
     ClientGoneHookPtr clientGoneHook;
 
-    SOCKET sock;
+    rfbSocket sock;
     char *host;
 
     /* RFB protocol minor version number */
@@ -774,13 +773,13 @@ extern int rfbReadExactTimeout(rfbClientPtr cl, char *buf, int len,int timeout);
 extern int rfbPeekExactTimeout(rfbClientPtr cl, char *buf, int len,int timeout);
 extern int rfbWriteExact(rfbClientPtr cl, const char *buf, int len);
 extern int rfbCheckFds(rfbScreenInfoPtr rfbScreen,long usec);
-extern int rfbConnect(rfbScreenInfoPtr rfbScreen, char* host, int port);
-extern int rfbConnectToTcpAddr(char* host, int port);
-extern int rfbListenOnTCPPort(int port, in_addr_t iface);
-extern int rfbListenOnTCP6Port(int port, const char* iface);
-extern int rfbListenOnUDPPort(int port, in_addr_t iface);
+extern rfbSocket rfbConnect(rfbScreenInfoPtr rfbScreen, char* host, int port);
+extern rfbSocket rfbConnectToTcpAddr(char* host, int port);
+extern rfbSocket rfbListenOnTCPPort(int port, in_addr_t iface);
+extern rfbSocket rfbListenOnTCP6Port(int port, const char* iface);
+extern rfbSocket rfbListenOnUDPPort(int port, in_addr_t iface);
 extern int rfbStringToAddr(char* string,in_addr_t* addr);
-extern rfbBool rfbSetNonBlocking(int sock);
+extern rfbBool rfbSetNonBlocking(rfbSocket sock);
 
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
 /* websockets.c */
@@ -805,14 +804,14 @@ extern void rfbReleaseClientIterator(rfbClientIteratorPtr iterator);
 extern void rfbIncrClientRef(rfbClientPtr cl);
 extern void rfbDecrClientRef(rfbClientPtr cl);
 
-extern void rfbNewClientConnection(rfbScreenInfoPtr rfbScreen,int sock);
-extern rfbClientPtr rfbNewClient(rfbScreenInfoPtr rfbScreen,int sock);
+extern void rfbNewClientConnection(rfbScreenInfoPtr rfbScreen,rfbSocket sock);
+extern rfbClientPtr rfbNewClient(rfbScreenInfoPtr rfbScreen,rfbSocket sock);
 extern rfbClientPtr rfbNewUDPClient(rfbScreenInfoPtr rfbScreen);
 extern rfbClientPtr rfbReverseConnection(rfbScreenInfoPtr rfbScreen,char *host, int port);
 extern void rfbClientConnectionGone(rfbClientPtr cl);
 extern void rfbProcessClientMessage(rfbClientPtr cl);
 extern void rfbClientConnFailed(rfbClientPtr cl, const char *reason);
-extern void rfbNewUDPConnection(rfbScreenInfoPtr rfbScreen,int sock);
+extern void rfbNewUDPConnection(rfbScreenInfoPtr rfbScreen,rfbSocket sock);
 extern void rfbProcessUDPInput(rfbScreenInfoPtr rfbScreen);
 extern rfbBool rfbSendFramebufferUpdate(rfbClientPtr cl, sraRegionPtr updateRegion);
 extern rfbBool rfbSendRectEncodingRaw(rfbClientPtr cl, int x,int y,int w,int h);

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -259,7 +259,7 @@ typedef struct _rfbClient {
 
 	/* rfbproto.c */
 
-	int sock;
+	rfbSocket sock;
 	rfbBool canUseCoRRE;
 	rfbBool canUseHextile;
 	char *desktopName;
@@ -396,13 +396,13 @@ typedef struct _rfbClient {
 	HandleXvpMsgProc           HandleXvpMsg;
 
 	/* listen.c */
-        int listenSock;
+        rfbSocket listenSock;
 
 	FinishedFrameBufferUpdateProc FinishedFrameBufferUpdate;
 
 	char *listenAddress;
         /* IPv6 listen socket, address and port*/
-        int listen6Sock;
+        rfbSocket listen6Sock;
         char* listen6Address;
         int listen6Port;
 
@@ -650,17 +650,17 @@ extern rfbBool errorMessageOnReadFailure;
 extern rfbBool ReadFromRFBServer(rfbClient* client, char *out, unsigned int n);
 extern rfbBool WriteToRFBServer(rfbClient* client, char *buf, int n);
 extern int FindFreeTcpPort(void);
-extern int ListenAtTcpPort(int port);
-extern int ListenAtTcpPortAndAddress(int port, const char *address);
-extern int ConnectClientToTcpAddr(unsigned int host, int port);
-extern int ConnectClientToTcpAddr6(const char *hostname, int port);
-extern int ConnectClientToUnixSock(const char *sockFile);
-extern int AcceptTcpConnection(int listenSock);
-extern rfbBool SetNonBlocking(int sock);
-extern rfbBool SetDSCP(int sock, int dscp);
+extern rfbSocket ListenAtTcpPort(int port);
+extern rfbSocket ListenAtTcpPortAndAddress(int port, const char *address);
+extern rfbSocket ConnectClientToTcpAddr(unsigned int host, int port);
+extern rfbSocket ConnectClientToTcpAddr6(const char *hostname, int port);
+extern rfbSocket ConnectClientToUnixSock(const char *sockFile);
+extern rfbSocket AcceptTcpConnection(rfbSocket listenSock);
+extern rfbBool SetNonBlocking(rfbSocket sock);
+extern rfbBool SetDSCP(rfbSocket sock, int dscp);
 
 extern rfbBool StringToIPAddr(const char *str, unsigned int *addr);
-extern rfbBool SameMachine(int sock);
+extern rfbBool SameMachine(rfbSocket sock);
 /**
  * Waits for an RFB message to arrive from the server. Before handling a message
  * with HandleRFBServerMessage(), you must wait for your client to receive one.

--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -62,7 +62,7 @@
 
 #include <stdint.h>
 
-#if defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32)
 typedef int8_t rfbBool;
 #include <sys/timeb.h>
 #include <winsock2.h>
@@ -90,14 +90,18 @@ typedef int8_t rfbBool;
 #endif
 
 #define rfbMax(a,b) (((a)>(b))?(a):(b))
-#if !defined(WIN32) || defined(__MINGW32__)
+#ifdef WIN32
+#define rfbSocket SOCKET
+#define RFB_INVALID_SOCKET INVALID_SOCKET
+#else
 #ifdef LIBVNCSERVER_HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
 #ifdef LIBVNCSERVER_HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
-#define SOCKET int
+#define rfbSocket int
+#define RFB_INVALID_SOCKET (-1)
 typedef int8_t rfbBool;
 #undef FALSE
 #define FALSE 0


### PR DESCRIPTION
The Windows Sockets 2 API uses the type SOCKET for all functions and is
defined as an unsigned integer with an architecture-specific width.
Storing the result of WS2 functions in an integer field is therefore
insufficient and may lead to a wrong behaviour. Additionally invalid
sockets are not represented by negative numbers but the constant
INVALID_SOCKETS.