### PR TITLE
avoid pthread_join if backgroundLoop is FALSE

### DIFF
--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -1112,6 +1112,7 @@ void rfbShutdownServer(rfbScreenInfoPtr screen,rfbBool disconnectClients) {
       }
 
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
+    if(currentCl->screen->backgroundLoop) {
       /*
 	Notify the thread. This simply writes a NULL byte to the notify pipe in order to get past the select()
 	in clientInput(), the loop in there will then break because the rfbCloseClient() above has set
@@ -1120,6 +1121,7 @@ void rfbShutdownServer(rfbScreenInfoPtr screen,rfbBool disconnectClients) {
       write(currentCl->pipe_notify_client_thread[1], "\x00", 1);
       /* And wait for it to finish. */
       pthread_join(currentCl->client_thread, NULL);
+    }
 #else
       rfbClientConnectionGone(currentCl);
 #endif


### PR DESCRIPTION
client_thread is created depending upon backgroundLoop, but joining
without checking for same condition. so we are trying to join a garbage
thread_id.