### PR TITLE
libvncclient: drop StringToIPAddr in IPv6 builds

### DIFF
--- a/libvncclient/sockets.c
+++ b/libvncclient/sockets.c
@@ -805,6 +805,7 @@ SetDSCP(rfbSocket sock, int dscp)
 
 
 
+#ifndef LIBVNCSERVER_IPv6
 /*
  * StringToIPAddr - convert a host string to an IP address.
  */
@@ -833,6 +834,7 @@ StringToIPAddr(const char *str, unsigned int *addr)
 
   return FALSE;
 }
+#endif
 
 
 /*

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -724,7 +724,10 @@ extern rfbBool SetNonBlocking(rfbSocket sock);
 extern rfbBool SetBlocking(rfbSocket sock);
 extern rfbBool SetDSCP(rfbSocket sock, int dscp);
 
+#ifndef LIBVNCSERVER_IPv6
 extern rfbBool StringToIPAddr(const char *str, unsigned int *addr);
+#endif
+
 extern rfbBool SameMachine(rfbSocket sock);
 /**
  * Waits for an RFB message to arrive from the server. Before handling a message


### PR DESCRIPTION
Since StringToIPAddr is used in IPv4 code paths only and uses the
deprecated and non-thread-safe gethostbyname() function (which causes
warnings by linters such as RPMLINT) drop it in IPv6 builds. Users
relying on the function can still use IPv4 builds.