### PR TITLE
rfbproto: invert bitmask using bitwise NOT

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -216,13 +216,13 @@ SetServer2Client(rfbClient* client, int messageType)
 void
 ClearClient2Server(rfbClient* client, int messageType)
 {
-  client->supportedMessages.client2server[((messageType & 0xFF)/8)] &= (!(1<<(messageType % 8)));
+  client->supportedMessages.client2server[((messageType & 0xFF)/8)] &= ~(1<<(messageType % 8));
 }
 
 void
 ClearServer2Client(rfbClient* client, int messageType)
 {
-  client->supportedMessages.server2client[((messageType & 0xFF)/8)] &= (!(1<<(messageType % 8)));
+  client->supportedMessages.server2client[((messageType & 0xFF)/8)] &= ~(1<<(messageType % 8));
 }
 
 


### PR DESCRIPTION
Inverting a bitmask should be done using a bitwise NOT instead of a
logical NOT.