### PR TITLE
LibVNCClient: fix potentially missing null byte

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -719,9 +719,9 @@ HandleMSLogonAuth(rfbClient *client)
   }
 
   memset(username, 0, sizeof(username));
-  strncpy((char *)username, cred->userCredential.username, sizeof(username));
+  strncpy((char *)username, cred->userCredential.username, sizeof(username)-1);
   memset(password, 0, sizeof(password));
-  strncpy((char *)password, cred->userCredential.password, sizeof(password));
+  strncpy((char *)password, cred->userCredential.password, sizeof(password)-1);
   FreeUserCredential(cred);
 
   srand(time(NULL));


### PR DESCRIPTION
Fixes warning with GCC 8:

rfbproto.c: warning: ‘strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]
   strncpy((char *)username, cred->userCredential.username, sizeof(username));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rfbproto.c: warning: ‘strncpy’ specified bound 64 equals destination size [-Wstringop-truncation]
   strncpy((char *)password, cred->userCredential.password, sizeof(password));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~