### PR TITLE
libvncclient: using gnutls_handshake_set_timeout()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ endif(WITH_THREADS)
 
 
 if(WITH_GNUTLS)
-  find_package(GnuTLS)
+  find_package(GnuTLS 3.4.0)
 endif(WITH_GNUTLS)
 
 


### PR DESCRIPTION
Following #525

Removed sleep, using `gnutls_handshake_set_timeout()` and `gnutls_system_recv_timeout()`. It's working since GNUTLS 3.4.0 (released 2015-04-08).

Found a solution here: https://github.com/gnutls/gnutls/blob/857543cc24114431dd5dde0e83c2c44b9b7e6050/lib/system/fastopen.c#L167

Also a loop without sleep seems to be the regular way to use GNUTLS according to github.