### PR TITLE
Bump so version to 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ enable_testing()
 
 set(PACKAGE_NAME           "LibVNCServer")
 set(FULL_PACKAGE_NAME      "LibVNCServer")
-set(VERSION_SO             "1")
+set(VERSION_SO             "1.1")
 set(PROJECT_BUGREPORT_PATH "https://github.com/LibVNC/libvncserver/issues")
 set(LIBVNCSERVER_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libvncserver)
 set(COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common)


### PR DESCRIPTION
Version 0.9.13 adds some new symbols (e.g. new fields to `rfbClientPtr` and new method such as `rfbSendExtDesktopSize` were added in 8e41510).

This PR bumps the so version number. Since the changes are backward-compatible, just bumping the minor version should be sufficient.

This makes sure that:

- Code that links with the newer version of libvncserver cannot run on older versions which do not have these symbols
- Code that dynamically interacts with libvncserver (such as Java or .NET wrappers) can detect the version of libvncserver in use.