### PR TITLE
Make sure cursorMutex is properly locked before we try to access cursor member

### DIFF
--- a/libvncserver/cursor.c
+++ b/libvncserver/cursor.c
@@ -503,10 +503,11 @@ void rfbMakeRichCursorFromXCursor(rfbScreenInfoPtr rfbScreen,rfbCursorPtr cursor
 void rfbHideCursor(rfbClientPtr cl)
 {
    rfbScreenInfoPtr s=cl->screen;
-   rfbCursorPtr c=s->cursor;
+   rfbCursorPtr c;
    int j,x1,x2,y1,y2,bpp=s->serverFormat.bitsPerPixel/8,
      rowstride=s->paddedWidthInBytes;
    LOCK(s->cursorMutex);
+   c=s->cursor;
    if(!c) {
      UNLOCK(s->cursorMutex);
      return;
@@ -545,14 +546,18 @@ void rfbHideCursor(rfbClientPtr cl)
 void rfbShowCursor(rfbClientPtr cl)
 {
    rfbScreenInfoPtr s=cl->screen;
-   rfbCursorPtr c=s->cursor;
+   rfbCursorPtr c;
    int i,j,x1,x2,y1,y2,i1,j1,bpp=s->serverFormat.bitsPerPixel/8,
      rowstride=s->paddedWidthInBytes,
      bufSize,w;
    rfbBool wasChanged=FALSE;
 
-   if(!c) return;
    LOCK(s->cursorMutex);
+   c=s->cursor;
+   if(!c) {
+	UNLOCK(s->cursorMutex);
+	return;
+   }
 
    bufSize=c->width*c->height*bpp;
    w=(c->width+7)/8;


### PR DESCRIPTION
This fixes random crashes in the cursor updating routines with VirtualBox 6.1.x running Ubuntu 22.04 guest when remote cursor is enabled (TightVNC client). 

The crash is as follows:

```
11/08/2022 11:58:59 Client Protocol Version 3.8
11/08/2022 11:58:59 Protocol version sent 3.8, using 3.8
11/08/2022 11:58:59 rfbProcessClientSecurityType: executing handler for type 2
11/08/2022 11:59:01 Enabling NewFBSize protocol extension for client 192.168.23.190
11/08/2022 11:59:01 Enabling LastRect protocol extension for client 192.168.23.190
11/08/2022 11:59:01 Enabling cursor position updates for client 192.168.23.190
11/08/2022 11:59:01 Enabling full-color cursor updates for client 192.168.23.190
11/08/2022 11:59:01 Using compression level 1 for client 192.168.23.190
11/08/2022 11:59:01 Using tight encoding for client 192.168.23.190
11/08/2022 11:59:01 Pixel format for client 192.168.23.190:
11/08/2022 11:59:01   32 bpp, depth 24, little endian
11/08/2022 11:59:01   true colour: max r 255 g 255 b 255, shift r 16 g 8 b 0
11/08/2022 11:59:04 Sending rfbEncodingNewFBSize for resize to (800x600)
11/08/2022 11:59:04 Sending rfbEncodingNewFBSize for resize to (1920x1080)

Thread 34 received signal SIGSEGV, Segmentation fault.
Address not mapped to object.
[Switching to LWP 105544 of process 39230]
0x0000000803325fb4 in rfbSendCursorShape (cl=0x803c2eb00) at /var/tmp/usr/ports/net/libvncserver/work/libvncserver-LibVNCServer-0.9.13/libvncserver/cursor.c:161
161                 bitmapByte = bitmapData[i * bitmapRowBytes + j];
(gdb) print i
$1 = 0
(gdb) print bitmapRowBytes
$2 = 4
(gdb) print j
$3 = 0
(gdb) print bitmapData
$4 = (uint8_t *) 0x0
(gdb) print pCursor
$5 = (rfbCursorPtr) 0x85ba37a30
(gdb) print *pCursor
$6 = {cleanup = 0 '\000', cleanupSource = 0 '\000', cleanupMask = 0 '\000', cleanupRichSource = 0 '\000', source = 0x0, mask = 0x0, width = 32, height = 32, xhot = 3, yhot = 3, foreRed = 0, foreGreen = 0,
  foreBlue = 0, backRed = 0, backGreen = 0, backBlue = 0, richSource = 0x0, alphaSource = 0x0, alphaPreMultiplied = 0 '\000'}


