### PR TITLE
Fix for missing stdio.h include needed for iOS

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -17,6 +17,7 @@
  *  USA.
  */
 
+#include <stdio.h>
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
 #include <rfb/rfbclient.h>

--- a/libvncclient/tls_openssl.c
+++ b/libvncclient/tls_openssl.c
@@ -18,6 +18,7 @@
  *  USA.
  */
 
+#include <stdio.h>
 #ifndef _MSC_VER
 #define _XOPEN_SOURCE 500
 #endif


### PR DESCRIPTION
rfb: Fix for missing stdio.h include (and hence undeclared snprintf).