### PR TITLE
Various minor cleanups and type cast fixes

### DIFF
--- a/common/turbojpeg.c
+++ b/common/turbojpeg.c
@@ -797,7 +797,9 @@ DLLEXPORT int DLLCALL tjDecompress2(tjhandle handle, unsigned char *jpegBuf,
 	}
 	if(scaledw>width || scaledh>height)
 		_throw("tjDecompress2(): Could not scale down to desired image dimensions");
+	#ifndef JCS_EXTENSIONS
 	width=scaledw;  height=scaledh;
+	#endif
 	dinfo->scale_num=sf[i].num;
 	dinfo->scale_denom=sf[i].denom;
 

--- a/common/turbojpeg.c
+++ b/common/turbojpeg.c
@@ -616,7 +616,7 @@ DLLEXPORT int DLLCALL tjCompress(tjhandle handle, unsigned char *srcBuf,
 	int width, int pitch, int height, int pixelSize, unsigned char *jpegBuf,
 	unsigned long *jpegSize, int jpegSubsamp, int jpegQual, int flags)
 {
-	int retval=0;  unsigned long size;
+	int retval=0;  unsigned long size = 0;
 	retval=tjCompress2(handle, srcBuf, width, pitch, height,
 		getPixelFormat(pixelSize, flags), &jpegBuf, &size, jpegSubsamp, jpegQual,
 		flags);

--- a/examples/cursors.c
+++ b/examples/cursors.c
@@ -265,7 +265,7 @@ static void SetAlphaCursor(rfbScreenInfoPtr screen,int mode)
 		}
 	if(c->cleanupMask)
 		free(c->mask);
-	c->mask=rfbMakeMaskFromAlphaSource(c->width,c->height,c->alphaSource);
+	c->mask=(unsigned char*)rfbMakeMaskFromAlphaSource(c->width,c->height,c->alphaSource);
 	c->cleanupMask=TRUE;
 }
 

--- a/libvncclient/sasl.c
+++ b/libvncclient/sasl.c
@@ -55,7 +55,7 @@ static char *vnc_connection_addr_to_string(char *host, int port)
 {
     char * buf = (char *)malloc(strlen(host) + 7);
     if (buf) {
-        sprintf(buf, "%s;%hu", host, port);
+        sprintf(buf, "%s;%hu", host, (unsigned short)port);
     }
     return buf;
 }
@@ -126,7 +126,7 @@ static int password_callback_adapt(sasl_conn_t *conn,
        return SASL_FAIL;
    }
 
-   strcpy(lsec->data, password);
+   strcpy((char *)lsec->data, password);
    lsec->len = strlen(password);
    client->saslSecret = lsec;
    *secret = lsec;

--- a/libvncclient/sasl.c
+++ b/libvncclient/sasl.c
@@ -169,7 +169,6 @@ HandleSASLAuth(rfbClient *client)
     char *mechlist;
     char *wantmech;
     const char *mechname;
-    rfbBool ret;
 
     client->saslconn = NULL;
 

--- a/libvncserver/rfbregion.c
+++ b/libvncserver/rfbregion.c
@@ -151,26 +151,22 @@ sraSpanListDup(const sraSpanList *src) {
 
 void
 sraSpanListDestroy(sraSpanList *list) {
-  sraSpan *curr, *next;
+  sraSpan *curr;
   while (list->front._next != &(list->back)) {
     curr = list->front._next;
-    next = curr->_next;
     sraSpanRemove(curr);
     sraSpanDestroy(curr);
-    curr = next;
   }
   free(list);
 }
 
 static void
 sraSpanListMakeEmpty(sraSpanList *list) {
-  sraSpan *curr, *next;
+  sraSpan *curr;
   while (list->front._next != &(list->back)) {
     curr = list->front._next;
-    next = curr->_next;
     sraSpanRemove(curr);
     sraSpanDestroy(curr);
-    curr = next;
   }
   list->front._next = &(list->back);
   list->front._prev = NULL;

--- a/libvncserver/rfbssl_gnutls.c
+++ b/libvncserver/rfbssl_gnutls.c
@@ -90,7 +90,7 @@ struct rfbssl_ctx *rfbssl_init_global(char *key, char *cert)
     struct rfbssl_ctx *ctx = NULL;
 
     if (NULL == (ctx = malloc(sizeof(struct rfbssl_ctx)))) {
-	ret = GNUTLS_E_MEMORY_ERROR;
+	return NULL;
     } else if (GNUTLS_E_SUCCESS != (ret = gnutls_global_init())) {
 	/* */
     } else if (GNUTLS_E_SUCCESS != (ret = gnutls_certificate_allocate_credentials(&ctx->x509_cred))) {

--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -121,7 +121,7 @@ rfbNewConnectionFromSock(rfbScreenInfoPtr rfbScreen, rfbSocket sock)
     }
 
     if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-		   (char *)&one, sizeof(one)) < 0) {
+		   (const char *)&one, sizeof(one)) < 0) {
       rfbLogPerror("rfbCheckFds: setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
     }
 
@@ -198,7 +198,7 @@ rfbInitSockets(rfbScreenInfoPtr rfbScreen)
 	    return;
 
 	if (setsockopt(rfbScreen->inetdSock, IPPROTO_TCP, TCP_NODELAY,
-		       (char *)&one, sizeof(one)) < 0) {
+		       (const char *)&one, sizeof(one)) < 0) {
 	    rfbLogPerror("setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
 	}
 
@@ -603,7 +603,7 @@ rfbConnect(rfbScreenInfoPtr rfbScreen,
     }
 
     if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
-		   (char *)&one, sizeof(one)) < 0) {
+		   (const char *)&one, sizeof(one)) < 0) {
 	rfbLogPerror("setsockopt failed: can't set TCP_NODELAY flag, non TCP socket?");
     }
 
@@ -922,7 +922,7 @@ rfbListenOnTCPPort(int port,
 	return RFB_INVALID_SOCKET;
     }
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
-		   (char *)&one, sizeof(one)) < 0) {
+		   (const char *)&one, sizeof(one)) < 0) {
 	rfbCloseSocket(sock);
 	return RFB_INVALID_SOCKET;
     }
@@ -973,7 +973,7 @@ rfbListenOnTCP6Port(int port,
 
 #ifdef IPV6_V6ONLY
 	/* we have separate IPv4 and IPv6 sockets since some OS's do not support dual binding */
-	if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (char *)&one, sizeof(one)) < 0) {
+	if (setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&one, sizeof(one)) < 0) {
 	  rfbLogPerror("rfbListenOnTCP6Port error in setsockopt IPV6_V6ONLY");
 	  rfbCloseSocket(sock);
 	  freeaddrinfo(servinfo);
@@ -981,7 +981,7 @@ rfbListenOnTCP6Port(int port,
 	}
 #endif
 
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&one, sizeof(one)) < 0) {
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&one, sizeof(one)) < 0) {
 	  rfbLogPerror("rfbListenOnTCP6Port: error in setsockopt SO_REUSEADDR");
 	  rfbCloseSocket(sock);
 	  freeaddrinfo(servinfo);
@@ -1104,7 +1104,7 @@ rfbListenOnUDPPort(int port,
 	return RFB_INVALID_SOCKET;
     }
     if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
-		   (char *)&one, sizeof(one)) < 0) {
+		   (const char *)&one, sizeof(one)) < 0) {
 	return RFB_INVALID_SOCKET;
     }
     if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {

--- a/libvncserver/tightvnc-filetransfer/handlefiletransferrequest.c
+++ b/libvncserver/tightvnc-filetransfer/handlefiletransferrequest.c
@@ -53,11 +53,11 @@ typedef unsigned int uid_t;
 #endif /* WIN32 */
 
 
-pthread_mutex_t fileDownloadMutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t fileDownloadMutex = PTHREAD_MUTEX_INITIALIZER;
 
-rfbBool fileTransferEnabled = TRUE;
-rfbBool fileTransferInitted = FALSE;
-char ftproot[PATH_MAX];
+static rfbBool fileTransferEnabled = TRUE;
+static rfbBool fileTransferInitted = FALSE;
+static char ftproot[PATH_MAX];
 
 
 /******************************************************************************

--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -169,9 +169,8 @@ webSocketsHandshake(rfbClientPtr cl, char *scheme)
 {
     char *buf, *response, *line;
     int n, linestart = 0, len = 0, llen, base64 = FALSE;
-    char prefix[5], trailer[17];
     char *path = NULL, *host = NULL, *origin = NULL, *protocol = NULL;
-    char *key1 = NULL, *key2 = NULL, *key3 = NULL;
+    char *key1 = NULL, *key2 = NULL;
     char *sec_ws_origin = NULL;
     char *sec_ws_key = NULL;
     char sec_ws_version = 0;
@@ -225,8 +224,6 @@ webSocketsHandshake(rfbClientPtr cl, char *scheme)
                         free(buf);
                         return FALSE;
                     }
-                    rfbLog("Got key3\n");
-                    key3 = buf+len;
                     len += 8;
                 } else {
                     buf[len] = '\0';

--- a/libvncserver/ws_decode.c
+++ b/libvncserver/ws_decode.c
@@ -258,11 +258,10 @@ hybiReadHeader(ws_ctx_t *wsctx, int *sockRet, int *nPayload)
     goto ret_header_pending;
   }
 
-  char *h = wsctx->codeBufDecode;
   int i;
   ws_dbg("Header:\n");
   for (i=0; i <10; i++) {
-    ws_dbg("0x%02X\n", (unsigned char)h[i]);
+    ws_dbg("0x%02X\n", (unsigned char)wsctx->codeBufDecode[i]);
   }
   ws_dbg("\n");
 


### PR DESCRIPTION
...the usual weekly bunch of minor fixes (issues reported by clang-analyzer and GCC with `-Wall`).

BTW: now that all GCC warnings even for `-Wall` are fixed, I propose adding `-Wall -Werror` at least to the GCC-based CI builds to raise the requirements for future contributions.