### PR TITLE
rfbproto: fix broken endianess handling on Win32

### DIFF
--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -63,7 +63,6 @@
 #include <stdint.h>
 
 #if defined(WIN32) && !defined(__MINGW32__)
-#define LIBVNCSERVER_WORDS_BIGENDIAN
 typedef int8_t rfbBool;
 #include <sys/timeb.h>
 #include <winsock2.h>


### PR DESCRIPTION
It's definitely wrong to build with LIBVNCSERVER_WORDS_BIGENDIAN
defined on Win32. Instead use the auto-detected endianess macro
(which will indicate little endian on i686/x86_64). Removing the
hardcoded define makes all tests pass (especially encodingtest)
when built with the MinGW64 toolchain.

In combination with PR #257 this fixes issues #165 and #249.