### PR TITLE
clang-warning-fix

### DIFF
--- a/libvncserver/main.c
+++ b/libvncserver/main.c
@@ -145,7 +145,7 @@ rfbUnregisterProtocolExtension(rfbProtocolExtension* extension)
 	rfbUnregisterProtocolExtension(extension->next);
 }
 
-rfbProtocolExtension* rfbGetExtensionIterator()
+rfbProtocolExtension* rfbGetExtensionIterator(void)
 {
 	if (! extMutex_initialized) {
 		INIT_MUTEX(extMutex);
@@ -156,7 +156,7 @@ rfbProtocolExtension* rfbGetExtensionIterator()
 	return rfbExtensionHead;
 }
 
-void rfbReleaseExtensionIterator()
+void rfbReleaseExtensionIterator(void)
 {
 	UNLOCK(extMutex);
 }

--- a/libvncserver/tightvnc-filetransfer/rfbtightserver.c
+++ b/libvncserver/tightvnc-filetransfer/rfbtightserver.c
@@ -536,13 +536,13 @@ static rfbSecurityHandler tightVncSecurityHandler = {
 	NULL
 };
 
-void rfbRegisterTightVNCFileTransferExtension() {
+void rfbRegisterTightVNCFileTransferExtension(void) {
 	rfbRegisterProtocolExtension(&tightVncFileTransferExtension);
 	rfbRegisterSecurityHandler(&tightVncSecurityHandler);
 }
 
 void 
-rfbUnregisterTightVNCFileTransferExtension() {
+rfbUnregisterTightVNCFileTransferExtension(void) {
 	rfbUnregisterProtocolExtension(&tightVncFileTransferExtension);
 	rfbUnregisterSecurityHandler(&tightVncSecurityHandler);
 }

--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -1026,8 +1026,8 @@ void rfbDoNothingWithClient(rfbClientPtr cl);
 enum rfbNewClientAction defaultNewClientHook(rfbClientPtr cl);
 void rfbRegisterProtocolExtension(rfbProtocolExtension* extension);
 void rfbUnregisterProtocolExtension(rfbProtocolExtension* extension);
-struct _rfbProtocolExtension* rfbGetExtensionIterator();
-void rfbReleaseExtensionIterator();
+struct _rfbProtocolExtension* rfbGetExtensionIterator(void);
+void rfbReleaseExtensionIterator(void);
 rfbBool rfbEnableExtension(rfbClientPtr cl, rfbProtocolExtension* extension,
 	void* data);
 rfbBool rfbDisableExtension(rfbClientPtr cl, rfbProtocolExtension* extension);
@@ -1069,12 +1069,12 @@ extern rfbBool rfbIsActive(rfbScreenInfoPtr screenInfo);
  * Register the TightVNC-1.3.x file transfer extension.
  * NB That TightVNC-2.x uses a different, incompatible file transfer protocol.
  */
-void rfbRegisterTightVNCFileTransferExtension();
+void rfbRegisterTightVNCFileTransferExtension(void);
 /**
  * Unregister the TightVNC-1.3.x file transfer extension.
  * NB That TightVNC-2.x uses a different, incompatible file transfer protocol.
  */
-void rfbUnregisterTightVNCFileTransferExtension();
+void rfbUnregisterTightVNCFileTransferExtension(void);
 
 /* Statistics */
 extern char *messageNameServer2Client(uint32_t type, char *buf, int len);

--- a/rfb/rfbregion.h
+++ b/rfb/rfbregion.h
@@ -19,7 +19,7 @@ typedef struct sraRegion sraRegion;
 
 /* -=- Region manipulation functions */
 
-extern sraRegion *sraRgnCreate();
+extern sraRegion *sraRgnCreate(void);
 extern sraRegion *sraRgnCreateRect(int x1, int y1, int x2, int y2);
 extern sraRegion *sraRgnCreateRgn(const sraRegion *src);
 


### PR DESCRIPTION
Add 'void' for few functions, as clang is not happy about fnc() instead of fnc(void). Small thing, but annoying. 