### PR TITLE
LibVNCClient: free buffers in rfbClientCleanup()

### DIFF
--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -519,6 +519,12 @@ void rfbClientCleanup(rfbClient* client) {
 #endif
 #endif
 
+  if (client->ultra_buffer)
+    free(client->ultra_buffer);
+
+  if (client->raw_buffer)
+    free(client->raw_buffer);
+
   FreeTLS(client);
 
   while (client->clientData) {


### PR DESCRIPTION
Buffers allocated by encoding handlers have to be freed as well.