### PR TITLE
CMakeLists.txt: use pkgconfig to find openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,8 @@ endif(WITH_GNUTLS)
 
 
 if(WITH_OPENSSL)
-  find_package(OpenSSL)
+  find_package(PkgConfig)
+  pkg_check_modules(OPENSSL "openssl")
 endif(WITH_OPENSSL)
 
 


### PR DESCRIPTION
find_package(openssl) fails to find openssl dependencies such as -lz so
use pkgconfig to fix static build

Fixes:
 - http://autobuild.buildroot.org/results/c3f75480cb4b8b042cdf6a34cc5568ea13e51342

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>