### PR TITLE
Use binary encoding as default instead of base64

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -171,7 +171,7 @@ static rfbBool
 webSocketsHandshake(rfbClientPtr cl, char *scheme)
 {
     char *buf, *response, *line;
-    int n, linestart = 0, len = 0, llen, base64 = TRUE;
+    int n, linestart = 0, len = 0, llen, base64 = FALSE;
     char prefix[5], trailer[17];
     char *path = NULL, *host = NULL, *origin = NULL, *protocol = NULL;
     char *key1 = NULL, *key2 = NULL, *key3 = NULL;
@@ -294,15 +294,14 @@ webSocketsHandshake(rfbClientPtr cl, char *scheme)
         return FALSE;
     }
 
-    if ((protocol) && (strstr(protocol, "binary"))) {
-        rfbLog("  - webSocketsHandshake: using binary/raw encoding\n");
-        base64 = FALSE;
-        protocol = "binary";
-    } else {
+    if ((protocol) && (strstr(protocol, "base64"))) {
         rfbLog("  - webSocketsHandshake: using base64 encoding\n");
         base64 = TRUE;
-        if ((protocol) && (strstr(protocol, "base64"))) {
-            protocol = "base64";
+        protocol = "base64";
+    } else {
+        rfbLog("  - webSocketsHandshake: using binary/raw encoding\n");
+        if ((protocol) && (strstr(protocol, "binary"))) {
+            protocol = "binary";
         } else {
             protocol = "";
         }


### PR DESCRIPTION
The WebSocket specification does not include base64 encoding. It was mentioned in a very early draft of the specification but never made it to any final version.

Not many WebSocket clients out there support base64 data, and the ones that do are very outdated.

Then there's the topic of subprotocols - Currently, libvncserver requires a client to specify 'binary' as a subprotocol in order to not get base 64 data. To have this subprotocol value is also not valid according to the WebSocket standard.

With this PR the code will still be compatible with old clients that specifically ask for 'binary' or 'base64' using subprotocols. (Even if subprotocols shouldn't actually be used to determine the main encoding that is used for the data on the WebSocket.)