### PR TITLE
Adding ability to override log and err functions. Fix for missing include.

### DIFF
--- a/libvncclient/tls_openssl.c
+++ b/libvncclient/tls_openssl.c
@@ -18,6 +18,8 @@
  *  USA.
  */
 
+#include <stdio.h>
+
 #ifndef _MSC_VER
 #define _XOPEN_SOURCE 500
 #endif

--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -493,7 +493,14 @@ rfbBool rfbInitClient(rfbClient* client,int* argc,char** argv) {
       }
     }
   }
-
+  if (client->RfbClientLog != NULL) {
+    // Redefine log function
+    rfbClientLog=client->RfbClientLog;
+  }
+  if (client->RfbClientErr != NULL) {
+    // Redefine err function
+    rfbClientErr=client->RfbClientErr;
+  }
   if(!rfbInitConnection(client)) {
     rfbClientCleanup(client);
     return FALSE;

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -234,6 +234,9 @@ typedef char* (*GetUserProc)(struct _rfbClient* client);
 typedef char* (*GetSASLMechanismProc)(struct _rfbClient* client, char* mechlist);
 #endif /* LIBVNCSERVER_HAVE_SASL */
 
+/* rfbproto.c (see below for the rest of the declarations for rfbproto.c) */
+typedef void (*rfbClientLogProc)(const char *format, ...);
+
 typedef struct _rfbClient {
 	uint8_t* frameBuffer;
 	int width, height;
@@ -450,6 +453,8 @@ typedef struct _rfbClient {
 
 #endif
 #endif
+    rfbClientLogProc RfbClientLog;
+    rfbClientLogProc RfbClientErr;
 } rfbClient;
 
 /* cursor.c */
@@ -469,7 +474,6 @@ extern int listenForIncomingConnectionsNoFork(rfbClient* viewer, int usec_timeou
 /* rfbproto.c */
 
 extern rfbBool rfbEnableClientLogging;
-typedef void (*rfbClientLogProc)(const char *format, ...);
 extern rfbClientLogProc rfbClientLog,rfbClientErr;
 extern rfbBool ConnectToRFBServer(rfbClient* client,const char *hostname, int port);
 extern rfbBool ConnectToRFBRepeater(rfbClient* client,const char *repeaterHost, int repeaterPort, const char *destHost, int destPort);


### PR DESCRIPTION
libvncclient: Add ability to optionally override log and err functions.
rfb: Fix for missing stdio.h include (and hence undeclared snprintf).