### PR TITLE
docs: fix simple typo, funtions -> functions

### DIFF
--- a/libvncserver/rfbssl_gnutls.c
+++ b/libvncserver/rfbssl_gnutls.c
@@ -1,5 +1,5 @@
 /*
- * rfbssl_gnutls.c - Secure socket funtions (gnutls version)
+ * rfbssl_gnutls.c - Secure socket functions (gnutls version)
  */
 
 /*

--- a/libvncserver/rfbssl_openssl.c
+++ b/libvncserver/rfbssl_openssl.c
@@ -1,5 +1,5 @@
 /*
- * rfbssl_openssl.c - Secure socket funtions (openssl version)
+ * rfbssl_openssl.c - Secure socket functions (openssl version)
  */
 
 /*


### PR DESCRIPTION
There is a small typo in libvncserver/rfbssl_gnutls.c, libvncserver/rfbssl_openssl.c.

Should read `functions` rather than `funtions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md