### PR TITLE
libvncclient: rfbproto: do not fallback to IPv4

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -330,18 +330,16 @@ ConnectToRFBServer(rfbClient* client,const char *hostname, int port)
   {
 #ifdef LIBVNCSERVER_IPv6
     client->sock = ConnectClientToTcpAddr6(hostname, port);
-    if (client->sock == RFB_INVALID_SOCKET)
-#endif
-    {
-      unsigned int host;
+#else
+    unsigned int host;
 
-      /* serverHost is a hostname */
-      if (!StringToIPAddr(hostname, &host)) {
-        rfbClientLog("Couldn't convert '%s' to host address\n", hostname);
-        return FALSE;
-      }
-      client->sock = ConnectClientToTcpAddr(host, port);
+    /* serverHost is a hostname */
+    if (!StringToIPAddr(hostname, &host)) {
+      rfbClientLog("Couldn't convert '%s' to host address\n", hostname);
+      return FALSE;
     }
+    client->sock = ConnectClientToTcpAddr(host, port);
+#endif
   }
 
   if (client->sock == RFB_INVALID_SOCKET) {
@@ -367,17 +365,15 @@ rfbBool ConnectToRFBRepeater(rfbClient* client,const char *repeaterHost, int rep
 
 #ifdef LIBVNCSERVER_IPv6
   client->sock = ConnectClientToTcpAddr6(repeaterHost, repeaterPort);
-  if (client->sock == RFB_INVALID_SOCKET)
-#endif
-  {
-    unsigned int host;
-    if (!StringToIPAddr(repeaterHost, &host)) {
-      rfbClientLog("Couldn't convert '%s' to host address\n", repeaterHost);
-      return FALSE;
-    }
-
-    client->sock = ConnectClientToTcpAddr(host, repeaterPort);
+#else
+  unsigned int host;
+  if (!StringToIPAddr(repeaterHost, &host)) {
+    rfbClientLog("Couldn't convert '%s' to host address\n", repeaterHost);
+    return FALSE;
   }
+
+  client->sock = ConnectClientToTcpAddr(host, repeaterPort);
+#endif
 
   if (client->sock == RFB_INVALID_SOCKET) {
     rfbClientLog("Unable to connect to VNC repeater\n");


### PR DESCRIPTION
The IPv4 code which is used as fallback contains calls to deprecated
network functions such as gethostbyname() which are not thread-safe
and thus can lead to crashes when called in multiple threads at the
same time. The IPv6 code properly uses getaddrinfo() which does not
suffer from these problems. When IPv6 is enabled the modern code
paths should be used exclusively. It's unlikely anyway that the
legacy network code succeeds after IPv6 (which is capable of
establishing IPv4 connections as well) failed before.

Closes #262.