### PR TITLE
CMakeLists.txt: fix build without C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 cmake_policy(SET CMP0037 NEW)
 
-project(LibVNCServer)
+project(LibVNCServer C)
 include(CheckFunctionExists)
 include(CheckSymbolExists)
 include(CheckIncludeFile)


### PR DESCRIPTION
Specify that libvncserver is a C project file otherwise build will fail
if no C++ compiler is found by cmake

Fixes:
 - http://autobuild.buildroot.org/results/16aaa4e86a2dbf1acf95f10d5131b0f7b8a3d61a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>