### PR TITLE
Explicitely including avcodec.h

### DIFF
--- a/client_examples/vnc2mpg.c
+++ b/client_examples/vnc2mpg.c
@@ -29,6 +29,7 @@
 #include <math.h>
 #include <signal.h>
 #include <sys/time.h>
+#include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
 #include <rfb/rfbclient.h>


### PR DESCRIPTION
Build fails with the master branch of FFmpeg with these kinds of errors:

```
../client_examples/vnc2mpg.c:55:5: error: unknown type name ‘AVCodecContext’
     AVCodecContext *enc;
     ^~~~~~~~~~~~~~
``` 

This patch adds `libavcodec/avcodec.h` in vnc2mpg.c