### PR TITLE
libvncclient: allow non-encrypted sub auth methods inside VeNCrypt

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -314,10 +314,9 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
 {
     uint8_t count=0;
     uint8_t loop=0;
-    uint8_t flag=0;
     uint32_t tAuth[256], t;
     char buf1[500],buf2[10];
-    uint32_t authScheme;
+    uint32_t origAuthScheme, authScheme;
 
     if (!ReadFromRFBServer(client, (char *)&count, 1)) return FALSE;
 
@@ -335,8 +334,10 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
         if (!ReadFromRFBServer(client, (char *)&tAuth[loop], 4)) return FALSE;
         t=rfbClientSwap32IfLE(tAuth[loop]);
         rfbClientLog("%d) Received security type %d\n", loop, t);
-        if (flag) continue;
-        if (t==rfbVeNCryptTLSNone ||
+        if (t==rfbNoAuth ||
+            t==rfbVncAuth ||
+            t==rfbVeNCryptPlain ||
+            t==rfbVeNCryptTLSNone ||
             t==rfbVeNCryptTLSVNC ||
             t==rfbVeNCryptTLSPlain ||
 #ifdef LIBVNCSERVER_HAVE_SASL
@@ -347,11 +348,16 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
             t==rfbVeNCryptX509VNC ||
             t==rfbVeNCryptX509Plain)
         {
-            flag++;
-            authScheme=t;
-            rfbClientLog("Selecting security type %d (%d/%d in the list)\n", authScheme, loop, count);
-            /* send back 4 bytes (in original byte order!) indicating which security type to use */
-            if (!WriteToRFBServer(client, (char *)&tAuth[loop], 4)) return FALSE;
+            if (
+                authScheme==0 ||
+                authScheme==rfbNoAuth ||
+                authScheme==rfbVncAuth ||
+                authScheme==rfbVeNCryptPlain)
+            {
+                /* for security reasons, the encrypted type has a higher priority */
+                origAuthScheme=tAuth[loop];
+                authScheme=t;
+            }
         }
         tAuth[loop]=t;
     }
@@ -367,6 +373,12 @@ ReadVeNCryptSecurityType(rfbClient* client, uint32_t *result)
         rfbClientLog("Unknown VeNCrypt authentication scheme from VNC server: %s\n",
                buf1);
         return FALSE;
+    }
+    else
+    {
+        rfbClientLog("Selecting security type %d\n", authScheme);
+        /* send back 4 bytes (in original byte order!) indicating which security type to use */
+        if (!WriteToRFBServer(client, (char *)&origAuthScheme, 4)) return FALSE;
     }
     *result = authScheme;
     return TRUE;
@@ -459,8 +471,6 @@ HandleVeNCryptAuth(rfbClient* client)
   gnutls_certificate_credentials_t x509_cred = NULL;
   int ret;
 
-  if (!InitializeTLS()) return FALSE;
-
   /* Read VeNCrypt version */
   if (!ReadFromRFBServer(client, (char *)&major, 1) ||
       !ReadFromRFBServer(client, (char *)&minor, 1))
@@ -489,16 +499,18 @@ HandleVeNCryptAuth(rfbClient* client)
   }
 
   if (!ReadVeNCryptSecurityType(client, &authScheme)) return FALSE;
-  if (!ReadFromRFBServer(client, (char *)&status, 1) || status != 1)
-  {
-    rfbClientLog("Server refused VeNCrypt authentication %d (%d).\n", authScheme, (int)status);
-    return FALSE;
-  }
   client->subAuthScheme = authScheme;
 
-  /* Some VeNCrypt security types are anonymous TLS, others are X509 */
   switch (authScheme)
   {
+    /* Unencrypted types do not require additional actions */
+    case rfbNoAuth:
+    case rfbVncAuth:
+    case rfbVeNCryptPlain:
+      return TRUE;
+      break;
+
+    /* Some VeNCrypt security types are anonymous TLS, others are X509 */
     case rfbVeNCryptTLSNone:
     case rfbVeNCryptTLSVNC:
     case rfbVeNCryptTLSPlain:
@@ -507,10 +519,20 @@ HandleVeNCryptAuth(rfbClient* client)
 #endif /* LIBVNCSERVER_HAVE_SASL */
       anonTLS = TRUE;
       break;
+
     default:
       anonTLS = FALSE;
       break;
   }
+
+  /* Ack is only requred for the encrypted connection */
+  if (!ReadFromRFBServer(client, (char *)&status, 1) || status != 1)
+  {
+    rfbClientLog("Server refused VeNCrypt authentication %d (%d).\n", authScheme, (int)status);
+    return FALSE;
+  }
+
+  if (!InitializeTLS()) return FALSE;
 
   /* Get X509 Credentials if it's not anonymous */
   if (!anonTLS)


### PR DESCRIPTION
Following https://github.com/LibVNC/libvncserver/issues/458

`rfbNoAuth` and `rfbVncAuth` are not actually part of VeNCrypt, however it is important to support them to ensure better compatibility. When establishing a connection, the client does not know whether the server supports encryption, and always prefers VeNCrypt if enabled. Next, if encryption is not available on the server, the connection will fail. Since the RFB doesn't have any downgrade methods in case of failure, a client that does not support unencrypted VeNCrypt methods will never be able to connect.

`rfbVeNCryptPlain` is also supported for better compatibility.

The [RFB specification also considers any ordinary subauths valid](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#vencrypt), which legitimizes this solution:

> any of the normal VNC security types (except VeNCrypt) may be sent

For security and backward compatibility reasons, encrypted connections take precedence over unencrypted ones