### PR TITLE
libvncclient: handle half-open TCP connections

### DIFF
--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -272,6 +272,7 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->destPort = 5900;
   
   client->connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+  client->readTimeout = DEFAULT_READ_TIMEOUT;
 
   client->CurrentKeyboardLedState = 0;
   client->HandleKeyboardLedState = (HandleKeyboardLedStateProc)DummyPoint;

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -85,6 +85,7 @@
 #define SERVER_PORT_OFFSET 5900
 
 #define DEFAULT_CONNECT_TIMEOUT 60
+#define DEFAULT_READ_TIMEOUT 0
 
 #define DEFAULT_SSH_CMD "/usr/bin/ssh"
 #define DEFAULT_TUNNEL_CMD  \
@@ -454,6 +455,9 @@ typedef struct _rfbClient {
 #endif
 	/* timeout in seconds for select() after connect() */
 	unsigned int connectTimeout;
+	/* timeout in seconds when reading from half-open connections in
+	 * ReadFromRFBServer() - keep at 0 to disable timeout detection and handling */
+	unsigned int readTimeout;
 } rfbClient;
 
 /* cursor.c */


### PR DESCRIPTION
When a connection is not reset properly at the TCP level (e.g. sudden power loss or process crash) the TCP connection becomes half-open and read() always returns -1 with errno = EAGAIN while select() always returns 0. This leads to an infinite loop and can be fixed by closing the connection after a certain number of retries (based on a timeout) has been exceeded.
