### PR TITLE
Fixed Buffer Overflow Issue

### DIFF
--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -461,7 +461,7 @@ ConnectClientToUnixSock(const char *sockFile)
   int sock;
   struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, sockFile, sizeof(addr.sun_path) - 1);
+  strncpy(addr.sun_path, sockFile, sizeof(addr.sun_path));
 
   sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {

--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -461,7 +461,7 @@ ConnectClientToUnixSock(const char *sockFile)
   int sock;
   struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;
-  snprintf(saun.sun_path, sizeof(saun.sun_path), "%s", sockFile);
+  strncpy(addr.sun_path, sockFile, sizeof(addr.sun_path) - 1);
 
   sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {

--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -461,7 +461,7 @@ ConnectClientToUnixSock(const char *sockFile)
   int sock;
   struct sockaddr_un addr;
   addr.sun_family = AF_UNIX;
-  strcpy(addr.sun_path, sockFile);
+  snprintf(saun.sun_path, sizeof(saun.sun_path), "%s", sockFile);
 
   sock = socket(AF_UNIX, SOCK_STREAM, 0);
   if (sock < 0) {


### PR DESCRIPTION
Hi,

## Description
```
less /usr/include/linux/un.h
```
```bash
/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
#ifndef _LINUX_UN_H
#define _LINUX_UN_H

#include <linux/socket.h>

#define UNIX_PATH_MAX   108

struct sockaddr_un {
        __kernel_sa_family_t sun_family; /* AF_UNIX */
        char sun_path[UNIX_PATH_MAX];   /* pathname */
};

#define SIOCUNIXFILE (SIOCPROTOPRIVATE + 0) /* open a socket file with O_PATH */

#endif /* _LINUX_UN_H */
```

We see char buffer define `sun_path[UNIX_PATH_MAX]; /* pathname */` of `sockaddr_un` that UNIX_PATH_MAX=108

## Overflow code

`strcpy(saun.sun_path, sockFile);`

There isn't any check if length sockFile greater than length saun.sun_path

