### PR TITLE
LibVNCServer: properly use thread-local storage

### DIFF
--- a/libvncserver/tight.c
+++ b/libvncserver/tight.c
@@ -57,10 +57,11 @@
  * that we resort to using thread local storage instead of having
  * per-client data.
  */
-#if LIBVNCSERVER_HAVE_LIBPTHREAD && LIBVNCSERVER_HAVE_TLS && !defined(TLS) && defined(__linux__)
+#if defined(__GNUC__)
 #define TLS __thread
-#endif
-#ifndef TLS
+#elif defined(_MSC_VER)
+#define TLS __declspec(thread)
+#else
 #define TLS
 #endif
 

--- a/libvncserver/zlib.c
+++ b/libvncserver/zlib.c
@@ -45,10 +45,11 @@
  * tight.  N.B. ZRLE does it the traditional way with per-client storage
  * (and so at least ZRLE will work threaded on older systems.)
  */
-#if LIBVNCSERVER_HAVE_LIBPTHREAD && LIBVNCSERVER_HAVE_TLS && !defined(TLS) && defined(__linux__)
+#if defined(__GNUC__)
 #define TLS __thread
-#endif
-#ifndef TLS
+#elif defined(_MSC_VER)
+#define TLS __declspec(thread)
+#else
 #define TLS
 #endif
 


### PR DESCRIPTION
The TLS macro never has been defined due to the missing
LIBVNCSERVER_HAVE_TLS macro. This revises the macro logic to also cover
Win32 builds with MSVC.