### PR TITLE
Allow to use global LZO library instead of miniLZO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 script:
   - mkdir build
   - cd build
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; sudo apt-get --no-install-suggests --no-install-recommends install libsdl2-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; sudo apt-get --no-install-suggests --no-install-recommends install libsdl2-dev liblzo2-dev; fi
   - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update; brew install sdl2; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake .. -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl; else cmake ..; fi
   - cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${CM
 # all the build configuration switches
 option(BUILD_SHARED_LIBS "Build shared libraries" ${UNIX})
 option(WITH_ZLIB "Search for the zlib compression library to support additional encodings" ON)
+option(WITH_LZO "Search for the LZO compression library to omit internal miniLZO implementation" ON)
 option(WITH_JPEG "Search for the libjpeg compression library to support additional encodings" ON)
 option(WITH_PNG "Search for the PNG compression library to support additional encodings" ON)
 option(WITH_SDL "Search for the Simple Direct Media Layer library to build an example SDL vnc client" ON)
@@ -56,6 +57,9 @@ if(WITH_ZLIB)
   find_package(ZLIB)
 endif(WITH_ZLIB)
 
+if(WITH_LZO)
+  find_package(LZO)
+endif()
 
 if(WITH_JPEG)
   find_package(JPEG)
@@ -189,6 +193,11 @@ if(ZLIB_FOUND)
 else()
   unset(ZLIB_LIBRARIES) # would otherwise contain -NOTFOUND, confusing target_link_libraries()
 endif(ZLIB_FOUND)
+if(LZO_FOUND)
+  set(LIBVNCSERVER_HAVE_LZO 1)
+else()
+  unset(LZO_LIBRARIES CACHE) # would otherwise contain -NOTFOUND, confusing target_link_libraries()
+endif()
 if(JPEG_FOUND)
   set(LIBVNCSERVER_HAVE_LIBJPEG 1)
 else()
@@ -317,7 +326,6 @@ set(LIBVNCSERVER_SOURCES
     ${COMMON_DIR}/d3des.c
     ${COMMON_DIR}/vncauth.c
     ${LIBVNCSERVER_DIR}/cargs.c
-    ${COMMON_DIR}/minilzo.c
     ${LIBVNCSERVER_DIR}/ultra.c
     ${LIBVNCSERVER_DIR}/scale.c
 )
@@ -328,7 +336,6 @@ set(LIBVNCCLIENT_SOURCES
     ${LIBVNCCLIENT_DIR}/rfbproto.c
     ${LIBVNCCLIENT_DIR}/sockets.c
     ${LIBVNCCLIENT_DIR}/vncviewer.c
-    ${COMMON_DIR}/minilzo.c
 )
 
 if(JPEG_FOUND)
@@ -388,6 +395,20 @@ if(ZLIB_FOUND)
   )
 endif(ZLIB_FOUND)
 
+if(LZO_FOUND)
+  add_definitions(-DLIBVNCSERVER_HAVE_LZO)
+  include_directories(${LZO_INCLUDE_DIR})
+else()
+  set(LIBVNCSERVER_SOURCES
+    ${LIBVNCSERVER_SOURCES}
+    ${COMMON_DIR}/minilzo.c
+  )
+  set(LIBVNCCLIENT_SOURCES
+    ${LIBVNCCLIENT_SOURCES}
+    ${COMMON_DIR}/minilzo.c
+  )
+endif()
+
 if(JPEG_FOUND)
   add_definitions(-DLIBVNCSERVER_HAVE_LIBJPEG)
   include_directories(${JPEG_INCLUDE_DIR})
@@ -434,6 +455,7 @@ endif(WIN32)
 target_link_libraries(vncclient
                       ${ADDITIONAL_LIBS}
                       ${ZLIB_LIBRARIES}
+                      ${LZO_LIBRARIES}
                       ${JPEG_LIBRARIES}
                       ${GNUTLS_LIBRARIES}
                       ${OPENSSL_LIBRARIES}
@@ -441,6 +463,7 @@ target_link_libraries(vncclient
 target_link_libraries(vncserver
                       ${ADDITIONAL_LIBS}
                       ${ZLIB_LIBRARIES}
+                      ${LZO_LIBRARIES}
                       ${JPEG_LIBRARIES}
 		      ${PNG_LIBRARIES}
 		      ${CRYPTO_LIBRARIES}

--- a/cmake/Modules/FindLZO.cmake
+++ b/cmake/Modules/FindLZO.cmake
@@ -1,0 +1,31 @@
+# Find liblzo2
+# LZO_FOUND - system has the LZO library
+# LZO_INCLUDE_DIR - the LZO include directory
+# LZO_LIBRARIES - The libraries needed to use LZO
+
+if (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+	# in cache already
+	SET(LZO_FOUND TRUE)
+else (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+	FIND_PATH(LZO_INCLUDE_DIR NAMES lzo/lzo1x.h)
+
+	FIND_LIBRARY(LZO_LIBRARIES NAMES lzo2)
+
+	if (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+		 set(LZO_FOUND TRUE)
+	endif (LZO_INCLUDE_DIR AND LZO_LIBRARIES)
+
+	if (LZO_FOUND)
+		 if (NOT LZO_FIND_QUIETLY)
+				message(STATUS "Found LZO: ${LZO_LIBRARIES}")
+		 endif (NOT LZO_FIND_QUIETLY)
+	else (LZO_FOUND)
+		 if (LZO_FIND_REQUIRED)
+				message(FATAL_ERROR "Could NOT find LZO")
+         else()
+				message(STATUS "Could NOT find LZO")
+		 endif (LZO_FIND_REQUIRED)
+	endif (LZO_FOUND)
+
+#	MARK_AS_ADVANCED(LZO_INCLUDE_DIR LZO_LIBRARIES)
+endif (LZO_INCLUDE_DIR AND LZO_LIBRARIES)

--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -61,7 +61,11 @@
 #endif
 
 #include "sasl.h"
+#ifdef LIBVNCSERVER_HAVE_LZO
+#include <lzo/lzo1x.h>
+#else
 #include "minilzo.h"
+#endif
 #include "tls.h"
 
 #ifdef _MSC_VER

--- a/libvncserver/ultra.c
+++ b/libvncserver/ultra.c
@@ -8,7 +8,11 @@
  */
 
 #include <rfb/rfb.h>
+#ifdef LIBVNCSERVER_HAVE_LZO
+#include <lzo/lzo1x.h>
+#else
 #include "minilzo.h"
+#endif
 
 /*
  * cl->beforeEncBuf contains pixel data in the client's format.

--- a/rfb/rfbconfig.h.cmakein
+++ b/rfb/rfbconfig.h.cmakein
@@ -72,6 +72,9 @@
 /* Define to 1 if you have the `z' library (-lz). */
 #cmakedefine LIBVNCSERVER_HAVE_LIBZ  1 
 
+/* Define to 1 if you have the `lzo2' library (-llzo2). */
+#cmakedefine LIBVNCSERVER_HAVE_LZO  1
+
 /* Define to 1 if you have the <netinet/in.h> header file. */
 #cmakedefine LIBVNCSERVER_HAVE_NETINET_IN_H  1 
 


### PR DESCRIPTION
The complete LZO library nowadays is installed on many systems so we can
optionally make use of it and omit internal miniLZO implementation.