### PR TITLE
Don't print an uninitialized string

### DIFF
--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -139,8 +139,9 @@ rfbNewConnectionFromSock(rfbScreenInfoPtr rfbScreen, rfbSocket sock)
     char host[1024];
     if(getnameinfo((struct sockaddr*)&addr, addrlen, host, sizeof(host), NULL, 0, NI_NUMERICHOST) != 0) {
       rfbLogPerror("rfbProcessNewConnection: error in getnameinfo");
+    } else {
+      rfbLog("Got connection from client %s\n", host);
     }
-    rfbLog("Got connection from client %s\n", host);
 #else
     rfbLog("Got connection from client %s\n", inet_ntoa(addr.sin_addr));
 #endif


### PR DESCRIPTION
I discovered some garbage characters in my x11vnc terminal:
```
20/11/2019 13:07:08 Got connection from client Ku�A
20/11/2019 13:07:08 rfbNewClient: error in getnameinfo: Transport endpoint is not connected
20/11/2019 13:07:08   other clients:
20/11/2019 13:07:08 webSocketsHandshake: unknown connection error
```
This change avoids printing an uninitialized string when getnameinfo failed.