### PR TITLE
add missed screen->backgroundLoop check

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -554,7 +554,7 @@ rfbClientConnectionGone(rfbClientPtr cl)
     UNLOCK(rfbClientListMutex);
 
 #if defined(LIBVNCSERVER_HAVE_LIBPTHREAD) || defined(LIBVNCSERVER_HAVE_WIN32THREADS)
-    if(cl->screen->backgroundLoop != FALSE) {
+    if(cl->screen->backgroundLoop) {
       int i;
       do {
 	LOCK(cl->refCountMutex);
@@ -626,8 +626,10 @@ rfbClientConnectionGone(rfbClientPtr cl)
     TINI_MUTEX(cl->sendMutex);
 
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
-    close(cl->pipe_notify_client_thread[0]);
-    close(cl->pipe_notify_client_thread[1]);
+    if(cl->screen->backgroundLoop != FALSE) {
+        close(cl->pipe_notify_client_thread[0]);
+        close(cl->pipe_notify_client_thread[1]);
+    }
 #endif
 
     rfbPrintStats(cl);

--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -554,7 +554,7 @@ rfbClientConnectionGone(rfbClientPtr cl)
     UNLOCK(rfbClientListMutex);
 
 #if defined(LIBVNCSERVER_HAVE_LIBPTHREAD) || defined(LIBVNCSERVER_HAVE_WIN32THREADS)
-    if(cl->screen->backgroundLoop) {
+    if (cl->screen->backgroundLoop) {
       int i;
       do {
 	LOCK(cl->refCountMutex);
@@ -626,7 +626,7 @@ rfbClientConnectionGone(rfbClientPtr cl)
     TINI_MUTEX(cl->sendMutex);
 
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
-    if(cl->screen->backgroundLoop != FALSE) {
+    if (cl->screen->backgroundLoop) {
         close(cl->pipe_notify_client_thread[0]);
         close(cl->pipe_notify_client_thread[1]);
     }


### PR DESCRIPTION
Some minor fixes:

backgroundLoop != FALSE -- means true

missed `screen->backgroundLoop` check in case of LIBPTHREAD defined in rfbClientConnectionGone()