### PR TITLE
Make D3DES thread safe + minor fixes

### DIFF
--- a/common/d3des.c
+++ b/common/d3des.c
@@ -43,10 +43,10 @@ static unsigned char Df_Key[24] = {
 	0x89,0xab,0xcd,0xef,0x01,0x23,0x45,0x67 };
 */
 
-static unsigned short bytebit[8]	= {
+static const unsigned short bytebit[8]	= {
 	01, 02, 04, 010, 020, 040, 0100, 0200 };
 
-static unsigned long bigbyte[24] = {
+static const unsigned long bigbyte[24] = {
 	0x800000L,	0x400000L,	0x200000L,	0x100000L,
 	0x80000L,	0x40000L,	0x20000L,	0x10000L,
 	0x8000L,	0x4000L,	0x2000L,	0x1000L,
@@ -56,16 +56,16 @@ static unsigned long bigbyte[24] = {
 
 /* Use the key schedule specified in the Standard (ANSI X3.92-1981). */
 
-static unsigned char pc1[56] = {
+static const unsigned char pc1[56] = {
 	56, 48, 40, 32, 24, 16,  8,	 0, 57, 49, 41, 33, 25, 17,
 	 9,  1, 58, 50, 42, 34, 26,	18, 10,  2, 59, 51, 43, 35,
 	62, 54, 46, 38, 30, 22, 14,	 6, 61, 53, 45, 37, 29, 21,
 	13,  5, 60, 52, 44, 36, 28,	20, 12,  4, 27, 19, 11,  3 };
 
-static unsigned char totrot[16] = {
+static const unsigned char totrot[16] = {
 	1,2,4,6,8,10,12,14,15,17,19,21,23,25,27,28 };
 
-static unsigned char pc2[48] = {
+static const unsigned char pc2[48] = {
 	13, 16, 10, 23,  0,  4,  2, 27, 14,  5, 20,  9,
 	22, 18, 11,  3, 25,  7, 15,  6, 26, 19, 12,  1,
 	40, 51, 30, 36, 46, 54, 29, 39, 50, 44, 32, 47,
@@ -186,7 +186,7 @@ static void unscrun(register unsigned long *outof,
 	return;
 	}
 
-static unsigned long SP1[64] = {
+static const unsigned long SP1[64] = {
 	0x01010400L, 0x00000000L, 0x00010000L, 0x01010404L,
 	0x01010004L, 0x00010404L, 0x00000004L, 0x00010000L,
 	0x00000400L, 0x01010400L, 0x01010404L, 0x00000400L,
@@ -204,7 +204,7 @@ static unsigned long SP1[64] = {
 	0x00000404L, 0x01000400L, 0x01000400L, 0x00000000L,
 	0x00010004L, 0x00010400L, 0x00000000L, 0x01010004L };
 
-static unsigned long SP2[64] = {
+static const unsigned long SP2[64] = {
 	0x80108020L, 0x80008000L, 0x00008000L, 0x00108020L,
 	0x00100000L, 0x00000020L, 0x80100020L, 0x80008020L,
 	0x80000020L, 0x80108020L, 0x80108000L, 0x80000000L,
@@ -222,7 +222,7 @@ static unsigned long SP2[64] = {
 	0x00108000L, 0x00000000L, 0x80008000L, 0x00008020L,
 	0x80000000L, 0x80100020L, 0x80108020L, 0x00108000L };
 
-static unsigned long SP3[64] = {
+static const unsigned long SP3[64] = {
 	0x00000208L, 0x08020200L, 0x00000000L, 0x08020008L,
 	0x08000200L, 0x00000000L, 0x00020208L, 0x08000200L,
 	0x00020008L, 0x08000008L, 0x08000008L, 0x00020000L,
@@ -240,7 +240,7 @@ static unsigned long SP3[64] = {
 	0x08020000L, 0x08000208L, 0x00000208L, 0x08020000L,
 	0x00020208L, 0x00000008L, 0x08020008L, 0x00020200L };
 
-static unsigned long SP4[64] = {
+static const unsigned long SP4[64] = {
 	0x00802001L, 0x00002081L, 0x00002081L, 0x00000080L,
 	0x00802080L, 0x00800081L, 0x00800001L, 0x00002001L,
 	0x00000000L, 0x00802000L, 0x00802000L, 0x00802081L,
@@ -258,7 +258,7 @@ static unsigned long SP4[64] = {
 	0x00002001L, 0x00002080L, 0x00800000L, 0x00802001L,
 	0x00000080L, 0x00800000L, 0x00002000L, 0x00802080L };
 
-static unsigned long SP5[64] = {
+static const unsigned long SP5[64] = {
 	0x00000100L, 0x02080100L, 0x02080000L, 0x42000100L,
 	0x00080000L, 0x00000100L, 0x40000000L, 0x02080000L,
 	0x40080100L, 0x00080000L, 0x02000100L, 0x40080100L,
@@ -276,7 +276,7 @@ static unsigned long SP5[64] = {
 	0x00080100L, 0x02000100L, 0x40000100L, 0x00080000L,
 	0x00000000L, 0x40080000L, 0x02080100L, 0x40000100L };
 
-static unsigned long SP6[64] = {
+static const unsigned long SP6[64] = {
 	0x20000010L, 0x20400000L, 0x00004000L, 0x20404010L,
 	0x20400000L, 0x00000010L, 0x20404010L, 0x00400000L,
 	0x20004000L, 0x00404010L, 0x00400000L, 0x20000010L,
@@ -294,7 +294,7 @@ static unsigned long SP6[64] = {
 	0x00004000L, 0x00400010L, 0x20004010L, 0x00000000L,
 	0x20404000L, 0x20000000L, 0x00400010L, 0x20004010L };
 
-static unsigned long SP7[64] = {
+static const unsigned long SP7[64] = {
 	0x00200000L, 0x04200002L, 0x04000802L, 0x00000000L,
 	0x00000800L, 0x04000802L, 0x00200802L, 0x04200800L,
 	0x04200802L, 0x00200000L, 0x00000000L, 0x04000002L,
@@ -312,7 +312,7 @@ static unsigned long SP7[64] = {
 	0x00000000L, 0x00200802L, 0x04200000L, 0x00000800L,
 	0x04000002L, 0x04000800L, 0x00000800L, 0x00200002L };
 
-static unsigned long SP8[64] = {
+static const unsigned long SP8[64] = {
 	0x10001040L, 0x00001000L, 0x00040000L, 0x10041040L,
 	0x10000000L, 0x10001040L, 0x00000040L, 0x10000000L,
 	0x00040040L, 0x10040000L, 0x10041040L, 0x00041000L,

--- a/common/d3des.c
+++ b/common/d3des.c
@@ -28,12 +28,20 @@
 
 #include "d3des.h"
 
+#if defined(__GNUC__)
+#define TLS __thread
+#elif defined(_MSC_VER)
+#define TLS __declspec(thread)
+#else
+#define TLS
+#endif
+
 static void scrunch(unsigned char *, unsigned long *);
 static void unscrun(unsigned long *, unsigned char *);
 static void desfunc(unsigned long *, unsigned long *);
 static void cookey(unsigned long *);
 
-static unsigned long KnL[32] = { 0L };
+static TLS unsigned long KnL[32] = { 0L };
 /*
 static unsigned long KnR[32] = { 0L };
 static unsigned long Kn3[32] = { 0L };

--- a/common/d3des.c
+++ b/common/d3des.c
@@ -129,14 +129,6 @@ static void cookey(register unsigned long *raw1)
 	return;
 	}
 
-void rfbCPKey(register unsigned long *into)
-{
-	register unsigned long *from, *endp;
-
-	from = KnL, endp = &KnL[32];
-	while( from < endp ) *into++ = *from++;
-	return;
-	}
 
 void rfbUseKey(register unsigned long *from)
 {

--- a/common/d3des.h
+++ b/common/d3des.h
@@ -37,12 +37,6 @@ extern void rfbUseKey(unsigned long *);
  * Loads the internal key register with the data in cookedkey.
  */
 
-extern void rfbCPKey(unsigned long *);
-/*		   cookedkey[32]
- * Copies the contents of the internal key register into the storage
- * located at &cookedkey[0].
- */
-
 extern void rfbDes(unsigned char *, unsigned char *);
 /*		    from[8]	      to[8]
  * Encrypts/Decrypts (according to the key currently loaded in the

--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -2426,7 +2426,6 @@ PrintPixelFormat(rfbPixelFormat *format)
 #define rfbDes rfbClientDes
 #define rfbDesKey rfbClientDesKey
 #define rfbUseKey rfbClientUseKey
-#define rfbCPKey rfbClientCPKey
 
 #include "vncauth.c"
 #include "d3des.c"


### PR DESCRIPTION
One more PR... The current D3Des implementation is not thread safe as it operates on a global array for the DES key register. Adding compiler-specific attributes for TLS fixes the issue.