### PR TITLE
Prevent crash on incomplete WebSocket handshake

### DIFF
--- a/libvncserver/websockets.c
+++ b/libvncserver/websockets.c
@@ -275,6 +275,13 @@ webSocketsHandshake(rfbClientPtr cl, char *scheme)
         return FALSE;
     } 
 
+    if (!sec_ws_key) {
+        rfbErr("webSocketsHandshake: sec-websocket-key is missing\n");
+        free(response);
+        free(buf);
+        return FALSE;
+    }
+
     if (!(path && host && (origin || sec_ws_origin))) {
         rfbErr("webSocketsHandshake: incomplete client handshake\n");
         free(response);


### PR DESCRIPTION
In our libvcnserver-based application we once met a crash likely caused by a client issue - it has somehow sent and invalid handshake without a key. However, it's not a good idea for the server to crash in this key, we should return an error on such occasion and keep running.
