### PR TITLE
rfbserver: make readBuf a signed char array

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -1503,7 +1503,7 @@ char *rfbProcessFileTransferReadBuffer(rfbClientPtr cl, uint32_t length)
 rfbBool rfbSendFileTransferChunk(rfbClientPtr cl)
 {
     /* Allocate buffer for compression */
-    unsigned char readBuf[sz_rfbBlockSize];
+    char readBuf[sz_rfbBlockSize];
     int bytesRead=0;
     int retval=0;
     fd_set wfds;
@@ -1575,11 +1575,11 @@ rfbBool rfbSendFileTransferChunk(rfbClientPtr cl)
                 rfbLog("rfbSendFileTransferChunk(): Read %d bytes\n", bytesRead);
                 */
                 if (!cl->fileTransfer.compressionEnabled)
-                    return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, (char *)readBuf);
+                    return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, readBuf);
                 else
                 {
 #ifdef LIBVNCSERVER_HAVE_LIBZ
-                    nRetC = compress(compBuf, &nMaxCompSize, readBuf, bytesRead);
+                    nRetC = compress(compBuf, &nMaxCompSize, (unsigned char *)readBuf, bytesRead);
                     /*
                     rfbLog("Compressed the packet from %d -> %d bytes\n", nMaxCompSize, bytesRead);
                     */
@@ -1587,10 +1587,10 @@ rfbBool rfbSendFileTransferChunk(rfbClientPtr cl)
                     if ((nRetC==0) && (nMaxCompSize<bytesRead))
                         return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 1, nMaxCompSize, (char *)compBuf);
                     else
-                        return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, (char *)readBuf);
+                        return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, readBuf);
 #else
                     /* We do not support compression of the data stream */
-                    return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, (char *)readBuf);
+                    return  rfbSendFileTransferMessage(cl, rfbFilePacket, 0, 0, bytesRead, readBuf);
 #endif
                 }
             }


### PR DESCRIPTION
As of e1d06824e7a957bf483a81903bc8a19d89414492 for Windows builds read() is properly
wrapped to recv() which takes a signed char array. Since we cast the
pointer to signed char for other function calls as well we can make it
a signed char array right from the start.

Fixes compiler warning/error:

```
libvncserver/libvncserver/rfbserver.c: In function ‘rfbSendFileTransferChunk’:
libvncserver/libvncserver/rfbserver.c:1549:51: error: pointer targets in passing argument 2 of ‘recv’ differ in signedness [-Werror=pointer-sign]
             bytesRead = read(cl->fileTransfer.fd, readBuf, sz_rfbBlockSize);
                                                   ^~~~~~~
libvncserver/common/sockets.h:51:38: note: in definition of macro ‘read’
 #define read(sock,buf,len) recv(sock,buf,len,0)
                                      ^~~
In file included from libvncserver/rfb/rfbproto.h:68,
                 from libvncserver/rfb/rfb.h:44,
                 from libvncserver/libvncserver/rfbserver.c:37:
/usr/share/mingw-w64/include/winsock2.h:992:34: note: expected ‘char *’ but argument is of type ‘unsigned char *’
   WINSOCK_API_LINKAGE int WSAAPI recv(SOCKET s,char *buf,int len,int flags);
```