### PR TITLE
websockets: fix buffer overflow in webSocketsEncodeHybi()

### DIFF
--- a/libvncserver/sockets.c
+++ b/libvncserver/sockets.c
@@ -811,6 +811,19 @@ rfbWriteExact(rfbClientPtr cl,
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
     if (cl->wsctx) {
         char *tmp = NULL;
+
+        while (len > UPDATE_BUF_SIZE) {
+            /* webSocketsEncode() can only handle data lengths up to UPDATE_BUF_SIZE
+               so split large writes into multiple smaller writes/frames */
+
+            if (rfbWriteExact(cl, buf, UPDATE_BUF_SIZE) == -1) {
+                return -1;
+            }
+
+            buf += UPDATE_BUF_SIZE;
+            len -= UPDATE_BUF_SIZE;
+        }
+
         if ((len = webSocketsEncode(cl, buf, len, &tmp)) < 0) {
             rfbErr("WriteExact: WebSockets encode error\n");
             return -1;

--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -375,6 +375,10 @@ webSocketsEncodeHybi(rfbClientPtr cl, const char *src, int len, char **dst)
 	  /* nothing to encode */
 	  return 0;
     }
+    if (len > UPDATE_BUF_SIZE) {
+      rfbErr("%s: Data length %d larger than maximum of %d bytes\n", __func__, len, UPDATE_BUF_SIZE);
+      return -1;
+    }
 
     header = (ws_header_t *)wsctx->codeBufEncode;
 


### PR DESCRIPTION
The websocket code has internal buffers that expect data
not to be larger than UPDATE_BUF_SIZE

- Modify rfbWriteExact() to split larger writes in multiple
  frames.
- Let webSocketsEncodeHybi() return -1 if somebody else
  tries to pass a too large buffer to it.
  (While in the libvncserver code rfbWriteExact() is the only
  function that calls websocketEncode(), it is exposed by rfb.h,
  so could theoretically also be called from application code)

Closes #484
