### PR TITLE
rfbserver: don't close fd 0 accidentally

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -463,6 +463,11 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
 
       cl->lastPtrX = -1;
 
+#ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+      cl->pipe_notify_client_thread[0] = -1;
+      cl->pipe_notify_client_thread[1] = -1;
+#endif
+
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
       /*
        * Wait a few ms for the client to send WebSockets connection (TLS/SSL or plain)


### PR DESCRIPTION
Commit cedae6e6f97b14f5df3ea7c5f7efd59f2bc9ad82 introduces a pipe fd pair (pipe_notify_client_thread) to rfbClientRec. These fd's are created only in the "background loop" operation mode. Otherwise they are incorrectly left as zero. In effect, rfbClientConnectionGone closes fd 0 (twice), causing lots of problems later on.

This commit fixes the issue by properly intializing the unused fd's to -1