### PR TITLE
LibVNCServer: fix inclusion of own headers

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -71,7 +71,7 @@
 #define DEBUGPROTO(x)
 #endif
 #include <stdarg.h>
-#include <scale.h>
+#include "scale.h"
 /* stst() */
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/libvncserver/zrle.c
+++ b/libvncserver/zrle.c
@@ -45,46 +45,46 @@
 #define ENDIAN_NO 2
 #define BPP 8
 #define ZYWRLE_ENDIAN ENDIAN_NO
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef BPP
 #define BPP 15
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_LITTLE
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_BIG
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef BPP
 #define BPP 16
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_LITTLE
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_BIG
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef BPP
 #define BPP 32
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_LITTLE
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_BIG
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #define CPIXEL 24A
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_LITTLE
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_BIG
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef CPIXEL
 #define CPIXEL 24B
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_LITTLE
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef ZYWRLE_ENDIAN
 #define ZYWRLE_ENDIAN ENDIAN_BIG
-#include <zrleencodetemplate.c>
+#include "zrleencodetemplate.c"
 #undef CPIXEL
 #undef BPP
 


### PR DESCRIPTION
Local header files shouldn't be included as system header files.