### PR TITLE
libvncclient: Add qemu extended key event

### DIFF
--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -571,6 +571,17 @@ extern rfbBool SendPointerEvent(rfbClient* client,int x, int y, int buttonMask);
  */
 extern rfbBool SendKeyEvent(rfbClient* client,uint32_t key, rfbBool down);
 /**
+ * The same as SendKeyEvent, except a key code will be sent along with the
+ * symbol if the server supports extended key events.
+ * @param client The client through which to send the key event
+ * @param keysym An rfbKeySym defined in rfb/keysym.h
+ * @param keycode An XT key code
+ * @param down true if this was a key down event, false otherwise
+ * @return true if the extended key event is supported and was sent
+ * successfully, false otherwise
+ */
+extern rfbBool SendExtendedKeyEvent(rfbClient* client, uint32_t keysym, uint32_t keycode, rfbBool down);
+/**
  * Places a string on the server's clipboard. Use this function if you want to
  * be able to copy and paste between the server and your application. For
  * instance, when your application is notified that the user copied some text

--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -426,6 +426,7 @@ typedef struct {
 #define rfbXvp 250
 /* SetDesktopSize client -> server message */
 #define rfbSetDesktopSize 251
+#define rfbQemuEvent 255
 
 
 
@@ -517,6 +518,8 @@ typedef struct {
 #define rfbEncodingQualityLevel7   0xFFFFFFE7
 #define rfbEncodingQualityLevel8   0xFFFFFFE8
 #define rfbEncodingQualityLevel9   0xFFFFFFE9
+
+#define rfbEncodingQemuExtendedKeyEvent 0xFFFFFEFE /* -258 */
 
 
 /* LibVNCServer additions.   We claim 0xFFFE0000 - 0xFFFE00FF */
@@ -1390,6 +1393,17 @@ typedef struct {
 } rfbKeyEventMsg;
 
 #define sz_rfbKeyEventMsg 8
+
+
+typedef struct {
+    uint8_t type;     /* always rfbQemuEvent */
+    uint8_t subtype;  /* always 0 */
+    uint16_t down;
+    uint32_t keysym;  /* keysym is specified as an X keysym, may be 0 */
+    uint32_t keycode; /* keycode is specified as XT key code */
+} rfbQemuExtendedKeyEventMsg;
+
+#define sz_rfbQemuExtendedKeyEventMsg 12
 
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds qemu extended key events to libvncclient, which greatly simplifies key event handling and improves robustness over the standard method.

An example of the new function call, `SendExtendedKeyEvent`, being used can be found here: https://github.com/any1/wlvncc/blob/qemu-extended-key-event/src/vnc.c#L215-L226

This functionality was tested using https://github.com/any1/wayvnc/tree/qemu-kb-ext & https://github.com/any1/neatvnc/tree/qemu-kb-ext.