### PR TITLE
libvncserver/ws_decode: include endian.h in ws_decode.h

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -34,12 +34,6 @@
 /* errno */
 #include <errno.h>
 
-#ifdef LIBVNCSERVER_HAVE_ENDIAN_H
-#include <endian.h>
-#elif LIBVNCSERVER_HAVE_SYS_ENDIAN_H
-#include <sys/endian.h>
-#endif
-
 #ifdef LIBVNCSERVER_HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/libvncserver/ws_decode.h
+++ b/libvncserver/ws_decode.h
@@ -15,6 +15,12 @@
 
 #else
 
+#ifdef LIBVNCSERVER_HAVE_ENDIAN_H
+#include <endian.h>
+#elif LIBVNCSERVER_HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#endif
+
 #define WS_NTOH64(n) htobe64(n)
 #define WS_NTOH32(n) htobe32(n)
 #define WS_NTOH16(n) htobe16(n)


### PR DESCRIPTION
When htobe64 is a macro (FreeBSD) not having sys/endian.h in ws_decode.h results in a linker error.

I believe the same block can be removed from websockets.c since it includes ws_decode.h
