### PR TITLE
Add TLS R/W mutex to rfbClient

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -252,6 +252,8 @@ InitializeTLSSession(rfbClient* client, rfbBool anonTLS)
   gnutls_transport_set_push_function((gnutls_session_t)client->tlsSession, PushTLS);
   gnutls_transport_set_pull_function((gnutls_session_t)client->tlsSession, PullTLS);
 
+  INIT_MUTEX(client->tlsRwMutex);
+
   rfbClientLog("TLS session initialized.\n");
 
   return TRUE;
@@ -566,7 +568,10 @@ ReadFromTLS(rfbClient* client, char *out, unsigned int n)
 {
   ssize_t ret;
 
+  LOCK(client->tlsRwMutex);
   ret = gnutls_record_recv((gnutls_session_t)client->tlsSession, out, n);
+  UNLOCK(client->tlsRwMutex);
+
   if (ret >= 0) return ret;
   if (ret == GNUTLS_E_REHANDSHAKE || ret == GNUTLS_E_AGAIN)
   {
@@ -585,39 +590,22 @@ WriteToTLS(rfbClient* client, const char *buf, unsigned int n)
   unsigned int offset = 0;
   ssize_t ret;
 
-  if (client->LockWriteToTLS)
-  {
-    if (!client->LockWriteToTLS(client))
-    {
-      rfbClientLog("Callback to get lock in WriteToTLS() failed\n");
-      return -1;
-    }
-  }
   while (offset < n)
   {
+    LOCK(client->tlsRwMutex);
     ret = gnutls_record_send((gnutls_session_t)client->tlsSession, buf+offset, (size_t)(n-offset));
+    UNLOCK(client->tlsRwMutex);
+
     if (ret == 0) continue;
     if (ret < 0)
     {
       if (ret == GNUTLS_E_AGAIN || ret == GNUTLS_E_INTERRUPTED) continue;
       rfbClientLog("Error writing to TLS: %s.\n", gnutls_strerror(ret));
-      if (client->UnlockWriteToTLS)
-      {
-        if (!client->UnlockWriteToTLS(client))
-          rfbClientLog("Callback to unlock WriteToTLS() failed\n");
-      }
       return -1;
     }
     offset += (unsigned int)ret;
   }
-  if (client->UnlockWriteToTLS)
-  {
-    if (!client->UnlockWriteToTLS(client))
-    {
-      rfbClientLog("Callback to unlock WriteToTLS() failed\n");
-      return -1;
-    }
-  }
+
   return offset;
 }
 
@@ -627,6 +615,7 @@ void FreeTLS(rfbClient* client)
   {
     gnutls_deinit((gnutls_session_t)client->tlsSession);
     client->tlsSession = NULL;
+    TINI_MUTEX(client->tlsRwMutex);
   }
 }
 

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -229,8 +229,8 @@ typedef void (*GotCopyRectProc)(struct _rfbClient* client, int src_x, int src_y,
 typedef void (*GotFillRectProc)(struct _rfbClient* client, int x, int y, int w, int h, uint32_t colour);
 typedef void (*GotBitmapProc)(struct _rfbClient* client, const uint8_t* buffer, int x, int y, int w, int h);
 typedef rfbBool (*GotJpegProc)(struct _rfbClient* client, const uint8_t* buffer, int length, int x, int y, int w, int h);
-typedef rfbBool (*LockWriteToTLSProc)(struct _rfbClient* client);
-typedef rfbBool (*UnlockWriteToTLSProc)(struct _rfbClient* client);
+typedef rfbBool (*LockWriteToTLSProc)(struct _rfbClient* client);   /** @deprecated */
+typedef rfbBool (*UnlockWriteToTLSProc)(struct _rfbClient* client); /** @deprecated */
 
 #ifdef LIBVNCSERVER_HAVE_SASL
 typedef char* (*GetUserProc)(struct _rfbClient* client);
@@ -415,7 +415,12 @@ typedef struct _rfbClient {
         /* Output Window ID. When set, client application enables libvncclient to perform direct rendering in its window */
         unsigned long outputWindow;
 
-	/** Hooks for optional protection WriteToTLS() by mutex */
+	/** 
+	 * These lock/unlock hooks are not used anymore. LibVNCClient will now use 
+	 * platform-specific synchronization library to protect concurrent TLS R/W.
+	 *  
+	 * @deprecated
+	 */
 	LockWriteToTLSProc LockWriteToTLS;
 	UnlockWriteToTLSProc UnlockWriteToTLS;
 

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -55,6 +55,7 @@
 #endif
 #include <rfb/rfbproto.h>
 #include <rfb/keysym.h>
+#include <common/threading.h>
 
 #ifdef LIBVNCSERVER_HAVE_SASL
 #include <sasl/sasl.h>
@@ -454,6 +455,12 @@ typedef struct _rfbClient {
 #endif
 	/* timeout in seconds for select() after connect() */
 	unsigned int connectTimeout;
+
+	/**
+	 * Mutex to protect concurrent TLS read/write.
+	 * For internal use only.
+	 */
+	MUTEX(tlsRwMutex);
 } rfbClient;
 
 /* cursor.c */


### PR DESCRIPTION
I have added a comment to indicate its internal use but to allow this type of modifications in future we could create a separate 'internal' structure.