### PR TITLE
LibVNCClient: add support for custom auth handlers

### DIFF
--- a/client_examples/backchannel.c
+++ b/client_examples/backchannel.c
@@ -71,7 +71,9 @@ static rfbClientProtocolExtension backChannel = {
 	backChannelEncodings,		/* encodings */
 	NULL,				/* handleEncoding */
 	handleBackChannelMessage,	/* handleMessage */
-	NULL				/* next extension */
+	NULL,				/* next extension */
+	NULL,				/* securityTypes */
+	NULL				/* handleAuthentication */
 };
 
 int

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -620,6 +620,9 @@ typedef struct _rfbClientProtocolExtension {
 	rfbBool (*handleMessage)(rfbClient* cl,
 		 rfbServerToClientMsg* message);
 	struct _rfbClientProtocolExtension* next;
+	uint32_t const* securityTypes;
+	/** returns TRUE if it handled the authentication */
+	rfbBool (*handleAuthentication)(rfbClient* cl, uint32_t authScheme);
 } rfbClientProtocolExtension;
 
 void rfbClientRegisterExtension(rfbClientProtocolExtension* e);


### PR DESCRIPTION
This allows to register custom authentication handlers in order to
support additional security types.