### PR TITLE
libvnc{client,server}.pc.cmakein: remove zlib

### DIFF
--- a/libvncclient.pc.cmakein
+++ b/libvncclient.pc.cmakein
@@ -7,7 +7,7 @@ Name: LibVNCClient
 Description: A library for easy implementation of a VNC client.
 Version: @LibVNCServer_VERSION@
 Requires:
-Requires.private: zlib
+Requires.private:
 Libs: -L${libdir} -lvncclient
 Libs.private: @PRIVATE_LIBS@
 Cflags: -I${includedir}

--- a/libvncserver.pc.cmakein
+++ b/libvncserver.pc.cmakein
@@ -7,7 +7,7 @@ Name: LibVNCServer
 Description: A library for easy implementation of a VNC server.
 Version: @LibVNCServer_VERSION@
 Requires:
-Requires.private: zlib
+Requires.private:
 Libs: -L${libdir} -lvncserver
 Libs.private: @PRIVATE_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Remove zlib from Requires.private as libvnc can be built without zlib
thanks to WITH_LIB, zlib will be added to Libs.private thanks to
PRIVATE_LIBS

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>