### PR TITLE
For #410: Don't select TLS security types if TLS is not supported

### DIFF
--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -482,7 +482,7 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
     for (loop=0;loop<count;loop++)
     {
         if (!ReadFromRFBServer(client, (char *)&tAuth[loop], 1)) return FALSE;
-        rfbClientLog("%d) Received security type %d\n", loop, tAuth[loop]);
+        rfbClientLog("%d) Received security type %d\n", loop + 1, tAuth[loop]);
         if (flag) continue;
         extAuthHandler=FALSE;
         for (e = rfbClientExtensions; e; e = e->next) {
@@ -524,7 +524,7 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
             }
             if (flag)
             {
-                rfbClientLog("Selecting security type %d (%d/%d in the list)\n", authScheme, loop, count);
+                rfbClientLog("Selecting security type %d (%d/%d in the list)\n", authScheme, loop + 1, count);
                 /* send back a single byte indicating which security type to use */
                 if (!WriteToRFBServer(client, (char *)&tAuth[loop], 1)) return FALSE;
             }

--- a/libvncclient/rfbproto.c
+++ b/libvncclient/rfbproto.c
@@ -497,13 +497,12 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
         if (tAuth[loop]==rfbVncAuth || tAuth[loop]==rfbNoAuth ||
 			extAuthHandler ||
 #if defined(LIBVNCSERVER_HAVE_GNUTLS) || defined(LIBVNCSERVER_HAVE_LIBSSL)
-            tAuth[loop]==rfbVeNCrypt ||
+            (!subAuth && (tAuth[loop]==rfbTLS || (tAuth[loop]==rfbVeNCrypt && client->GetCredential))) ||
 #endif
 #ifdef LIBVNCSERVER_HAVE_SASL
             tAuth[loop]==rfbSASL ||
 #endif /* LIBVNCSERVER_HAVE_SASL */
-            (tAuth[loop]==rfbARD && client->GetCredential) ||
-            (!subAuth && (tAuth[loop]==rfbTLS || (tAuth[loop]==rfbVeNCrypt && client->GetCredential))))
+            (tAuth[loop]==rfbARD && client->GetCredential))
         {
             if (!subAuth && client->clientAuthSchemes)
             {


### PR DESCRIPTION
Now, test for `rfbTLS` & `rfbVeNCrypt` is only enabled if TLS support is present.

There is slight change for `rfbVeNCrypt`: Earlier, it could have been selected even if `client->GetCredential` is not set. But now this must be set. (I think this was the original intention but correct me If this is not the case.)

And slightly better logs 🙂.