### PR TITLE
LibVNCClient: limit security type count to 254

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -330,7 +330,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
 
     if (count>(sizeof(tAuth)/sizeof(tAuth[0])))
     {
-        rfbClientLog("%d security types are too many; maximum is %d\n", count, sizeof(tAuth));
+         rfbClientLog("%d security types are too many; maximum is %d\n", count, (sizeof(tAuth)/sizeof(tAuth[0])));
         return FALSE;
     }
 
@@ -648,4 +648,3 @@ GetTLSCipherBits(rfbClient* client)
     return gnutls_cipher_get_key_size(cipher) * 8;
 }
 #endif /* LIBVNCSERVER_HAVE_SASL */
-

--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -316,7 +316,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
     uint8_t count=0;
     uint8_t loop=0;
     uint8_t flag=0;
-    uint32_t tAuth[256], t;
+    uint32_t tAuth[254], t;
     char buf1[500],buf2[10];
     uint32_t authScheme;
 
@@ -328,7 +328,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
         return FALSE;
     }
 
-    if (count>sizeof(tAuth))
+    if (count>(sizeof(tAuth)/sizeof(tAuth[0])))
     {
         rfbClientLog("%d security types are too many; maximum is %d\n", count, sizeof(tAuth));
         return FALSE;

--- a/libvncclient/tls_openssl.c
+++ b/libvncclient/tls_openssl.c
@@ -456,7 +456,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
 
     if (count>(sizeof(tAuth)/sizeof(tAuth[0])))
     {
-        rfbClientLog("%d security types are too many; maximum is %d\n", count, sizeof(tAuth));
+         rfbClientLog("%d security types are too many; maximum is %d\n", count, (sizeof(tAuth)/sizeof(tAuth[0])));
         return FALSE;
     }
 
@@ -693,4 +693,3 @@ int GetTLSCipherBits(rfbClient* client)
     return SSL_CIPHER_get_bits(cipher, NULL);
 }
 #endif /* LIBVNCSERVER_HAVE_SASL */
-

--- a/libvncclient/tls_openssl.c
+++ b/libvncclient/tls_openssl.c
@@ -442,7 +442,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
     uint8_t count=0;
     uint8_t loop=0;
     uint8_t flag=0;
-    uint32_t tAuth[256], t;
+    uint32_t tAuth[254], t;
     char buf1[500],buf2[10];
     uint32_t authScheme;
 
@@ -454,7 +454,7 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
         return FALSE;
     }
 
-    if (count>sizeof(tAuth))
+    if (count>(sizeof(tAuth)/sizeof(tAuth[0])))
     {
         rfbClientLog("%d security types are too many; maximum is %d\n", count, sizeof(tAuth));
         return FALSE;


### PR DESCRIPTION
As the security type count is stored in an uint8_t it will never exceed
255. The check for too many security types will therefore always
evaluate to FALSE. We can prevent this by limiting the number of
accepted security types to 254.