### PR TITLE
trle: add missing variable initializations

### DIFF
--- a/libvncclient/trle.c
+++ b/libvncclient/trle.c
@@ -52,12 +52,12 @@
 
 static rfbBool HandleTRLE(rfbClient *client, int rx, int ry, int rw, int rh) {
   int x, y, w, h;
-  uint8_t type, last_type;
+  uint8_t type, last_type = 0;
   int min_buffer_size = 16 * 16 * (REALBPP / 8) * 2;
   uint8_t *buffer;
   CARDBPP palette[128];
-  int bpp, mask, divider;
-  CARDBPP color;
+  int bpp = 0, mask = 0, divider = 0;
+  CARDBPP color = 0;
 
   /* First make sure we have a large enough raw buffer to hold the
    * decompressed data.  In practice, with a fixed REALBPP, fixed frame


### PR DESCRIPTION
Fixes compiler warnings:

In file included from libvncserver/libvncclient/rfbproto.c:2390:
libvncserver/libvncclient/trle.c: In function 'HandleTRLE8':
libvncserver/libvncclient/trle.c:128:11: warning: 'color' may be used uninitialized in this function [-Wmaybe-uninitialized]
           client->GotFillRect(client, x, y, w, h, color);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libvncserver/libvncclient/trle.c:145:54: warning: 'divider' may be used uninitialized in this function [-Wmaybe-uninitialized]
                                    (w + divider - 1) / divider * h))
                                    ~~~~~~~~~~~~~~~~~~^~~~~~~~~
libvncserver/libvncclient/trle.c:153:50: warning: 'mask' may be used uninitialized in this function [-Wmaybe-uninitialized]
                     palette[((*buffer) >> shift) & mask];
                             ~~~~~~~~~~~~~~~~~~~~~^~~~~~
libvncserver/libvncclient/trle.c:154:23: warning: 'bpp' may be used uninitialized in this function [-Wmaybe-uninitialized]
                 shift -= bpp;
                 ~~~~~~^~~~~~
libvncserver/libvncclient/trle.c:108:14: warning: 'last_type' may be used uninitialized in this function [-Wmaybe-uninitialized]
         type = last_type;
         ~~~~~^~~~~~~~~~~