### PR TITLE
rfb.h cleanup + fix OOB memory accesses in tight encoder

### DIFF
--- a/rfb/rfb.h
+++ b/rfb/rfb.h
@@ -905,8 +905,6 @@ extern rfbBool rfbSendRectEncodingZlib(rfbClientPtr cl, int x, int y, int w,
 #define TIGHT_DEFAULT_COMPRESSION  6
 #define TURBO_DEFAULT_SUBSAMP 0
 
-extern rfbBool rfbTightDisableGradient;
-
 extern int rfbNumCodedRectsTight(rfbClientPtr cl, int x,int y,int w,int h);
 
 extern rfbBool rfbSendRectEncodingTight(rfbClientPtr cl, int x,int y,int w,int h);


### PR DESCRIPTION
 As of 7124b5fbcf0df8db4d3f73023d77af6ea56409e7 the maximum rect width and size are equal for every compression level so we can easily save the LUT entries by using constants instead.
    
This fixes OOB memory accesses in `rfbNumCodedRectsTight()` when being called by `rfbSendFramebufferUpdate()` before `SendRectEncodingTight()` is being called the first time (which limits `cl->tightCompressLevel` to the size of `tightConf`).
