### PR TITLE
test: fix includetest to use CMAKE_MAKE_PROGRAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,7 +680,7 @@ endif(LIBVNCSERVER_WITH_WEBSOCKETS)
 
 add_test(NAME cargs COMMAND test_cargstest)
 if(UNIX)
-  add_test(NAME includetest COMMAND ${TESTS_DIR}/includetest.sh ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+  add_test(NAME includetest COMMAND ${TESTS_DIR}/includetest.sh ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR} ${CMAKE_MAKE_PROGRAM})
 endif(UNIX)
 if(FOUND_LIBJPEG_TURBO)
     add_test(NAME turbojpeg COMMAND test_tjunittest)

--- a/test/includetest.sh
+++ b/test/includetest.sh
@@ -5,10 +5,11 @@
 
 # expects install prefix like /usr as an argument
 PREFIX=$1
+CMAKE_MAKE_PROGRAM=$2
 
 TMPDIR=$(mktemp -d)
 
-make install DESTDIR=$TMPDIR
+DESTDIR="$TMPDIR" $CMAKE_MAKE_PROGRAM install
 
 echo \
 "
@@ -19,6 +20,6 @@ int main()
 {
     return 0;
 }
-" > $TMPDIR/includetest.c
+" > "$TMPDIR"/includetest.c
 
-cc -I $TMPDIR/$PREFIX $TMPDIR/includetest.c
+cc -I "$TMPDIR/$PREFIX" "$TMPDIR"/includetest.c


### PR DESCRIPTION
includetest currently fais if, for example, ninja is used as a CMake
generator. Fix it by using CMAKE_MAKE_PROGRAM in the test.