### PR TITLE
libvncclient: implement UltraVNC's MSLogonII authentication scheme

### DIFF
--- a/rfb/rfbproto.h
+++ b/rfb/rfbproto.h
@@ -294,6 +294,8 @@ typedef char rfbProtocolVersionMsg[13];	/* allow extra byte for null */
 #define rfbVeNCrypt 19
 #define rfbSASL 20
 #define rfbARD 30
+#define rfbUltraMSLogonI 0x70	/* UNIMPLEMENTED */
+#define rfbUltraMSLogonII 0x71
 #define rfbMSLogon 0xfffffffa
 
 #define rfbVeNCryptPlain 256


### PR DESCRIPTION
UltraVNC's MSLogonII protocol is relatively simple; the server sends along
DH parameters, we generate a shared secret, and we encrypt both the username
and password with it. The pubkey, username, and password then get written
back to the server.

Fixes #372