### PR TITLE
libvncserver: fix pixel format equality for different values of trueColour

### DIFF
--- a/libvncserver/translate.c
+++ b/libvncserver/translate.c
@@ -48,7 +48,7 @@ static const rfbPixelFormat BGR233Format = {
         ((x.bitsPerPixel == y.bitsPerPixel) &&                          \
          (x.depth == y.depth) &&                                        \
          ((x.bigEndian == y.bigEndian) || (x.bitsPerPixel == 8)) &&     \
-         (x.trueColour == y.trueColour) &&                              \
+         (!x.trueColour == !y.trueColour) &&                            \
          (!x.trueColour || ((x.redMax == y.redMax) &&                   \
                             (x.greenMax == y.greenMax) &&               \
                             (x.blueMax == y.blueMax) &&                 \


### PR DESCRIPTION
Compare boolean truthiness only. The spec implies that only zero vs
non-zero matters.

This allows using no-conversion with e.g. jump desktop client. 

https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#setpixelformat