### PR TITLE
Handle memory realloc failures

### DIFF
--- a/libvncserver/corre.c
+++ b/libvncserver/corre.c
@@ -96,20 +96,34 @@ rfbSendSmallRectEncodingCoRRE(rfbClientPtr cl,
     int maxRawSize = (cl->scaledScreen->width * cl->scaledScreen->height
                       * (cl->format.bitsPerPixel / 8));
 
-    if (cl->beforeEncBufSize < maxRawSize) {
-        cl->beforeEncBufSize = maxRawSize;
+    if (!cl->beforeEncBuf || cl->beforeEncBufSize < maxRawSize) {
         if (cl->beforeEncBuf == NULL)
-            cl->beforeEncBuf = (char *)malloc(cl->beforeEncBufSize);
-        else
-            cl->beforeEncBuf = (char *)realloc(cl->beforeEncBuf, cl->beforeEncBufSize);
+            cl->beforeEncBuf = (char *)malloc(maxRawSize);
+        else {
+            char *reallocedBeforeEncBuf = (char *)realloc(cl->beforeEncBuf, maxRawSize);
+            if (!reallocedBeforeEncBuf) return FALSE;
+            cl->beforeEncBuf = reallocedBeforeEncBuf;
+        }
+        if(cl->beforeEncBuf)
+            cl->beforeEncBufSize = maxRawSize;
     }
 
-    if (cl->afterEncBufSize < maxRawSize) {
-        cl->afterEncBufSize = maxRawSize;
+    if (!cl->afterEncBuf || cl->afterEncBufSize < maxRawSize) {
         if (cl->afterEncBuf == NULL)
-            cl->afterEncBuf = (char *)malloc(cl->afterEncBufSize);
-        else
-            cl->afterEncBuf = (char *)realloc(cl->afterEncBuf, cl->afterEncBufSize);
+            cl->afterEncBuf = (char *)malloc(maxRawSize);
+        else {
+            char *reallocedAfterEncBuf = (char *)realloc(cl->afterEncBuf, maxRawSize);
+            if (!reallocedAfterEncBuf) return FALSE;
+            cl->afterEncBuf = reallocedAfterEncBuf;
+        }
+        if(cl->afterEncBuf)
+            cl->afterEncBufSize = maxRawSize;
+    }
+
+    if (!cl->beforeEncBuf || !cl->afterEncBuf)
+    {
+        rfbLog("rfbSendSmallRectEncodingCoRRE: failed to allocate memory\n");
+        return FALSE;
     }
 
     (*cl->translateFn)(cl->translateLookupTable,&(cl->screen->serverFormat),

--- a/libvncserver/rre.c
+++ b/libvncserver/rre.c
@@ -62,20 +62,34 @@ rfbSendRectEncodingRRE(rfbClientPtr cl,
     int maxRawSize = (cl->scaledScreen->width * cl->scaledScreen->height
                       * (cl->format.bitsPerPixel / 8));
 
-    if (cl->beforeEncBufSize < maxRawSize) {
-        cl->beforeEncBufSize = maxRawSize;
+    if (!cl->beforeEncBuf || cl->beforeEncBufSize < maxRawSize) {
         if (cl->beforeEncBuf == NULL)
-            cl->beforeEncBuf = (char *)malloc(cl->beforeEncBufSize);
-        else
-            cl->beforeEncBuf = (char *)realloc(cl->beforeEncBuf, cl->beforeEncBufSize);
+            cl->beforeEncBuf = (char *)malloc(maxRawSize);
+        else {
+            char *reallocedBeforeEncBuf = (char *)realloc(cl->beforeEncBuf, maxRawSize);
+            if (!reallocedBeforeEncBuf) return FALSE;
+            cl->beforeEncBuf = reallocedBeforeEncBuf;
+        }
+        if(cl->beforeEncBuf)
+            cl->beforeEncBufSize = maxRawSize;
     }
 
-    if (cl->afterEncBufSize < maxRawSize) {
-        cl->afterEncBufSize = maxRawSize;
+    if (!cl->afterEncBuf || cl->afterEncBufSize < maxRawSize) {
         if (cl->afterEncBuf == NULL)
-            cl->afterEncBuf = (char *)malloc(cl->afterEncBufSize);
-        else
-            cl->afterEncBuf = (char *)realloc(cl->afterEncBuf, cl->afterEncBufSize);
+            cl->afterEncBuf = (char *)malloc(maxRawSize);
+        else {
+            char *reallocedAfterEncBuf = (char *)realloc(cl->afterEncBuf, maxRawSize);
+            if (!reallocedAfterEncBuf) return FALSE;
+            cl->afterEncBuf = reallocedAfterEncBuf;
+        }
+        if(cl->afterEncBuf)
+            cl->afterEncBufSize = maxRawSize;
+    }
+
+    if (!cl->beforeEncBuf || !cl->afterEncBuf)
+    {
+        rfbLog("rfbSendRectEncodingRRE: failed to allocate memory\n");
+        return FALSE;
     }
 
     (*cl->translateFn)(cl->translateLookupTable,

--- a/libvncserver/tight.c
+++ b/libvncserver/tight.c
@@ -346,13 +346,20 @@ SendRectEncodingTight(rfbClientPtr cl,
 
     /* Make sure we can write at least one pixel into tightBeforeBuf. */
 
-    if (tightBeforeBufSize < 4) {
-        tightBeforeBufSize = 4;
+    if (!tightBeforeBuf || tightBeforeBufSize < 4) {
         if (tightBeforeBuf == NULL)
-            tightBeforeBuf = (char *)malloc(tightBeforeBufSize);
-        else
-            tightBeforeBuf = (char *)realloc(tightBeforeBuf,
-                                             tightBeforeBufSize);
+            tightBeforeBuf = (char *)malloc(4);
+        else {
+            char *reallocedBeforeEncBuf = (char *)realloc(tightBeforeBuf, 4);
+            if (!reallocedBeforeEncBuf) return FALSE;
+            tightBeforeBuf = reallocedBeforeEncBuf;
+        }
+        if(!tightBeforeBuf)
+        {
+            rfbLog("SendRectEncodingTight: failed to allocate memory\n");
+            return FALSE;
+        }
+        tightBeforeBufSize = 4;
     }
 
     /* Calculate maximum number of rows in one non-solid rectangle. */
@@ -627,22 +634,34 @@ SendRectSimple(rfbClientPtr cl, int x, int y, int w, int h)
     maxBeforeSize = maxRectSize * (cl->format.bitsPerPixel / 8);
     maxAfterSize = maxBeforeSize + (maxBeforeSize + 99) / 100 + 12;
 
-    if (tightBeforeBufSize < maxBeforeSize) {
-        tightBeforeBufSize = maxBeforeSize;
+    if (!tightBeforeBuf || tightBeforeBufSize < maxBeforeSize) {
         if (tightBeforeBuf == NULL)
-            tightBeforeBuf = (char *)malloc(tightBeforeBufSize);
-        else
-            tightBeforeBuf = (char *)realloc(tightBeforeBuf,
-                                             tightBeforeBufSize);
+            tightBeforeBuf = (char *)malloc(maxBeforeSize);
+        else {
+            char *reallocedBeforeEncBuf = (char *)realloc(tightBeforeBuf, maxBeforeSize);
+            if (!reallocedBeforeEncBuf) return FALSE;
+            tightBeforeBuf = reallocedBeforeEncBuf;
+        }
+        if (tightBeforeBuf)
+            tightBeforeBufSize = maxBeforeSize;
     }
 
-    if (tightAfterBufSize < maxAfterSize) {
-        tightAfterBufSize = maxAfterSize;
+    if (!tightAfterBuf || tightAfterBufSize < maxAfterSize) {
         if (tightAfterBuf == NULL)
-            tightAfterBuf = (char *)malloc(tightAfterBufSize);
-        else
-            tightAfterBuf = (char *)realloc(tightAfterBuf,
-                                            tightAfterBufSize);
+            tightAfterBuf = (char *)malloc(maxAfterSize);
+        else {
+            char *reallocedAfterEncBuf = (char *)realloc(tightAfterBuf, maxAfterSize);
+            if (!reallocedAfterEncBuf) return FALSE;
+            tightAfterBuf = reallocedAfterEncBuf;
+        }
+        if(tightAfterBuf)
+            tightAfterBufSize = maxAfterSize;
+    }
+
+    if (!tightBeforeBuf || !tightAfterBuf)
+    {
+        rfbLog("SendRectSimple: failed to allocate memory\n");
+        return FALSE;
     }
 
     if (w > maxRectWidth || w * h > maxRectSize) {
@@ -1577,15 +1596,18 @@ SendJpegRect(rfbClientPtr cl, int x, int y, int w, int h, int quality)
         }
     }
 
-    if (tightAfterBufSize < TJBUFSIZE(w, h)) {
+    if (!tightAfterBuf || tightAfterBufSize < TJBUFSIZE(w, h)) {
         if (tightAfterBuf == NULL)
             tightAfterBuf = (char *)malloc(TJBUFSIZE(w, h));
-        else
-            tightAfterBuf = (char *)realloc(tightAfterBuf,
-                                            TJBUFSIZE(w, h));
-        if (!tightAfterBuf) {
-            rfbLog("Memory allocation failure!\n");
-            return 0;
+        else {
+            char *reallocedAfterEncBuf = (char *)realloc(tightAfterBuf, TJBUFSIZE(w, h));
+            if (!reallocedAfterEncBuf) return FALSE;
+            tightAfterBuf = reallocedAfterEncBuf;
+        }
+        if (!tightAfterBuf)
+        {
+            rfbLog("SendJpegRect: failed to allocate memory\n");
+            return FALSE;
         }
         tightAfterBufSize = TJBUFSIZE(w, h);
     }

--- a/libvncserver/ultra.c
+++ b/libvncserver/ultra.c
@@ -58,12 +58,16 @@ rfbSendOneRectEncodingUltra(rfbClientPtr cl,
 
     maxRawSize = (w * h * (cl->format.bitsPerPixel / 8));
 
-    if (cl->beforeEncBufSize < maxRawSize) {
-	cl->beforeEncBufSize = maxRawSize;
-	if (cl->beforeEncBuf == NULL)
-	    cl->beforeEncBuf = (char *)malloc(cl->beforeEncBufSize);
-	else
-	    cl->beforeEncBuf = (char *)realloc(cl->beforeEncBuf, cl->beforeEncBufSize);
+    if (!cl->beforeEncBuf || cl->beforeEncBufSize < maxRawSize) {
+        if (cl->beforeEncBuf == NULL)
+            cl->beforeEncBuf = (char *)malloc(maxRawSize);
+        else {
+            char *reallocedBeforeEncBuf = (char *)realloc(cl->beforeEncBuf, maxRawSize);
+            if (!reallocedBeforeEncBuf) return FALSE;
+            cl->beforeEncBuf = reallocedBeforeEncBuf;
+        }
+        if(cl->beforeEncBuf)
+            cl->beforeEncBufSize = maxRawSize;
     }
 
     /*
@@ -72,12 +76,22 @@ rfbSendOneRectEncodingUltra(rfbClientPtr cl,
      */
     maxCompSize = (maxRawSize + maxRawSize / 16 + 64 + 3);
 
-    if (cl->afterEncBufSize < (int)maxCompSize) {
-	cl->afterEncBufSize = maxCompSize;
-	if (cl->afterEncBuf == NULL)
-	    cl->afterEncBuf = (char *)malloc(cl->afterEncBufSize);
-	else
-	    cl->afterEncBuf = (char *)realloc(cl->afterEncBuf, cl->afterEncBufSize);
+    if (!cl->afterEncBuf || cl->afterEncBufSize < (int)maxCompSize) {
+        if (cl->afterEncBuf == NULL)
+            cl->afterEncBuf = (char *)malloc(maxCompSize);
+        else {
+            char *reallocedAfterEncBuf = (char *)realloc(cl->afterEncBuf, maxCompSize);
+            if (!reallocedAfterEncBuf) return FALSE;
+            cl->afterEncBuf = reallocedAfterEncBuf;
+        }
+        if(cl->afterEncBuf)
+            cl->afterEncBufSize = maxCompSize;
+    }
+
+    if (!cl->beforeEncBuf || !cl->afterEncBuf)
+    {
+        rfbLog("rfbSendOneRectEncodingUltra: failed to allocate memory\n");
+        return FALSE;
     }
 
     /* 

--- a/libvncserver/zrleoutstream.c
+++ b/libvncserver/zrleoutstream.c
@@ -48,14 +48,17 @@ static void zrleBufferFree(zrleBuffer *buffer)
 static rfbBool zrleBufferGrow(zrleBuffer *buffer, int size)
 {
   int offset;
+  void *new_buffer;
 
   size  += buffer->end - buffer->start;
   offset = ZRLE_BUFFER_LENGTH (buffer);
 
-  buffer->start = realloc(buffer->start, size);
-  if (!buffer->start) {
+  new_buffer = realloc(buffer->start, size);
+  if (!new_buffer) {
     return FALSE;
   }
+
+  buffer->start = new_buffer;
 
   buffer->end = buffer->start + size;
   buffer->ptr = buffer->start + offset;


### PR DESCRIPTION
When realloc() fails, previous pointer values have to be retained to leaking memory.