### PR TITLE
fix in rfbDisplayFinishedHookPtr type

### DIFF
--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -109,7 +109,7 @@ typedef rfbBool (*rfbSetTranslateFunctionProcPtr)(struct _rfbClientRec* cl);
 typedef rfbBool (*rfbPasswordCheckProcPtr)(struct _rfbClientRec* cl,const char* encryptedPassWord,int len);
 typedef enum rfbNewClientAction (*rfbNewClientHookPtr)(struct _rfbClientRec* cl);
 typedef void (*rfbDisplayHookPtr)(struct _rfbClientRec* cl);
-typedef void (*rfbDisplayFinishedHookPtr)(struct _rfbClientRec* cl, int result);
+typedef void (*rfbDisplayFinishedHookPtr)(struct _rfbClientRec* cl, rfbBool result);
 /** support the capability to view the caps/num/scroll states of the X server */
 typedef int  (*rfbGetKeyboardLedStateHookPtr)(struct _rfbScreenInfo* screen);
 typedef rfbBool (*rfbXvpHookPtr)(struct _rfbClientRec* cl, uint8_t, uint8_t);


### PR DESCRIPTION
According to rfbSendFramebufferUpdate() in rfbserver.c its should be rfbBool, not int.

```
      rfbBool result = TRUE;

      ...

      result = rfbSendUpdateBuf(cl);
      if(cl->screen->displayFinishedHook)
	cl->screen->displayFinishedHook(cl, result);
```