### PR TITLE
rfbserver: add a hooking function to deliver rfbFramebufferUpdateRequest messages

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -2380,8 +2380,10 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
 	        rfbLog("Warning, ignoring rfbFramebufferUpdateRequest: %dXx%dY-%dWx%dH\n",msg.fur.x, msg.fur.y, msg.fur.w, msg.fur.h);
 		return;
         }
- 
-        
+
+        if (cl->clientFramebufferUpdateRequestHook)
+            cl->clientFramebufferUpdateRequestHook(cl, &msg.fur);
+
 	tmpRegion =
 	  sraRgnCreateRect(msg.fur.x,
 			   msg.fur.y,

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -412,6 +412,7 @@ typedef struct sraRegion* sraRegionPtr;
  */
 
 typedef void (*ClientGoneHookPtr)(struct _rfbClientRec* cl);
+typedef void (*ClientFramebufferUpdateRequestHookPtr)(struct _rfbClientRec* cl, rfbFramebufferUpdateRequestMsg* furMsg);
 
 typedef struct _rfbFileTransferData {
   int fd;
@@ -694,6 +695,11 @@ typedef struct _rfbClientRec {
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
     int pipe_notify_client_thread[2];
 #endif
+    /**
+     * clientFramebufferUpdateRequestHook is called when a client requests a frame
+     * buffer update.
+     */
+    ClientFramebufferUpdateRequestHookPtr clientFramebufferUpdateRequestHook;
 } rfbClientRec, *rfbClientPtr;
 
 /**


### PR DESCRIPTION
This commit adds a hooking function to deliver
rfbFramebufferUpdateRequest messages from clients to the frame
producer for a case the producer needs to handle the messages for
flow control or etc.

This change is for OpenBMC KVM feature in:
https://github.com/openbmc/openbmc

Resolves this issue:
https://github.com/openbmc/bmcweb/issues/80
