### PR TITLE
libvncserver: handle EINTR

### DIFF
--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -560,10 +560,14 @@ clientInput(void *data)
 	tv.tv_sec = 60; /* 1 minute */
 	tv.tv_usec = 0;
 
+retry:
 	n = select(nfds + 1, &rfds, &wfds, &efds, &tv);
 
 	if (n < 0) {
 	    rfbLogPerror("ReadExact: select");
+        if (errno == EINTR) {
+            goto retry;
+        }
 	    break;
 	}
 	if (n == 0) /* timeout */


### PR DESCRIPTION
Hi,

I'm using libvncserver in a program that uses many signals, I have no control over that.
I noticed that this select sometimes gets an EINTR.

The proposed fix is not pretty because it uses a goto but it's also simple & readable.
Please tell me if you'd prefer a `do {} while` loop. The disadvantage is that the `break` after would have to changed.

Thanks for this awesome lib
Pierre

PS: I suspect other syscalls could have issues too