### PR TITLE
new feature: external socket management system flags

### DIFF
--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -350,6 +350,7 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->listen6Sock = RFB_INVALID_SOCKET;
   client->listen6Address = NULL;
   client->clientAuthSchemes = NULL;
+  client->external_socket_management = FALSE;
 
 #ifdef LIBVNCSERVER_HAVE_SASL
   client->GetSASLMechanism = NULL;
@@ -534,8 +535,10 @@ void rfbClientCleanup(rfbClient* client) {
     client->clientData = next;
   }
 
-  if (client->sock != RFB_INVALID_SOCKET)
-    rfbCloseSocket(client->sock);
+  if (!client->external_socket_management) {
+    if (client->sock != RFB_INVALID_SOCKET)
+      rfbCloseSocket(client->sock);
+  }
   if (client->listenSock != RFB_INVALID_SOCKET)
     rfbCloseSocket(client->listenSock);
   free(client->desktopName);

--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -963,6 +963,8 @@ rfbScreenInfoPtr rfbGetScreen(int* argc,char** argv,
 
    screen->permitFileTransfer = FALSE;
 
+   screen->external_socket_management = FALSE;
+
    if(!rfbProcessArguments(screen,argc,argv)) {
      free(screen);
      return NULL;

--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -566,8 +566,10 @@ rfbClientConnectionGone(rfbClientPtr cl)
     }
 #endif
 
-    if(cl->sock != RFB_INVALID_SOCKET)
-	rfbCloseSocket(cl->sock);
+    if (!cl->screen->external_socket_management) {
+      if(cl->sock != RFB_INVALID_SOCKET)
+        rfbCloseSocket(cl->sock);
+    }
 
     if (cl->scaledScreen!=NULL)
         cl->scaledScreen->scaledScreenRefCount--;

--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -302,7 +302,8 @@ void rfbShutdownSockets(rfbScreenInfoPtr rfbScreen)
     rfbScreen->socketState = RFB_SOCKET_SHUTDOWN;
 
     if(rfbScreen->inetdSock!=RFB_INVALID_SOCKET) {
-	rfbCloseSocket(rfbScreen->inetdSock);
+	if (!rfbScreen->external_socket_management)
+	  rfbCloseSocket(rfbScreen->inetdSock);
 	FD_CLR(rfbScreen->inetdSock,&rfbScreen->allFds);
 	rfbScreen->inetdSock=RFB_INVALID_SOCKET;
     }
@@ -567,9 +568,11 @@ rfbCloseClient(rfbClientPtr cl)
 	free(cl->wspath);
 #endif
 #ifndef __MINGW32__
-	shutdown(cl->sock,SHUT_RDWR);
+	if (!cl->screen->external_socket_management)
+	  shutdown(cl->sock,SHUT_RDWR);
 #endif
-	rfbCloseSocket(cl->sock);
+	if (!cl->screen->external_socket_management)
+	  rfbCloseSocket(cl->sock);
 	cl->sock = RFB_INVALID_SOCKET;
       }
     TSIGNAL(cl->updateCond);

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -360,6 +360,8 @@ typedef struct _rfbScreenInfo
 	of file descriptors LibVNCServer uses before denying new client connections.
 	It is set to 0.5 per default. */
     float fdQuota;
+    /** External sockets management system, do not shutdown or close sockets. */
+    rfbBool external_socket_management;
 
 } rfbScreenInfo, *rfbScreenInfoPtr;
 

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -251,6 +251,7 @@ typedef struct _rfbClient {
 	int serverPort; /**< if -1, then use file recorded by vncrec */
 	rfbBool listenSpecified;
 	int listenPort, flashPort;
+	rfbBool external_socket_management;
 
 	struct {
 		int x, y, w, h;


### PR DESCRIPTION
In some cases, for heavy load systems its better to have independent socket creation/close system in main application. So, don't need to close sockets in library at all.

So. i add 
client->external_socket_management 
and
screen->external_socket_management

flags to both libvncserver and libvncclient.
