### PR TITLE
libvncserver: pass unsigned char pointers to zlib

### DIFF
--- a/libvncserver/rfbserver.c
+++ b/libvncserver/rfbserver.c
@@ -2084,7 +2084,7 @@ rfbSendExtendedServerCutTextData(rfbClientPtr cl, const char *data, int len) {
         rfbCloseClient(cl);
         return FALSE;
     }
-    if (compress(bufAfterZlib + 12, &size, bufBeforeZlib, len + 4) != Z_OK) {
+    if (compress((unsigned char *)bufAfterZlib + 12, &size, (unsigned char *)bufBeforeZlib, len + 4) != Z_OK) {
         rfbLogPerror("rfbSendExtendedClipboardCapability: zlib deflation error");
         free(bufBeforeZlib);
         free(bufAfterZlib);
@@ -2165,7 +2165,7 @@ rfbProcessExtendedServerCutTextData(rfbClientPtr cl, uint32_t flags, const char 
             return FALSE;
         }
         stream.avail_out = size;
-        stream.next_out = buf;
+        stream.next_out = (unsigned char *)buf;
         if (inflate(&stream, Z_NO_FLUSH) != Z_OK) {
             rfbLogPerror("rfbProcessExtendedServerCutTextData: zlib inflation error");
             free(buf);


### PR DESCRIPTION
Fixes compiler warnings/errors:

```
libvncserver/rfbserver.c: In function 'rfbSendExtendedServerCutTextData':
libvncserver/rfbserver.c:2087:31: error: pointer targets in passing argument 1 of 'compress' differ in signedness [-Werror=pointer-sign]
     if (compress(bufAfterZlib + 12, &size, bufBeforeZlib, len + 4) != Z_OK) {
                  ~~~~~~~~~~~~~^~~~
In file included from rfb/rfbproto.h:73,
                 from rfb/rfb.h:44,
                 from libvncserver/rfbserver.c:37:
/usr/include/zlib.h:1228:21: note: expected 'Bytef *' {aka 'unsigned char *'} but argument is of type 'char *'
 ZEXTERN int ZEXPORT compress OF((Bytef *dest,   uLongf *destLen,
                     ^~~~~~~~
libvncserver/rfbserver.c:2087:44: error: pointer targets in passing argument 3 of 'compress' differ in signedness [-Werror=pointer-sign]
     if (compress(bufAfterZlib + 12, &size, bufBeforeZlib, len + 4) != Z_OK) {
                                            ^~~~~~~~~~~~~
In file included from rfb/rfbproto.h:73,
                 from rfb/rfb.h:44,
                 from libvncserver/rfbserver.c:37:
/usr/include/zlib.h:1228:21: note: expected 'const Bytef *' {aka 'const unsigned char *'} but argument is of type 'char *'
 ZEXTERN int ZEXPORT compress OF((Bytef *dest,   uLongf *destLen,
                     ^~~~~~~~
libvncserver/rfbserver.c: In function 'rfbProcessExtendedServerCutTextData':
libvncserver/rfbserver.c:2168:25: error: pointer targets in assignment from 'char *' to 'Bytef *' {aka 'unsigned char *'} differ in signedness [-Werror=pointer-sign] 
         stream.next_out = buf;
                         ^
```
