### PR TITLE
auth: Add API to unregister built in security handlers

### DIFF
--- a/libvncserver/auth.c
+++ b/libvncserver/auth.c
@@ -198,6 +198,13 @@ static rfbSecurityHandler VncSecurityHandlerNone = {
 };
                         
 
+void
+rfbUnregisterPrimarySecurityHandlers (void)
+{
+    rfbUnregisterSecurityHandler(&VncSecurityHandlerNone);
+    rfbUnregisterSecurityHandler(&VncSecurityHandlerVncAuth);
+}
+
 static void
 rfbSendSecurityTypeList(rfbClientPtr cl, int primaryType)
 {

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -862,6 +862,7 @@ extern void rfbProcessClientSecurityType(rfbClientPtr cl);
 extern void rfbAuthProcessClientMessage(rfbClientPtr cl);
 extern void rfbRegisterSecurityHandler(rfbSecurityHandler* handler);
 extern void rfbUnregisterSecurityHandler(rfbSecurityHandler* handler);
+extern void rfbUnregisterPrimarySecurityHandlers (void);
 
 /* rre.c */
 


### PR DESCRIPTION
If I have a VNC server that first accepts password based authentication,
then switches to something not using password (e.g. a prompt on screen),
the security handler from the first would still be sent as, meaning
clients would still ask for a password without there being one.


---


Not a big fan of this actually. The problem is that the primary method of previous sessions permanently adds things to the security handler list. Any ideas for a better API would be appreciated.