### PR TITLE
libvncclient: rfbAnonTLSPriority = "NORMAL:+ANON-ECDH:+ANON-DH"

### DIFF
--- a/libvncclient/tls_gnutls.c
+++ b/libvncclient/tls_gnutls.c
@@ -30,7 +30,7 @@
 
 
 static const char *rfbTLSPriority = "NORMAL:+DHE-DSS:+RSA:+DHE-RSA:+SRP";
-static const char *rfbAnonTLSPriority= "NORMAL:+ANON-DH";
+static const char *rfbAnonTLSPriority = "NORMAL:+ANON-ECDH:+ANON-DH";
 
 #define DH_BITS 1024
 static gnutls_dh_params_t rfbDHParams;


### PR DESCRIPTION
I.e. added ANON-ECDH just for better compatibility. Taken from TigerVNC: https://github.com/TigerVNC/tigervnc/blob/a97e9b11/common/rfb/CSecurityTLS.cxx#L210