### PR TITLE
libvncserver: fix string truncation warning

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -1347,7 +1347,7 @@ rfbBool rfbFilenameTranslate2DOS(rfbClientPtr cl, char *unixPath, char *path)
 
 rfbBool rfbSendDirContent(rfbClientPtr cl, int length, char *buffer)
 {
-    char retfilename[MAX_PATH];
+    char retfilename[MAX_PATH*2];
     char path[MAX_PATH];
     struct stat statbuf;
     RFB_FIND_DATA win32filename;


### PR DESCRIPTION
Calling snprintf with two arguments already containing up to MAX_PATH
bytes causes some GCC versions to complain about potential string
truncation:

libvncserver/rfbserver.c: In function 'rfbSendDirContent':

libvncserver/rfbserver.c:1396:50: error: '%s' directive output may be truncated writing up to 255 bytes into a region of size between 0 and 259 [-Werror=format-truncation=]

     snprintf(retfilename,sizeof(retfilename),"%s/%s", path, direntp->d_name);

                                                  ^~

libvncserver/rfbserver.c:1396:5: note: 'snprintf' output between 2 and 516 bytes into a destination of size 260

     snprintf(retfilename,sizeof(retfilename),"%s/%s", path, direntp->d_name);

     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

This can be fixed easily by doubling the size of retfilename.