### PR TITLE
rfbproto: add missing RFB_INVALID_SOCKET

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -367,7 +367,7 @@ rfbBool ConnectToRFBRepeater(rfbClient* client,const char *repeaterHost, int rep
 
 #ifdef LIBVNCSERVER_IPv6
   client->sock = ConnectClientToTcpAddr6(repeaterHost, repeaterPort);
-  if (client->sock == -1)
+  if (client->sock == RFB_INVALID_SOCKET)
 #endif
   {
     unsigned int host;


### PR DESCRIPTION
This amends 1f6da568b27629c6da1d6b356e430f4e0be3d3ee.