### PR TITLE
Dynamic resolution - support for SetDesktopSize in client

### DIFF
--- a/client_examples/SDLvncviewer.c
+++ b/client_examples/SDLvncviewer.c
@@ -299,6 +299,9 @@ static rfbBool handleSDLEvent(rfbClient *cl, SDL_Event *e)
 		SendFramebufferUpdateRequest(cl, 0, 0,
 					cl->width, cl->height, FALSE);
 		break;
+	    case SDL_WINDOWEVENT_RESIZED:
+	        SendExtDesktopSize(cl, e->window.data1, e->window.data2);
+	        break;
 	    case SDL_WINDOWEVENT_FOCUS_GAINED:
                 if (SDL_HasClipboardText()) {
 		        char *text = SDL_GetClipboardText();

--- a/libvncclient/vncviewer.c
+++ b/libvncclient/vncviewer.c
@@ -359,6 +359,10 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->saslSecret = NULL;
 #endif /* LIBVNCSERVER_HAVE_SASL */
 
+  client->requestedResize = FALSE;
+  client->screen.width = 0;
+  client->screen.height = 0;
+
   return client;
 }
 

--- a/rfb/rfbclient.h
+++ b/rfb/rfbclient.h
@@ -471,6 +471,9 @@ typedef struct _rfbClient {
 	 * For internal use only.
 	 */
 	MUTEX(tlsRwMutex);
+
+	rfbBool requestedResize;
+	rfbExtDesktopScreen screen;
 } rfbClient;
 
 /* cursor.c */
@@ -560,6 +563,14 @@ extern rfbBool SendScaleSetting(rfbClient* client,int scaleSetting);
  * @return true if the pointer event was sent successfully, false otherwise
  */
 extern rfbBool SendPointerEvent(rfbClient* client,int x, int y, int buttonMask);
+/**
+ * Sends a SetDesktopSize event to the server.
+ * @param client The client through which to send the SetDesktopSize event
+ * @param width The width of the update request rectangle
+ * @param height The height of the update request rectangle
+ * @return true if the SetDesktopSize event was send successfully, false otherwise
+ */
+extern rfbBool SendExtDesktopSize(rfbClient* client, uint16_t width, uint16_t height);
 /**
  * Sends a key event to the server. If your application is not merely a VNC
  * viewer (i.e. it controls the server), you'll want to send the keys that the


### PR DESCRIPTION
This PR adds support for the client to request the server to change resolution and replace original https://github.com/LibVNC/libvncserver/pull/452 due inactivity of the author since Nov 2020.

Should resolve issue: https://github.com/LibVNC/libvncserver/issues/341

Tested with a future version of Remmina:

Initial size:

![image](https://user-images.githubusercontent.com/102903237/163219684-eade05bd-c6c9-4653-8a70-abc38d180df2.png)

Resized only on X-axis:

![image](https://user-images.githubusercontent.com/102903237/163219823-32ae8559-7557-4169-a3db-148ce93a0966.png)

Resized only on Y-axis:

![image](https://user-images.githubusercontent.com/102903237/163219883-f0936388-37de-4305-a9d2-2422b2cb1347.png)

Resized on both axis:

![image](https://user-images.githubusercontent.com/102903237/163219947-44a4c284-9486-4e5d-9f1e-be8458ff0d6d.png)

As you can see from images and from the output of xrandr command, it works!

Regards,
Marco