### PR TITLE
BUGFIX: Assuming the header is always a minimum of 14 Bytes long is n…

### DIFF
--- a/libvncserver/ws_decode.c
+++ b/libvncserver/ws_decode.c
@@ -131,7 +131,7 @@ hybiReadHeader(ws_ctx_t *wsctx, int *sockRet, int *nPayload)
 {
   int ret;
   char *headerDst = wsctx->codeBufDecode + wsctx->header.nRead;
-  int n = ((uint64_t)WSHLENMAX) - wsctx->header.nRead;
+  int n = ((uint64_t)WS_HYBI_HEADER_LEN_SHORT) - wsctx->header.nRead;
 
 
   ws_dbg("header_read to %p with len=%d\n", headerDst, n);


### PR DESCRIPTION
BUGFIX: Assuming the header is always a minimum of 14 Bytes long is not correct according to the RFC 6455 spec, it can be as short as 2 Bytes. Using it in combination with the RFB protocol, which tells that a client message can be as short as 6 Bytes, leads to reading past the end of a message. The proposal is to use WS_HYBI_HEADER_LEN_SHORT instead of WSHLENMAX to read only the header. Original finding here: https://github.com/LibVNC/libvncserver/issues/297