### PR TITLE
CI: Setup ABI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: false
     strategy:
       matrix:
         os:
@@ -51,6 +52,7 @@ jobs:
           cd build
           ctest -C Debug --output-on-failure
   fuzzing_build:
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -68,3 +70,35 @@ jobs:
           cd build
           cmake ..
           cmake --build .
+  abi_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install liblzo2-dev libssl-dev gnutls-dev libgcrypt-dev abi-dumper abi-compliance-checker universal-ctags
+      - name: Build libraries
+        env:
+          CFLAGS: "-gdwarf-4 -Og"      
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --target vncclient
+          cmake --build . --target vncserver
+      - name: Check ABI
+        run: |
+          mkdir abi-check
+          cd abi-check
+          abi-dumper -lver $GITHUB_REF_NAME ../build/libvncclient.so -o client-abi-new.dump -public-headers ../rfb
+          abi-dumper -lver $GITHUB_REF_NAME ../build/libvncserver.so -o server-abi-new.dump -public-headers ../rfb
+          abi-compliance-checker -l LibVNCClient  -old ../utils/abi/client-abi-v1.dump -new client-abi-new.dump -report-path client-report.html 
+          abi-compliance-checker -l LibVNCServer  -old ../utils/abi/server-abi-v1.dump -new server-abi-new.dump -report-path server-report.html 
+      
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: abi-check-result
+          path: abi-check
+            

--- a/utils/abi/client-abi-v1.dump
+++ b/utils/abi/client-abi-v1.dump
@@ -1,0 +1,5902 @@
+$VAR1 = {
+          'ABI_DUMPER_VERSION' => '1.2',
+          'ABI_DUMP_VERSION' => '3.5',
+          'Arch' => 'x86_64',
+          'GccVersion' => '11.3.0',
+          'Headers' => {
+                         'rfbclient.h' => 1,
+                         'rfbproto.h' => 1
+                       },
+          'Language' => 'C',
+          'LibraryName' => 'libvncclient.so.0.9.14',
+          'LibraryVersion' => 'v1',
+          'NameSpaces' => {},
+          'Needed' => {
+                        'libc.so.6' => 1,
+                        'libgcrypt.so.20' => 1,
+                        'libgnutls.so.30' => 1,
+                        'libjpeg.so.8' => 1,
+                        'liblzo2.so.2' => 1,
+                        'libz.so.1' => 1
+                      },
+          'PublicABI' => '1',
+          'Sources' => {
+                         'cursor.c' => 1,
+                         'listen.c' => 1,
+                         'rfbproto.c' => 1,
+                         'sockets.c' => 1,
+                         'vncviewer.c' => 1
+                       },
+          'SymbolInfo' => {
+                            '100680' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'client',
+                                                                'type' => '4962'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'usecs',
+                                                                'type' => '64'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'WaitForMessage',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '848'
+                                        },
+                            '101657' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'str',
+                                                                'type' => '1039'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'addr',
+                                                                'type' => '101940'
+                                                              }
+                                                     },
+                                          'Return' => '1453',
+                                          'ShortName' => 'StringToIPAddr',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '760'
+                                        },
+                            '102322' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'sock',
+                                                                'type' => '137'
+                                                              }
+                                                     },
+                                          'Return' => '1453',
+                                          'ShortName' => 'SetBlocking',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '701'
+                                        },
+                            '103793' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'port',
+                                                                'type' => '137'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'ListenAtTcpPort',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '547'
+                                        },
+                            '103876' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Return' => '137',
+                                          'ShortName' => 'FindFreeTcpPort',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '514'
+                                        },
+                            '104718' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'sockFile',
+                                                                'type' => '1039'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'ConnectClientToUnixSock',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '460'
+                                        },
+                            '105701' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'hostname',
+                                                                'type' => '1039'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'port',
+                                                                'type' => '137'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'ConnectClientToTcpAddr6',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '378'
+                                        },
+                            '105858' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'host',
+                                                                'type' => '64'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'port',
+                                                                'type' => '137'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'timeout',
+                                                                'type' => '64'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'ConnectClientToTcpAddrWithTimeout',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '334'
+                                        },
+                            '106415' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'host',
+                                                                'type' => '64'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'port',
+                                                                'type' => '137'
+                                                              }
+                                                     },
+                                          'Return' => '137',
+                                          'ShortName' => 'ConnectClientToTcpAddr',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '323'
+                                        },
+                            '10943' => {
+                                         'Data' => 1,
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '500',
+                                         'Return' => '10912',
+                                         'ShortName' => 'rfbClientLog',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '98'
+                                       },
+                            '10956' => {
+                                         'Data' => 1,
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '500',
+                                         'Return' => '10912',
+                                         'ShortName' => 'rfbClientErr',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '99'
+                                       },
+                            '11017' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '748',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'sock',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SetNonBlocking',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '695'
+                                       },
+                            '11040' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '747',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'listenSock',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '137',
+                                         'ShortName' => 'AcceptTcpConnection',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '666'
+                                       },
+                            '11219' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '703',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'port',
+                                                               'type' => '137'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'address',
+                                                               'type' => '1039'
+                                                             }
+                                                    },
+                                         'Return' => '137',
+                                         'ShortName' => 'ListenAtTcpPortAndAddress',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '560'
+                                       },
+                            '11247' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '494',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'timeout',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '137',
+                                         'ShortName' => 'listenForIncomingConnectionsNoFork',
+                                         'Source' => 'listen.c',
+                                         'SourceLine' => '150'
+                                       },
+                            '115204' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'client',
+                                                                'type' => '4962'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbClientCleanup',
+                                          'Source' => 'vncviewer.c',
+                                          'SourceLine' => '513'
+                                        },
+                            '115657' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'client',
+                                                                'type' => '4962'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'argc',
+                                                                'type' => '10969'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'argv',
+                                                                'type' => '110169'
+                                                              }
+                                                     },
+                                          'Return' => '1453',
+                                          'ShortName' => 'rfbInitClient',
+                                          'Source' => 'vncviewer.c',
+                                          'SourceLine' => '432'
+                                        },
+                            '117239' => {
+                                          'Header' => 'rfbclient.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'bitsPerSample',
+                                                                'type' => '137'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'samplesPerPixel',
+                                                                'type' => '137'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'bytesPerPixel',
+                                                                'type' => '137'
+                                                              }
+                                                     },
+                                          'Return' => '4962',
+                                          'ShortName' => 'rfbGetClient',
+                                          'Source' => 'vncviewer.c',
+                                          'SourceLine' => '251'
+                                        },
+                            '11939' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '493',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'listenForIncomingConnections',
+                                         'Source' => 'listen.c',
+                                         'SourceLine' => '49'
+                                       },
+                            '20651' => {
+                                         'Data' => 1,
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '498',
+                                         'Return' => '1453',
+                                         'ShortName' => 'rfbEnableClientLogging',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '74'
+                                       },
+                            '20947' => {
+                                         'Data' => 1,
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '697',
+                                         'Return' => '1453',
+                                         'ShortName' => 'errorMessageOnReadFailure',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '46'
+                                       },
+                            '21802' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '753',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'sock',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SameMachine',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '793'
+                                       },
+                            '22165' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '700',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'buf',
+                                                               'type' => '1039'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'n',
+                                                               'type' => '64'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'WriteToRFBServer',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '250'
+                                       },
+                            '22434' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '750',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'sock',
+                                                               'type' => '137'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'dscp',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SetDSCP',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '712'
+                                       },
+                            '22462' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '739',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'hostname',
+                                                               'type' => '1039'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'port',
+                                                               'type' => '137'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'timeout',
+                                                               'type' => '64'
+                                                             }
+                                                    },
+                                         'Return' => '137',
+                                         'ShortName' => 'ConnectClientToTcpAddr6WithTimeout',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '389'
+                                       },
+                            '22495' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '746',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'sockFile',
+                                                               'type' => '1039'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'timeout',
+                                                               'type' => '64'
+                                                             }
+                                                    },
+                                         'Return' => '137',
+                                         'ShortName' => 'ConnectClientToUnixSockWithTimeout',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '471'
+                                       },
+                            '23383' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'format',
+                                                               'type' => '23594'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'PrintPixelFormat',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '2557'
+                                       },
+                            '4968' => {
+                                        'Header' => 'rfbclient.h',
+                                        'Line' => '699',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'name' => 'client',
+                                                              'type' => '4962'
+                                                            },
+                                                     '1' => {
+                                                              'name' => 'out',
+                                                              'type' => '211'
+                                                            },
+                                                     '2' => {
+                                                              'name' => 'n',
+                                                              'type' => '64'
+                                                            }
+                                                   },
+                                        'Return' => '1453',
+                                        'ShortName' => 'ReadFromRFBServer',
+                                        'Source' => 'sockets.c',
+                                        'SourceLine' => '63'
+                                      },
+                            '5043' => {
+                                        'Header' => 'rfbclient.h',
+                                        'Line' => '489',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'name' => 'client',
+                                                              'type' => '4962'
+                                                            },
+                                                     '1' => {
+                                                              'name' => 'xhot',
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'name' => 'yhot',
+                                                              'type' => '137'
+                                                            },
+                                                     '3' => {
+                                                              'name' => 'width',
+                                                              'type' => '137'
+                                                            },
+                                                     '4' => {
+                                                              'name' => 'height',
+                                                              'type' => '137'
+                                                            },
+                                                     '5' => {
+                                                              'name' => 'enc',
+                                                              'type' => '1074'
+                                                            }
+                                                   },
+                                        'Return' => '1453',
+                                        'ShortName' => 'HandleCursorShape',
+                                        'Source' => 'cursor.c',
+                                        'SourceLine' => '42'
+                                      },
+                            '72431' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'HandleRFBServerMessage',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1797'
+                                       },
+                            '76363' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'str',
+                                                               'type' => '211'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendClientCutText',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1777'
+                                       },
+                            '76670' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'keysym',
+                                                               'type' => '1074'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'keycode',
+                                                               'type' => '1074'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'down',
+                                                               'type' => '1453'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendExtendedKeyEvent',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1752'
+                                       },
+                            '76964' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'key',
+                                                               'type' => '1074'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'down',
+                                                               'type' => '1453'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendKeyEvent',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1733'
+                                       },
+                            '77234' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'width',
+                                                               'type' => '1062'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'height',
+                                                               'type' => '1062'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendExtDesktopSize',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1692'
+                                       },
+                            '77713' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '137'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '137'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'buttonMask',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendPointerEvent',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1654'
+                                       },
+                            '77921' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'version',
+                                                               'type' => '1045'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'code',
+                                                               'type' => '1045'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendXvpMsg',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1632'
+                                       },
+                            '78114' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'enabled',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'PermitServerInput',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1605'
+                                       },
+                            '78285' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'TextChatFinish',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1589'
+                                       },
+                            '78435' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'TextChatClose',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1578'
+                                       },
+                            '78585' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'TextChatOpen',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1566'
+                                       },
+                            '78735' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'text',
+                                                               'type' => '211'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'TextChatSend',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1544'
+                                       },
+                            '78987' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '547',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'scaleSetting',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendScaleSetting',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1515'
+                                       },
+                            '79222' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '544',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '137'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '137'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '137'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '137'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'incremental',
+                                                               'type' => '1453'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendFramebufferUpdateRequest',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1486'
+                                       },
+                            '79498' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SendIncrementalFramebufferUpdateRequest',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1473'
+                                       },
+                            '79582' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '522',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SetFormatAndEncodings',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '1248'
+                                       },
+                            '80826' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '504',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'InitialiseRFBConnection',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '964'
+                                       },
+                            '82572' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'authSchemes',
+                                                               'type' => '20902'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'size',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'SetClientAuthSchemes',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '933'
+                                       },
+                            '89710' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '502',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'repeaterHost',
+                                                               'type' => '1039'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'repeaterPort',
+                                                               'type' => '137'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'destHost',
+                                                               'type' => '1039'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'destPort',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'ConnectToRFBRepeater',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '363'
+                                       },
+                            '90407' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Line' => '501',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'hostname',
+                                                               'type' => '1039'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'port',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Return' => '1453',
+                                         'ShortName' => 'ConnectToRFBServer',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '294'
+                                       },
+                            '92402' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'messageType',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi'
+                                                  },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SupportsServer2Client',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '195'
+                                       },
+                            '92465' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'messageType',
+                                                               'type' => '137'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi'
+                                                  },
+                                         'Return' => '1453',
+                                         'ShortName' => 'SupportsClient2Server',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '189'
+                                       },
+                            '92528' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'tag',
+                                                               'type' => '71'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi'
+                                                  },
+                                         'Return' => '71',
+                                         'ShortName' => 'rfbClientGetClientData',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '130'
+                                       },
+                            '92611' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'client',
+                                                               'type' => '4962'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'tag',
+                                                               'type' => '71'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'data',
+                                                               'type' => '71'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbClientSetClientData',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '113'
+                                       },
+                            '92746' => {
+                                         'Header' => 'rfbclient.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'e',
+                                                               'type' => '21060'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbClientRegisterExtension',
+                                         'Source' => 'rfbproto.c',
+                                         'SourceLine' => '105'
+                                       }
+                          },
+          'SymbolVersion' => {},
+          'Symbols' => {
+                         'libvncclient.so.0.9.14' => {
+                                                       'AcceptTcpConnection' => 1,
+                                                       'ClearClient2Server' => 1,
+                                                       'ClearServer2Client' => 1,
+                                                       'ConnectClientToTcpAddr' => 1,
+                                                       'ConnectClientToTcpAddr6' => 1,
+                                                       'ConnectClientToTcpAddr6WithTimeout' => 1,
+                                                       'ConnectClientToTcpAddrWithTimeout' => 1,
+                                                       'ConnectClientToUnixSock' => 1,
+                                                       'ConnectClientToUnixSockWithTimeout' => 1,
+                                                       'ConnectToRFBRepeater' => 1,
+                                                       'ConnectToRFBServer' => 1,
+                                                       'DefaultSupportedMessages' => 1,
+                                                       'DefaultSupportedMessagesTightVNC' => 1,
+                                                       'DefaultSupportedMessagesUltraVNC' => 1,
+                                                       'FindFreeTcpPort' => 1,
+                                                       'FreeTLS' => 1,
+                                                       'HandleAnonTLSAuth' => 1,
+                                                       'HandleCursorShape' => 1,
+                                                       'HandleRFBServerMessage' => 1,
+                                                       'HandleVeNCryptAuth' => 1,
+                                                       'InitialiseRFBConnection' => 1,
+                                                       'ListenAtTcpPort' => 1,
+                                                       'ListenAtTcpPortAndAddress' => 1,
+                                                       'PermitServerInput' => 1,
+                                                       'PrintInHex' => 1,
+                                                       'PrintPixelFormat' => 1,
+                                                       'ReadFromRFBServer' => 1,
+                                                       'ReadFromTLS' => 1,
+                                                       'SameMachine' => 1,
+                                                       'SendClientCutText' => 1,
+                                                       'SendExtDesktopSize' => 1,
+                                                       'SendExtendedKeyEvent' => 1,
+                                                       'SendFramebufferUpdateRequest' => 1,
+                                                       'SendIncrementalFramebufferUpdateRequest' => 1,
+                                                       'SendKeyEvent' => 1,
+                                                       'SendPointerEvent' => 1,
+                                                       'SendScaleSetting' => 1,
+                                                       'SendXvpMsg' => 1,
+                                                       'SetBlocking' => 1,
+                                                       'SetClient2Server' => 1,
+                                                       'SetClientAuthSchemes' => 1,
+                                                       'SetDSCP' => 1,
+                                                       'SetFormatAndEncodings' => 1,
+                                                       'SetNonBlocking' => 1,
+                                                       'SetServer2Client' => 1,
+                                                       'StringToIPAddr' => 1,
+                                                       'SupportsClient2Server' => 1,
+                                                       'SupportsServer2Client' => 1,
+                                                       'TJBUFSIZE' => 1,
+                                                       'TextChatClose' => 1,
+                                                       'TextChatFinish' => 1,
+                                                       'TextChatOpen' => 1,
+                                                       'TextChatSend' => 1,
+                                                       'WaitForMessage' => 1,
+                                                       'WriteToRFBServer' => 1,
+                                                       'WriteToTLS' => 1,
+                                                       'decrypt_rfbdes' => 1,
+                                                       'dh_compute_shared_key' => 1,
+                                                       'dh_generate_keypair' => 1,
+                                                       'encrypt_aes128ecb' => 1,
+                                                       'encrypt_rfbdes' => 1,
+                                                       'errorMessageOnReadFailure' => -1,
+                                                       'hash_md5' => 1,
+                                                       'hash_sha1' => 1,
+                                                       'listenForIncomingConnections' => 1,
+                                                       'listenForIncomingConnectionsNoFork' => 1,
+                                                       'random_bytes' => 1,
+                                                       'rfbClientCleanup' => 1,
+                                                       'rfbClientEncryptBytes' => 1,
+                                                       'rfbClientEncryptBytes2' => 1,
+                                                       'rfbClientErr' => -8,
+                                                       'rfbClientExtensions' => -8,
+                                                       'rfbClientGetClientData' => 1,
+                                                       'rfbClientLog' => -8,
+                                                       'rfbClientRegisterExtension' => 1,
+                                                       'rfbClientSetClientData' => 1,
+                                                       'rfbEnableClientLogging' => -1,
+                                                       'rfbGetClient' => 1,
+                                                       'rfbHandleAuthResult' => 1,
+                                                       'rfbInitClient' => 1,
+                                                       'sock_set_nonblocking' => 1,
+                                                       'sock_wait_for_connected' => 1,
+                                                       'tjBufSize' => 1,
+                                                       'tjCompress' => 1,
+                                                       'tjCompress2' => 1,
+                                                       'tjDecompress' => 1,
+                                                       'tjDecompress2' => 1,
+                                                       'tjDecompressHeader' => 1,
+                                                       'tjDecompressHeader2' => 1,
+                                                       'tjDestroy' => 1,
+                                                       'tjGetErrorStr' => 1,
+                                                       'tjGetScalingFactors' => 1,
+                                                       'tjInitCompress' => 1,
+                                                       'tjInitDecompress' => 1,
+                                                       'zywrleSynthesize16LE' => 1,
+                                                       'zywrleSynthesize32LE' => 1
+                                                     }
+                       },
+          'Target' => 'unix',
+          'TypeInfo' => {
+                          '-1' => {
+                                    'Name' => '...',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '1' => {
+                                   'Name' => 'void',
+                                   'Type' => 'Intrinsic'
+                                 },
+                          '1011' => {
+                                      'BaseType' => '217',
+                                      'Name' => 'char[40]',
+                                      'Size' => '40',
+                                      'Type' => 'Array'
+                                    },
+                          '101940' => {
+                                        'BaseType' => '64',
+                                        'Name' => 'unsigned int*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '1027' => {
+                                      'Header' => 'pthreadtypes.h',
+                                      'Line' => '72',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__data',
+                                                           'offset' => '0',
+                                                           'type' => '847'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__size',
+                                                           'offset' => '0',
+                                                           'type' => '1011'
+                                                         },
+                                                  '2' => {
+                                                           'name' => '__align',
+                                                           'offset' => '0',
+                                                           'type' => '156'
+                                                         }
+                                                },
+                                      'Name' => 'union pthread_mutex_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Union'
+                                    },
+                          '1039' => {
+                                      'BaseType' => '224',
+                                      'Name' => 'char const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1045' => {
+                                      'BaseType' => '106',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '24',
+                                      'Name' => 'uint8_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1057' => {
+                                      'BaseType' => '1045',
+                                      'Name' => 'uint8_t const',
+                                      'Size' => '1',
+                                      'Type' => 'Const'
+                                    },
+                          '106' => {
+                                     'BaseType' => '73',
+                                     'Header' => 'types.h',
+                                     'Line' => '38',
+                                     'Name' => '__uint8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1062' => {
+                                      'BaseType' => '125',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '25',
+                                      'Name' => 'uint16_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1074' => {
+                                      'BaseType' => '144',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '26',
+                                      'Name' => 'uint32_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1086' => {
+                                      'BaseType' => '73',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '391',
+                                      'Name' => 'Byte',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '10912' => {
+                                       'BaseType' => '10925',
+                                       'Header' => 'rfbclient.h',
+                                       'Line' => '499',
+                                       'Name' => 'rfbClientLogProc',
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10925' => {
+                                       'Name' => 'void(*)(char const*, ...)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '1039'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '-1'
+                                                           }
+                                                  },
+                                       'Return' => '1',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '10969' => {
+                                       'BaseType' => '137',
+                                       'Name' => 'int*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1099' => {
+                                      'BaseType' => '64',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '393',
+                                      'Name' => 'uInt',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '110169' => {
+                                        'BaseType' => '211',
+                                        'Name' => 'char**',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '1112' => {
+                                      'BaseType' => '57',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '394',
+                                      'Name' => 'uLong',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1125' => {
+                                      'BaseType' => '1086',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '400',
+                                      'Name' => 'Bytef',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1138' => {
+                                      'BaseType' => '71',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '409',
+                                      'Name' => 'voidpf',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1151' => {
+                                      'BaseType' => '1163',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '81',
+                                      'Name' => 'alloc_func',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1163' => {
+                                      'Name' => 'voidpf(*)(voidpf, uInt, uInt)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '1138'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1099'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '1099'
+                                                          }
+                                                 },
+                                      'Return' => '1138',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '118' => {
+                                     'Name' => 'short',
+                                     'Size' => '2',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '1194' => {
+                                      'BaseType' => '1206',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '82',
+                                      'Name' => 'free_func',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1206' => {
+                                      'Name' => 'void(*)(voidpf, voidpf)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '1138'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1138'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '1228' => {
+                                      'Header' => 'zlib.h',
+                                      'Line' => '86',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'next_in',
+                                                           'offset' => '0',
+                                                           'type' => '1424'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'avail_in',
+                                                           'offset' => '8',
+                                                           'type' => '1099'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'opaque',
+                                                            'offset' => '128',
+                                                            'type' => '1138'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'data_type',
+                                                            'offset' => '136',
+                                                            'type' => '137'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'adler',
+                                                            'offset' => '150',
+                                                            'type' => '1112'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'reserved',
+                                                            'offset' => '260',
+                                                            'type' => '1112'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'total_in',
+                                                           'offset' => '22',
+                                                           'type' => '1112'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'next_out',
+                                                           'offset' => '36',
+                                                           'type' => '1424'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'avail_out',
+                                                           'offset' => '50',
+                                                           'type' => '1099'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'total_out',
+                                                           'offset' => '64',
+                                                           'type' => '1112'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'msg',
+                                                           'offset' => '72',
+                                                           'type' => '211'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'state',
+                                                           'offset' => '86',
+                                                           'type' => '1435'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'zalloc',
+                                                           'offset' => '100',
+                                                           'type' => '1151'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'zfree',
+                                                           'offset' => '114',
+                                                           'type' => '1194'
+                                                         }
+                                                },
+                                      'Name' => 'struct z_stream_s',
+                                      'PrivateABI' => 1,
+                                      'Size' => '112',
+                                      'Type' => 'Struct'
+                                    },
+                          '125' => {
+                                     'BaseType' => '80',
+                                     'Header' => 'types.h',
+                                     'Line' => '40',
+                                     'Name' => '__uint16_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '2',
+                                     'Type' => 'Typedef'
+                                   },
+                          '12970' => {
+                                       'BaseType' => '137',
+                                       'Name' => 'int const',
+                                       'Size' => '4',
+                                       'Type' => 'Const'
+                                     },
+                          '132847' => {
+                                        'BaseType' => '12970',
+                                        'Name' => 'int const*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '132859' => {
+                                        'BaseType' => '1039',
+                                        'Name' => 'char const*const',
+                                        'Size' => '8',
+                                        'Type' => 'Const'
+                                      },
+                          '132869' => {
+                                        'BaseType' => '73',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '48',
+                                        'Name' => 'JSAMPLE',
+                                        'PrivateABI' => 1,
+                                        'Size' => '1',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132881' => {
+                                        'BaseType' => '118',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '77',
+                                        'Name' => 'JCOEF',
+                                        'PrivateABI' => 1,
+                                        'Size' => '2',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132893' => {
+                                        'BaseType' => '73',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '86',
+                                        'Name' => 'JOCTET',
+                                        'PrivateABI' => 1,
+                                        'Size' => '1',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132905' => {
+                                        'BaseType' => '132893',
+                                        'Name' => 'JOCTET const',
+                                        'Size' => '1',
+                                        'Type' => 'Const'
+                                      },
+                          '132910' => {
+                                        'BaseType' => '73',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '99',
+                                        'Name' => 'UINT8',
+                                        'PrivateABI' => 1,
+                                        'Size' => '1',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132922' => {
+                                        'BaseType' => '80',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '104',
+                                        'Name' => 'UINT16',
+                                        'PrivateABI' => 1,
+                                        'Size' => '2',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132934' => {
+                                        'BaseType' => '64',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '159',
+                                        'Name' => 'JDIMENSION',
+                                        'PrivateABI' => 1,
+                                        'Size' => '4',
+                                        'Type' => 'Typedef'
+                                      },
+                          '132946' => {
+                                        'BaseType' => '137',
+                                        'Header' => 'jmorecfg.h',
+                                        'Line' => '207',
+                                        'Name' => 'boolean',
+                                        'PrivateABI' => 1,
+                                        'Size' => '4',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133307' => {
+                                        'BaseType' => '133319',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '69',
+                                        'Name' => 'JSAMPROW',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133319' => {
+                                        'BaseType' => '132869',
+                                        'Name' => 'JSAMPLE*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '133325' => {
+                                        'BaseType' => '133337',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '70',
+                                        'Name' => 'JSAMPARRAY',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133337' => {
+                                        'BaseType' => '133307',
+                                        'Name' => 'JSAMPROW*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '133343' => {
+                                        'BaseType' => '133355',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '73',
+                                        'Name' => 'JBLOCK',
+                                        'PrivateABI' => 1,
+                                        'Size' => '128',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133355' => {
+                                        'BaseType' => '132881',
+                                        'Name' => 'JCOEF[64]',
+                                        'Size' => '128',
+                                        'Type' => 'Array'
+                                      },
+                          '133371' => {
+                                        'BaseType' => '133383',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '74',
+                                        'Name' => 'JBLOCKROW',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133383' => {
+                                        'BaseType' => '133343',
+                                        'Name' => 'JBLOCK*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '133389' => {
+                                        'BaseType' => '133401',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '75',
+                                        'Name' => 'JBLOCKARRAY',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '133401' => {
+                                        'BaseType' => '133371',
+                                        'Name' => 'JBLOCKROW*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '133443' => {
+                                        'BaseType' => '132922',
+                                        'Name' => 'UINT16[64]',
+                                        'Size' => '128',
+                                        'Type' => 'Array'
+                                      },
+                          '133459' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '98',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'quantval',
+                                                             'offset' => '0',
+                                                             'type' => '133443'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'sent_table',
+                                                             'offset' => '296',
+                                                             'type' => '132946'
+                                                           }
+                                                  },
+                                        'Name' => 'struct JQUANT_TBL',
+                                        'PrivateABI' => 1,
+                                        'Size' => '132',
+                                        'Type' => 'Struct'
+                                      },
+                          '133522' => {
+                                        'BaseType' => '132910',
+                                        'Name' => 'UINT8[17]',
+                                        'Size' => '17',
+                                        'Type' => 'Array'
+                                      },
+                          '133538' => {
+                                        'BaseType' => '132910',
+                                        'Name' => 'UINT8[256]',
+                                        'Size' => '256',
+                                        'Type' => 'Array'
+                                      },
+                          '133554' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '114',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'bits',
+                                                             'offset' => '0',
+                                                             'type' => '133522'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'huffval',
+                                                             'offset' => '23',
+                                                             'type' => '133538'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'sent_table',
+                                                             'offset' => '630',
+                                                             'type' => '132946'
+                                                           }
+                                                  },
+                                        'Name' => 'struct JHUFF_TBL',
+                                        'PrivateABI' => 1,
+                                        'Size' => '280',
+                                        'Type' => 'Struct'
+                                      },
+                          '133862' => {
+                                        'BaseType' => '133459',
+                                        'Name' => 'JQUANT_TBL*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '133868' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '187',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'component_id',
+                                                             'offset' => '0',
+                                                             'type' => '137'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'component_index',
+                                                             'offset' => '4',
+                                                             'type' => '137'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'DCT_v_scaled_size',
+                                                              'offset' => '64',
+                                                              'type' => '137'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'downsampled_width',
+                                                              'offset' => '68',
+                                                              'type' => '132934'
+                                                            },
+                                                    '12' => {
+                                                              'name' => 'downsampled_height',
+                                                              'offset' => '72',
+                                                              'type' => '132934'
+                                                            },
+                                                    '13' => {
+                                                              'name' => 'component_needed',
+                                                              'offset' => '82',
+                                                              'type' => '132946'
+                                                            },
+                                                    '14' => {
+                                                              'name' => 'MCU_width',
+                                                              'offset' => '86',
+                                                              'type' => '137'
+                                                            },
+                                                    '15' => {
+                                                              'name' => 'MCU_height',
+                                                              'offset' => '96',
+                                                              'type' => '137'
+                                                            },
+                                                    '16' => {
+                                                              'name' => 'MCU_blocks',
+                                                              'offset' => '100',
+                                                              'type' => '137'
+                                                            },
+                                                    '17' => {
+                                                              'name' => 'MCU_sample_width',
+                                                              'offset' => '104',
+                                                              'type' => '137'
+                                                            },
+                                                    '18' => {
+                                                              'name' => 'last_col_width',
+                                                              'offset' => '114',
+                                                              'type' => '137'
+                                                            },
+                                                    '19' => {
+                                                              'name' => 'last_row_height',
+                                                              'offset' => '118',
+                                                              'type' => '137'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'h_samp_factor',
+                                                             'offset' => '8',
+                                                             'type' => '137'
+                                                           },
+                                                    '20' => {
+                                                              'name' => 'quant_table',
+                                                              'offset' => '128',
+                                                              'type' => '133862'
+                                                            },
+                                                    '21' => {
+                                                              'name' => 'dct_table',
+                                                              'offset' => '136',
+                                                              'type' => '71'
+                                                            },
+                                                    '3' => {
+                                                             'name' => 'v_samp_factor',
+                                                             'offset' => '18',
+                                                             'type' => '137'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'quant_tbl_no',
+                                                             'offset' => '22',
+                                                             'type' => '137'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'dc_tbl_no',
+                                                             'offset' => '32',
+                                                             'type' => '137'
+                                                           },
+                                                    '6' => {
+                                                             'name' => 'ac_tbl_no',
+                                                             'offset' => '36',
+                                                             'type' => '137'
+                                                           },
+                                                    '7' => {
+                                                             'name' => 'width_in_blocks',
+                                                             'offset' => '40',
+                                                             'type' => '132934'
+                                                           },
+                                                    '8' => {
+                                                             'name' => 'height_in_blocks',
+                                                             'offset' => '50',
+                                                             'type' => '132934'
+                                                           },
+                                                    '9' => {
+                                                             'name' => 'DCT_h_scaled_size',
+                                                             'offset' => '54',
+                                                             'type' => '137'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_component_info',
+                                        'PrivateABI' => 1,
+                                        'Size' => '96',
+                                        'Type' => 'Struct'
+                                      },
+                          '133997' => {
+                                        'BaseType' => '134009',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '201',
+                                        'Name' => 'jpeg_saved_marker_ptr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '134009' => {
+                                        'BaseType' => '134015',
+                                        'Name' => 'struct jpeg_marker_struct*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '134015' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '203',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'next',
+                                                             'offset' => '0',
+                                                             'type' => '133997'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'marker',
+                                                             'offset' => '8',
+                                                             'type' => '132910'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'original_length',
+                                                             'offset' => '18',
+                                                             'type' => '64'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'data_length',
+                                                             'offset' => '22',
+                                                             'type' => '64'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'data',
+                                                             'offset' => '36',
+                                                             'type' => '134094'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_marker_struct',
+                                        'PrivateABI' => 1,
+                                        'Size' => '32',
+                                        'Type' => 'Struct'
+                                      },
+                          '134094' => {
+                                        'BaseType' => '132893',
+                                        'Name' => 'JOCTET*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '134217' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '242',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'JCS_UNKNOWN',
+                                                             'value' => '0'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'JCS_GRAYSCALE',
+                                                             'value' => '1'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'JCS_EXT_XBGR',
+                                                              'value' => '10'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'JCS_EXT_XRGB',
+                                                              'value' => '11'
+                                                            },
+                                                    '12' => {
+                                                              'name' => 'JCS_EXT_RGBA',
+                                                              'value' => '12'
+                                                            },
+                                                    '13' => {
+                                                              'name' => 'JCS_EXT_BGRA',
+                                                              'value' => '13'
+                                                            },
+                                                    '14' => {
+                                                              'name' => 'JCS_EXT_ABGR',
+                                                              'value' => '14'
+                                                            },
+                                                    '15' => {
+                                                              'name' => 'JCS_EXT_ARGB',
+                                                              'value' => '15'
+                                                            },
+                                                    '16' => {
+                                                              'name' => 'JCS_RGB565',
+                                                              'value' => '16'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'JCS_RGB',
+                                                             'value' => '2'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'JCS_YCbCr',
+                                                             'value' => '3'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'JCS_CMYK',
+                                                             'value' => '4'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'JCS_YCCK',
+                                                             'value' => '5'
+                                                           },
+                                                    '6' => {
+                                                             'name' => 'JCS_EXT_RGB',
+                                                             'value' => '6'
+                                                           },
+                                                    '7' => {
+                                                             'name' => 'JCS_EXT_RGBX',
+                                                             'value' => '7'
+                                                           },
+                                                    '8' => {
+                                                             'name' => 'JCS_EXT_BGR',
+                                                             'value' => '8'
+                                                           },
+                                                    '9' => {
+                                                             'name' => 'JCS_EXT_BGRX',
+                                                             'value' => '9'
+                                                           }
+                                                  },
+                                        'Name' => 'enum J_COLOR_SPACE',
+                                        'PrivateABI' => 1,
+                                        'Size' => '4',
+                                        'Type' => 'Enum'
+                                      },
+                          '134262' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '250',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'JDCT_ISLOW',
+                                                             'value' => '0'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'JDCT_IFAST',
+                                                             'value' => '1'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'JDCT_FLOAT',
+                                                             'value' => '2'
+                                                           }
+                                                  },
+                                        'Name' => 'enum J_DCT_METHOD',
+                                        'PrivateABI' => 1,
+                                        'Size' => '4',
+                                        'Type' => 'Enum'
+                                      },
+                          '134308' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '265',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'JDITHER_NONE',
+                                                             'value' => '0'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'JDITHER_ORDERED',
+                                                             'value' => '1'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'JDITHER_FS',
+                                                             'value' => '2'
+                                                           }
+                                                  },
+                                        'Name' => 'enum J_DITHER_MODE',
+                                        'PrivateABI' => 1,
+                                        'Size' => '4',
+                                        'Type' => 'Enum'
+                                      },
+                          '134321' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '282',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'err',
+                                                             'offset' => '0',
+                                                             'type' => '134631'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'mem',
+                                                             'offset' => '8',
+                                                             'type' => '134834'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'progress',
+                                                             'offset' => '22',
+                                                             'type' => '134925'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'client_data',
+                                                             'offset' => '36',
+                                                             'type' => '71'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'is_decompressor',
+                                                             'offset' => '50',
+                                                             'type' => '132946'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'global_state',
+                                                             'offset' => '54',
+                                                             'type' => '137'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_common_struct',
+                                        'PrivateABI' => 1,
+                                        'Size' => '40',
+                                        'Type' => 'Struct'
+                                      },
+                          '134420' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '720',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'error_exit',
+                                                             'offset' => '0',
+                                                             'type' => '138118'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'emit_message',
+                                                             'offset' => '8',
+                                                             'type' => '138140'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'last_jpeg_message',
+                                                              'offset' => '324',
+                                                              'type' => '137'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'addon_message_table',
+                                                              'offset' => '338',
+                                                              'type' => '138168'
+                                                            },
+                                                    '12' => {
+                                                              'name' => 'first_addon_message',
+                                                              'offset' => '352',
+                                                              'type' => '137'
+                                                            },
+                                                    '13' => {
+                                                              'name' => 'last_addon_message',
+                                                              'offset' => '356',
+                                                              'type' => '137'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'output_message',
+                                                             'offset' => '22',
+                                                             'type' => '138118'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'format_message',
+                                                             'offset' => '36',
+                                                             'type' => '138162'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'reset_error_mgr',
+                                                             'offset' => '50',
+                                                             'type' => '138118'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'msg_code',
+                                                             'offset' => '64',
+                                                             'type' => '137'
+                                                           },
+                                                    '6' => {
+                                                             'name' => 'msg_parm',
+                                                             'offset' => '68',
+                                                             'type' => '138042'
+                                                           },
+                                                    '7' => {
+                                                             'name' => 'trace_level',
+                                                             'offset' => '292',
+                                                             'type' => '137'
+                                                           },
+                                                    '8' => {
+                                                             'name' => 'num_warnings',
+                                                             'offset' => '296',
+                                                             'type' => '156'
+                                                           },
+                                                    '9' => {
+                                                             'name' => 'jpeg_message_table',
+                                                             'offset' => '310',
+                                                             'type' => '138168'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_error_mgr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '168',
+                                        'Type' => 'Struct'
+                                      },
+                          '134631' => {
+                                        'BaseType' => '134420',
+                                        'Name' => 'struct jpeg_error_mgr*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '134637' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '833',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'alloc_small',
+                                                             'offset' => '0',
+                                                             'type' => '138377'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'alloc_large',
+                                                             'offset' => '8',
+                                                             'type' => '138377'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'self_destruct',
+                                                              'offset' => '128',
+                                                              'type' => '138118'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'max_memory_to_use',
+                                                              'offset' => '136',
+                                                              'type' => '156'
+                                                            },
+                                                    '12' => {
+                                                              'name' => 'max_alloc_chunk',
+                                                              'offset' => '150',
+                                                              'type' => '156'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'alloc_sarray',
+                                                             'offset' => '22',
+                                                             'type' => '138413'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'alloc_barray',
+                                                             'offset' => '36',
+                                                             'type' => '138449'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'request_virt_sarray',
+                                                             'offset' => '50',
+                                                             'type' => '138495'
+                                                           },
+                                                    '5' => {
+                                                             'name' => 'request_virt_barray',
+                                                             'offset' => '64',
+                                                             'type' => '138541'
+                                                           },
+                                                    '6' => {
+                                                             'name' => 'realize_virt_arrays',
+                                                             'offset' => '72',
+                                                             'type' => '138118'
+                                                           },
+                                                    '7' => {
+                                                             'name' => 'access_virt_sarray',
+                                                             'offset' => '86',
+                                                             'type' => '138582'
+                                                           },
+                                                    '8' => {
+                                                             'name' => 'access_virt_barray',
+                                                             'offset' => '100',
+                                                             'type' => '138623'
+                                                           },
+                                                    '9' => {
+                                                             'name' => 'free_pool',
+                                                             'offset' => '114',
+                                                             'type' => '138140'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_memory_mgr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '104',
+                                        'Type' => 'Struct'
+                                      },
+                          '134834' => {
+                                        'BaseType' => '134637',
+                                        'Name' => 'struct jpeg_memory_mgr*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '134840' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '778',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'progress_monitor',
+                                                             'offset' => '0',
+                                                             'type' => '138118'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'pass_counter',
+                                                             'offset' => '8',
+                                                             'type' => '156'
+                                                           },
+                                                    '2' => {
+                                                             'name' => 'pass_limit',
+                                                             'offset' => '22',
+                                                             'type' => '156'
+                                                           },
+                                                    '3' => {
+                                                             'name' => 'completed_passes',
+                                                             'offset' => '36',
+                                                             'type' => '137'
+                                                           },
+                                                    '4' => {
+                                                             'name' => 'total_passes',
+                                                             'offset' => '40',
+                                                             'type' => '137'
+                                                           }
+                                                  },
+                                        'Name' => 'struct jpeg_progress_mgr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '32',
+                                        'Type' => 'Struct'
+                                      },
+                          '134925' => {
+                                        'BaseType' => '134840',
+                                        'Name' => 'struct jpeg_progress_mgr*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '134931' => {
+                                        'BaseType' => '134944',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '290',
+                                        'Name' => 'j_common_ptr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '134944' => {
+                                        'BaseType' => '134321',
+                                        'Name' => 'struct jpeg_common_struct*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '136095' => {
+                                        'BaseType' => '136108',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '292',
+                                        'Name' => 'j_decompress_ptr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '136108' => {
+                                        'BaseType' => '136114',
+                                        'Name' => 'struct jpeg_decompress_struct*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '136114' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '472',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'err',
+                                                             'offset' => '0',
+                                                             'type' => '134631'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'mem',
+                                                             'offset' => '8',
+                                                             'type' => '134834'
+                                                           },
+                                                    '10' => {
+                                                              'name' => 'jpeg_color_space',
+                                                              'offset' => '96',
+                                                              'type' => '134217'
+                                                            },
+                                                    '11' => {
+                                                              'name' => 'out_color_space',
+                                                              'offset' => '100',
+                                                              'type' => '134217'
+                                                            },
+                                                    '12' => {
+                                                              'name' => 'scale_num',
+                                                              'offset' => '104',
+                                                              'type' => '64'
+                                                            },
+                                                    '13' => {
+                                                              'name' => 'scale_denom',
+                                                              'offset' => '114',
+                                                              'type' => '64'
+                                                            },
+                                                    '14' => {
+                                                              'name' => 'output_gamma',
+                                                              'offset' => '128',
+                                                              'type' => '21490'
+                                                            },
+                                                    '15' => {
+                                                              'name' => 'buffered_image',
+                                                              'offset' => '136',
+                                                              'type' => '132946'
+                                                            },
+                                                    '16' => {
+                                                              'name' => 'raw_data_out',
+                                                              'offset' => '146',
+                                                              'type' => '132946'
+                                                            },
+                                                    '17' => {
+                                                              'name' => 'dct_method',
+                                                              'offset' => '150',
+                                                              'type' => '134262'
+                                                            },
+                                                    '18' => {
+                                                              'name' => 'do_fancy_upsampling',
+                                                              'offset' => '256',
+                                                              'type' => '132946'
+                                                            },
+                                                    '19' => {
+                                                              'name' => 'do_block_smoothing',
+                                                              'offset' => '260',
+                                                              'type' => '132946'
+                                                            },
+                                                    '2' => {
+                                                             'name' => 'progress',
+                                                             'offset' => '22',
+                                                             'type' => '134925'
+                                                           },
+                                                    '20' => {
+                                                              'name' => 'quantize_colors',
+                                                              'offset' => '264',
+                                                              'type' => '132946'
+                                                            },
+                                                    '21' => {
+                                                              'name' => 'dither_mode',
+                                                              'offset' => '274',
+                                                              'type' => '134308'
+                                                            },
+                                                    '22' => {
+                                                              'name' => 'two_pass_quantize',
+                                                              'offset' => '278',
+                                                              'type' => '132946'
+                                                            },
+                                                    '23' => {
+                                                              'name' => 'desired_number_of_colors',
+                                                              'offset' => '288',
+                                                              'type' => '137'
+                                                            },
+                                                    '24' => {
+                                                              'name' => 'enable_1pass_quant',
+                                                              'offset' => '292',
+                                                              'type' => '132946'
+                                                            },
+                                                    '25' => {
+                                                              'name' => 'enable_external_quant',
+                                                              'offset' => '296',
+                                                              'type' => '132946'
+                                                            },
+                                                    '26' => {
+                                                              'name' => 'enable_2pass_quant',
+                                                              'offset' => '306',
+                                                              'type' => '132946'
+                                                            },
+                                                    '27' => {
+                                                              'name' => 'output_width',
+                                                              'offset' => '310',
+                                                              'type' => '132934'
+                                                            },
+                                                    '28' => {
+                                                              'name' => 'output_height',
+                                                              'offset' => '320',
+                                                              'type' => '132934'
+                                                            },
+                                                    '29' => {
+                                                              'name' => 'out_color_components',
+                                                              'offset' => '324',
+                                                              'type' => '137'
+                                                            },
+                                                    '3' => {
+                                                             'name' => 'client_data',
+                                                             'offset' => '36',
+                                                             'type' => '71'
+                                                           },
+                                                    '30' => {
+                                                              'name' => 'output_components',
+                                                              'offset' => '328',
+                                                              'type' => '137'
+                                                            },
+                                                    '31' => {
+                                                              'name' => 'rec_outbuf_height',
+                                                              'offset' => '338',
+                                                              'type' => '137'
+                                                            },
+                                                    '32' => {
+                                                              'name' => 'actual_number_of_colors',
+                                                              'offset' => '342',
+                                                              'type' => '137'
+                                                            },
+                                                    '33' => {
+                                                              'name' => 'colormap',
+                                                              'offset' => '352',
+                                                              'type' => '133325'
+                                                            },
+                                                    '34' => {
+                                                              'name' => 'output_scanline',
+                                                              'offset' => '360',
+                                                              'type' => '132934'
+                                                            },
+                                                    '35' => {
+                                                              'name' => 'input_scan_number',
+                                                              'offset' => '370',
+                                                              'type' => '137'
+                                                            },
+                                                    '36' => {
+                                                              'name' => 'input_iMCU_row',
+                                                              'offset' => '374',
+                                                              'type' => '132934'
+                                                            },
+                                                    '37' => {
+                                                              'name' => 'output_scan_number',
+                                                              'offset' => '384',
+                                                              'type' => '137'
+                                                            },
+                                                    '38' => {
+                                                              'name' => 'output_iMCU_row',
+                                                              'offset' => '388',
+                                                              'type' => '132934'
+                                                            },
+                                                    '39' => {
+                                                              'name' => 'coef_bits',
+                                                              'offset' => '402',
+                                                              'type' => '137915'
+                                                            },
+                                                    '4' => {
+                                                             'name' => 'is_decompressor',
+                                                             'offset' => '50',
+                                                             'type' => '132946'
+                                                           },
+                                                    '40' => {
+                                                              'name' => 'quant_tbl_ptrs',
+                                                              'offset' => '512',
+                                                              'type' => '137583'
+                                                            },
+                                                    '41' => {
+                                                              'name' => 'dc_huff_tbl_ptrs',
+                                                              'offset' => '562',
+                                                              'type' => '137599'
+                                                            },
+                                                    '42' => {
+                                                              'name' => 'ac_huff_tbl_ptrs',
+                                                              'offset' => '612',
+                                                              'type' => '137599'
+                                                            },
+                                                    '43' => {
+                                                              'name' => 'data_precision',
+                                                              'offset' => '662',
+                                                              'type' => '137'
+                                                            },
+                                                    '44' => {
+                                                              'name' => 'comp_info',
+                                                              'offset' => '772',
+                                                              'type' => '137577'
+                                                            },
+                                                    '45' => {
+                                                              'name' => 'is_baseline',
+                                                              'offset' => '786',
+                                                              'type' => '132946'
+                                                            },
+                                                    '46' => {
+                                                              'name' => 'progressive_mode',
+                                                              'offset' => '790',
+                                                              'type' => '132946'
+                                                            },
+                                                    '47' => {
+                                                              'name' => 'arith_code',
+                                                              'offset' => '800',
+                                                              'type' => '132946'
+                                                            },
+                                                    '48' => {
+                                                              'name' => 'arith_dc_L',
+                                                              'offset' => '804',
+                                                              'type' => '137621'
+                                                            },
+                                                    '49' => {
+                                                              'name' => 'arith_dc_U',
+                                                              'offset' => '832',
+                                                              'type' => '137621'
+                                                            },
+                                                    '5' => {
+                                                             'name' => 'global_state',
+                                                             'offset' => '54',
+                                                             'type' => '137'
+                                                           },
+                                                    '50' => {
+                                                              'name' => 'arith_ac_K',
+                                                              'offset' => '854',
+                                                              'type' => '137621'
+                                                            },
+                                                    '51' => {
+                                                              'name' => 'restart_interval',
+                                                              'offset' => '882',
+                                                              'type' => '64'
+                                                            },
+                                                    '52' => {
+                                                              'name' => 'saw_JFIF_marker',
+                                                              'offset' => '886',
+                                                              'type' => '132946'
+                                                            },
+                                                    '53' => {
+                                                              'name' => 'JFIF_major_version',
+                                                              'offset' => '896',
+                                                              'type' => '132910'
+                                                            },
+                                                    '54' => {
+                                                              'name' => 'JFIF_minor_version',
+                                                              'offset' => '897',
+                                                              'type' => '132910'
+                                                            },
+                                                    '55' => {
+                                                              'name' => 'density_unit',
+                                                              'offset' => '898',
+                                                              'type' => '132910'
+                                                            },
+                                                    '56' => {
+                                                              'name' => 'X_density',
+                                                              'offset' => '900',
+                                                              'type' => '132922'
+                                                            },
+                                                    '57' => {
+                                                              'name' => 'Y_density',
+                                                              'offset' => '902',
+                                                              'type' => '132922'
+                                                            },
+                                                    '58' => {
+                                                              'name' => 'saw_Adobe_marker',
+                                                              'offset' => '904',
+                                                              'type' => '132946'
+                                                            },
+                                                    '59' => {
+                                                              'name' => 'Adobe_transform',
+                                                              'offset' => '914',
+                                                              'type' => '132910'
+                                                            },
+                                                    '6' => {
+                                                             'name' => 'src',
+                                                             'offset' => '64',
+                                                             'type' => '4925'
+                                                           },
+                                                    '60' => {
+                                                              'name' => 'CCIR601_sampling',
+                                                              'offset' => '918',
+                                                              'type' => '132946'
+                                                            },
+                                                    '61' => {
+                                                              'name' => 'marker_list',
+                                                              'offset' => '1024',
+                                                              'type' => '133997'
+                                                            },
+                                                    '62' => {
+                                                              'name' => 'max_h_samp_factor',
+                                                              'offset' => '1032',
+                                                              'type' => '137'
+                                                            },
+                                                    '63' => {
+                                                              'name' => 'max_v_samp_factor',
+                                                              'offset' => '1042',
+                                                              'type' => '137'
+                                                            },
+                                                    '64' => {
+                                                              'name' => 'min_DCT_h_scaled_size',
+                                                              'offset' => '1046',
+                                                              'type' => '137'
+                                                            },
+                                                    '65' => {
+                                                              'name' => 'min_DCT_v_scaled_size',
+                                                              'offset' => '1056',
+                                                              'type' => '137'
+                                                            },
+                                                    '66' => {
+                                                              'name' => 'total_iMCU_rows',
+                                                              'offset' => '1060',
+                                                              'type' => '132934'
+                                                            },
+                                                    '67' => {
+                                                              'name' => 'sample_range_limit',
+                                                              'offset' => '1074',
+                                                              'type' => '133319'
+                                                            },
+                                                    '68' => {
+                                                              'name' => 'comps_in_scan',
+                                                              'offset' => '1088',
+                                                              'type' => '137'
+                                                            },
+                                                    '69' => {
+                                                              'name' => 'cur_comp_info',
+                                                              'offset' => '1096',
+                                                              'type' => '137643'
+                                                            },
+                                                    '7' => {
+                                                             'name' => 'image_width',
+                                                             'offset' => '72',
+                                                             'type' => '132934'
+                                                           },
+                                                    '70' => {
+                                                              'name' => 'MCUs_per_row',
+                                                              'offset' => '1152',
+                                                              'type' => '132934'
+                                                            },
+                                                    '71' => {
+                                                              'name' => 'MCU_rows_in_scan',
+                                                              'offset' => '1156',
+                                                              'type' => '132934'
+                                                            },
+                                                    '72' => {
+                                                              'name' => 'blocks_in_MCU',
+                                                              'offset' => '1160',
+                                                              'type' => '137'
+                                                            },
+                                                    '73' => {
+                                                              'name' => 'MCU_membership',
+                                                              'offset' => '1170',
+                                                              'type' => '137659'
+                                                            },
+                                                    '74' => {
+                                                              'name' => 'Ss',
+                                                              'offset' => '1330',
+                                                              'type' => '137'
+                                                            },
+                                                    '75' => {
+                                                              'name' => 'Se',
+                                                              'offset' => '1334',
+                                                              'type' => '137'
+                                                            },
+                                                    '76' => {
+                                                              'name' => 'Ah',
+                                                              'offset' => '1344',
+                                                              'type' => '137'
+                                                            },
+                                                    '77' => {
+                                                              'name' => 'Al',
+                                                              'offset' => '1348',
+                                                              'type' => '137'
+                                                            },
+                                                    '78' => {
+                                                              'name' => 'block_size',
+                                                              'offset' => '1352',
+                                                              'type' => '137'
+                                                            },
+                                                    '79' => {
+                                                              'name' => 'natural_order',
+                                                              'offset' => '1362',
+                                                              'type' => '132847'
+                                                            },
+                                                    '8' => {
+                                                             'name' => 'image_height',
+                                                             'offset' => '82',
+                                                             'type' => '132934'
+                                                           },
+                                                    '80' => {
+                                                              'name' => 'lim_Se',
+                                                              'offset' => '1376',
+                                                              'type' => '137'
+                                                            },
+                                                    '81' => {
+                                                              'name' => 'unread_marker',
+                                                              'offset' => '1380',
+                                                              'type' => '137'
+                                                            },
+                                                    '82' => {
+                                                              'name' => 'master',
+                                                              'offset' => '1384',
+                                                              'type' => '137926'
+                                                            },
+                                                    '83' => {
+                                                              'name' => 'main',
+                                                              'offset' => '1398',
+                                                              'type' => '137937'
+                                                            },
+                                                    '84' => {
+                                                              'name' => 'coef',
+                                                              'offset' => '1412',
+                                                              'type' => '137948'
+                                                            },
+                                                    '85' => {
+                                                              'name' => 'post',
+                                                              'offset' => '1426',
+                                                              'type' => '137959'
+                                                            },
+                                                    '86' => {
+                                                              'name' => 'inputctl',
+                                                              'offset' => '1536',
+                                                              'type' => '137970'
+                                                            },
+                                                    '87' => {
+                                                              'name' => 'marker',
+                                                              'offset' => '1544',
+                                                              'type' => '137981'
+                                                            },
+                                                    '88' => {
+                                                              'name' => 'entropy',
+                                                              'offset' => '1558',
+                                                              'type' => '137992'
+                                                            },
+                                                    '89' => {
+                                                              'name' => 'idct',
+                                                              'offset' => '1572',
+                                                              'type' => '138003'
+                                                            },
+                                                    '9' => {
+                                                             'name' => 'num_components',
+                                                             'offset' => '86',
+                                                             'type' => '137'
+                                                           },
+                                                    '90' => {
+                                                              'name' => 'upsample',
+                                                              'offset' => '1586',
+                                                              'type' => '138014'
+                                                            },
+                                                    '91' => {
+                                                              'name' => 'cconvert',
+                                                              'offset' => '1600',
+                                                              'type' => '138025'
+                                                            },
+                                                    '92' => {
+                                                              'name' => 'cquantize',
+                                                              'offset' => '1608',
+                                                              'type' => '138036'
+                                                            }
+                                                  },
+                                        'Name' => 'struct jpeg_decompress_struct',
+                                        'PrivateABI' => 1,
+                                        'Size' => '656',
+                                        'Type' => 'Struct'
+                                      },
+                          '137' => {
+                                     'Name' => 'int',
+                                     'Size' => '4',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '137577' => {
+                                        'BaseType' => '133868',
+                                        'Name' => 'jpeg_component_info*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137583' => {
+                                        'BaseType' => '133862',
+                                        'Name' => 'JQUANT_TBL*[4]',
+                                        'Size' => '32',
+                                        'Type' => 'Array'
+                                      },
+                          '137599' => {
+                                        'BaseType' => '137615',
+                                        'Name' => 'JHUFF_TBL*[4]',
+                                        'Size' => '32',
+                                        'Type' => 'Array'
+                                      },
+                          '137615' => {
+                                        'BaseType' => '133554',
+                                        'Name' => 'JHUFF_TBL*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137621' => {
+                                        'BaseType' => '132910',
+                                        'Name' => 'UINT8[16]',
+                                        'Size' => '16',
+                                        'Type' => 'Array'
+                                      },
+                          '137643' => {
+                                        'BaseType' => '137577',
+                                        'Name' => 'jpeg_component_info*[4]',
+                                        'Size' => '32',
+                                        'Type' => 'Array'
+                                      },
+                          '137659' => {
+                                        'BaseType' => '137',
+                                        'Name' => 'int[10]',
+                                        'Size' => '40',
+                                        'Type' => 'Array'
+                                      },
+                          '137899' => {
+                                        'BaseType' => '137',
+                                        'Name' => 'int[64]',
+                                        'Size' => '256',
+                                        'Type' => 'Array'
+                                      },
+                          '137915' => {
+                                        'BaseType' => '137899',
+                                        'Name' => 'int[64]*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137921' => {
+                                        'Name' => 'struct jpeg_decomp_master',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137926' => {
+                                        'BaseType' => '137921',
+                                        'Name' => 'struct jpeg_decomp_master*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137932' => {
+                                        'Name' => 'struct jpeg_d_main_controller',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137937' => {
+                                        'BaseType' => '137932',
+                                        'Name' => 'struct jpeg_d_main_controller*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137943' => {
+                                        'Name' => 'struct jpeg_d_coef_controller',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137948' => {
+                                        'BaseType' => '137943',
+                                        'Name' => 'struct jpeg_d_coef_controller*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137954' => {
+                                        'Name' => 'struct jpeg_d_post_controller',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137959' => {
+                                        'BaseType' => '137954',
+                                        'Name' => 'struct jpeg_d_post_controller*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137965' => {
+                                        'Name' => 'struct jpeg_input_controller',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137970' => {
+                                        'BaseType' => '137965',
+                                        'Name' => 'struct jpeg_input_controller*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137976' => {
+                                        'Name' => 'struct jpeg_marker_reader',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137981' => {
+                                        'BaseType' => '137976',
+                                        'Name' => 'struct jpeg_marker_reader*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137987' => {
+                                        'Name' => 'struct jpeg_entropy_decoder',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '137992' => {
+                                        'BaseType' => '137987',
+                                        'Name' => 'struct jpeg_entropy_decoder*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '137998' => {
+                                        'Name' => 'struct jpeg_inverse_dct',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138003' => {
+                                        'BaseType' => '137998',
+                                        'Name' => 'struct jpeg_inverse_dct*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138009' => {
+                                        'Name' => 'struct jpeg_upsampler',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138014' => {
+                                        'BaseType' => '138009',
+                                        'Name' => 'struct jpeg_upsampler*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138020' => {
+                                        'Name' => 'struct jpeg_color_deconverter',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138025' => {
+                                        'BaseType' => '138020',
+                                        'Name' => 'struct jpeg_color_deconverter*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138031' => {
+                                        'Name' => 'struct jpeg_color_quantizer',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138036' => {
+                                        'BaseType' => '138031',
+                                        'Name' => 'struct jpeg_color_quantizer*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138042' => {
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '738',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'i',
+                                                             'offset' => '0',
+                                                             'type' => '138075'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 's',
+                                                             'offset' => '0',
+                                                             'type' => '138091'
+                                                           }
+                                                  },
+                                        'Name' => 'anon-union-jpeglib.h-738',
+                                        'PrivateABI' => 1,
+                                        'Size' => '80',
+                                        'Type' => 'Union'
+                                      },
+                          '138075' => {
+                                        'BaseType' => '137',
+                                        'Name' => 'int[8]',
+                                        'Size' => '32',
+                                        'Type' => 'Array'
+                                      },
+                          '138091' => {
+                                        'BaseType' => '217',
+                                        'Name' => 'char[80]',
+                                        'Size' => '80',
+                                        'Type' => 'Array'
+                                      },
+                          '138118' => {
+                                        'Name' => 'void(*)(j_common_ptr)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            }
+                                                   },
+                                        'Return' => '1',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138140' => {
+                                        'Name' => 'void(*)(j_common_ptr, int)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            }
+                                                   },
+                                        'Return' => '1',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138162' => {
+                                        'Name' => 'void(*)(j_common_ptr, char*)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '211'
+                                                            }
+                                                   },
+                                        'Return' => '1',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138168' => {
+                                        'BaseType' => '132859',
+                                        'Name' => 'char const*const*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138212' => {
+                                        'BaseType' => '132905',
+                                        'Name' => 'JOCTET const*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138229' => {
+                                        'Name' => 'void(*)(j_decompress_ptr)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '136095'
+                                                            }
+                                                   },
+                                        'Return' => '1',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138250' => {
+                                        'Name' => 'boolean(*)(j_decompress_ptr)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '136095'
+                                                            }
+                                                   },
+                                        'Return' => '132946',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138272' => {
+                                        'Name' => 'void(*)(j_decompress_ptr, long)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '136095'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '156'
+                                                            }
+                                                   },
+                                        'Return' => '1',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138298' => {
+                                        'Name' => 'boolean(*)(j_decompress_ptr, int)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '136095'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            }
+                                                   },
+                                        'Return' => '132946',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138304' => {
+                                        'BaseType' => '138317',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '829',
+                                        'Name' => 'jvirt_sarray_ptr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '138317' => {
+                                        'BaseType' => '138323',
+                                        'Name' => 'struct jvirt_sarray_control*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138323' => {
+                                        'Name' => 'struct jvirt_sarray_control',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138328' => {
+                                        'BaseType' => '138341',
+                                        'Header' => 'jpeglib.h',
+                                        'Line' => '830',
+                                        'Name' => 'jvirt_barray_ptr',
+                                        'PrivateABI' => 1,
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '138341' => {
+                                        'BaseType' => '138347',
+                                        'Name' => 'struct jvirt_barray_control*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '138347' => {
+                                        'Name' => 'struct jvirt_barray_control',
+                                        'PrivateABI' => 1,
+                                        'Type' => 'Struct'
+                                      },
+                          '138377' => {
+                                        'Name' => 'void*(*)(j_common_ptr, int, size_t)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '45'
+                                                            }
+                                                   },
+                                        'Return' => '71',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138413' => {
+                                        'Name' => 'JSAMPARRAY(*)(j_common_ptr, int, JDIMENSION, JDIMENSION)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            }
+                                                   },
+                                        'Return' => '133325',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138449' => {
+                                        'Name' => 'JBLOCKARRAY(*)(j_common_ptr, int, JDIMENSION, JDIMENSION)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            }
+                                                   },
+                                        'Return' => '133389',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138495' => {
+                                        'Name' => 'jvirt_sarray_ptr(*)(j_common_ptr, int, boolean, JDIMENSION, JDIMENSION, JDIMENSION)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132946'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '4' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '5' => {
+                                                              'type' => '132934'
+                                                            }
+                                                   },
+                                        'Return' => '138304',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138541' => {
+                                        'Name' => 'jvirt_barray_ptr(*)(j_common_ptr, int, boolean, JDIMENSION, JDIMENSION, JDIMENSION)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '137'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132946'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '4' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '5' => {
+                                                              'type' => '132934'
+                                                            }
+                                                   },
+                                        'Return' => '138328',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138582' => {
+                                        'Name' => 'JSAMPARRAY(*)(j_common_ptr, jvirt_sarray_ptr, JDIMENSION, JDIMENSION, boolean)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '138304'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '4' => {
+                                                              'type' => '132946'
+                                                            }
+                                                   },
+                                        'Return' => '133325',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '138623' => {
+                                        'Name' => 'JBLOCKARRAY(*)(j_common_ptr, jvirt_barray_ptr, JDIMENSION, JDIMENSION, boolean)',
+                                        'Param' => {
+                                                     '0' => {
+                                                              'type' => '134931'
+                                                            },
+                                                     '1' => {
+                                                              'type' => '138328'
+                                                            },
+                                                     '2' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '3' => {
+                                                              'type' => '132934'
+                                                            },
+                                                     '4' => {
+                                                              'type' => '132946'
+                                                            }
+                                                   },
+                                        'Return' => '133389',
+                                        'Size' => '8',
+                                        'Type' => 'FuncPtr'
+                                      },
+                          '1424' => {
+                                      'BaseType' => '1125',
+                                      'Name' => 'Bytef*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1430' => {
+                                      'Name' => 'struct internal_state',
+                                      'PrivateABI' => 1,
+                                      'Type' => 'Struct'
+                                    },
+                          '1435' => {
+                                      'BaseType' => '1430',
+                                      'Name' => 'struct internal_state*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '144' => {
+                                     'BaseType' => '64',
+                                     'Header' => 'types.h',
+                                     'Line' => '42',
+                                     'Name' => '__uint32_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '4',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1441' => {
+                                      'BaseType' => '1228',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '106',
+                                      'Name' => 'z_stream',
+                                      'PrivateABI' => 1,
+                                      'Size' => '112',
+                                      'Type' => 'Typedef'
+                                    },
+                          '14492' => {
+                                       'BaseType' => '1074',
+                                       'Name' => 'uint32_t const',
+                                       'Size' => '4',
+                                       'Type' => 'Const'
+                                     },
+                          '1453' => {
+                                      'BaseType' => '730',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '108',
+                                      'Name' => 'rfbBool',
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '14998' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '152',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'x',
+                                                            'offset' => '0',
+                                                            'type' => '1062'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'y',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'w',
+                                                            'offset' => '4',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'h',
+                                                            'offset' => '6',
+                                                            'type' => '1062'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbRectangle',
+                                       'Size' => '8',
+                                       'Type' => 'Struct'
+                                     },
+                          '15388' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '562',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'nRects',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbFramebufferUpdateMsg',
+                                       'Size' => '4',
+                                       'Type' => 'Struct'
+                                     },
+                          '15438' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '577',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'r',
+                                                            'offset' => '0',
+                                                            'type' => '14998'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'encoding',
+                                                            'offset' => '8',
+                                                            'type' => '1074'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbFramebufferUpdateRectHeader',
+                                       'Size' => '12',
+                                       'Type' => 'Struct'
+                                     },
+                          '156' => {
+                                     'Name' => 'long',
+                                     'Size' => '8',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '15752' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '987',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'firstColour',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'nColours',
+                                                            'offset' => '4',
+                                                            'type' => '1062'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbSetColourMapEntriesMsg',
+                                       'Size' => '6',
+                                       'Type' => 'Struct'
+                                     },
+                          '15790' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '999',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbBellMsg',
+                                       'Size' => '1',
+                                       'Type' => 'Struct'
+                                     },
+                          '15870' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1015',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'pad2',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'length',
+                                                            'offset' => '4',
+                                                            'type' => '1074'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbServerCutTextMsg',
+                                       'Size' => '8',
+                                       'Type' => 'Struct'
+                                     },
+                          '15883' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1026',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'contentType',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'contentParam',
+                                                            'offset' => '2',
+                                                            'type' => '1045'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'pad',
+                                                            'offset' => '3',
+                                                            'type' => '1045'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'size',
+                                                            'offset' => '4',
+                                                            'type' => '1074'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'length',
+                                                            'offset' => '8',
+                                                            'type' => '1074'
+                                                          }
+                                                 },
+                                       'Name' => 'struct _rfbFileTransferMsg',
+                                       'Size' => '12',
+                                       'Type' => 'Struct'
+                                     },
+                          '15982' => {
+                                       'BaseType' => '15883',
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1035',
+                                       'Name' => 'rfbFileTransferMsg',
+                                       'Size' => '12',
+                                       'Type' => 'Typedef'
+                                     },
+                          '15995' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1102',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'pad2',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'length',
+                                                            'offset' => '4',
+                                                            'type' => '1074'
+                                                          }
+                                                 },
+                                       'Name' => 'struct _rfbTextChatMsg',
+                                       'Size' => '8',
+                                       'Type' => 'Struct'
+                                     },
+                          '16066' => {
+                                       'BaseType' => '15995',
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1108',
+                                       'Name' => 'rfbTextChatMsg',
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '16146' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1144',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'version',
+                                                            'offset' => '2',
+                                                            'type' => '1045'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'code',
+                                                            'offset' => '3',
+                                                            'type' => '1045'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbXvpMsg',
+                                       'Size' => '4',
+                                       'Type' => 'Struct'
+                                     },
+                          '16159' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1164',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'numberOfScreens',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad',
+                                                            'offset' => '1',
+                                                            'type' => '16202'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbExtDesktopSizeMsg',
+                                       'Size' => '4',
+                                       'Type' => 'Struct'
+                                     },
+                          '16202' => {
+                                       'BaseType' => '1045',
+                                       'Name' => 'uint8_t[3]',
+                                       'Size' => '3',
+                                       'Type' => 'Array'
+                                     },
+                          '16218' => {
+                                       'BaseType' => '16159',
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1169',
+                                       'Name' => 'rfbExtDesktopSizeMsg',
+                                       'Size' => '4',
+                                       'Type' => 'Typedef'
+                                     },
+                          '163' => {
+                                     'BaseType' => '156',
+                                     'Header' => 'types.h',
+                                     'Line' => '152',
+                                     'Name' => '__off_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1631' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '207',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'bitsPerPixel',
+                                                           'offset' => '0',
+                                                           'type' => '1045'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'depth',
+                                                           'offset' => '1',
+                                                           'type' => '1045'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '19',
+                                                            'type' => '1045'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'pad2',
+                                                            'offset' => '20',
+                                                            'type' => '1062'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'bigEndian',
+                                                           'offset' => '2',
+                                                           'type' => '1045'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'trueColour',
+                                                           'offset' => '3',
+                                                           'type' => '1045'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'redMax',
+                                                           'offset' => '4',
+                                                           'type' => '1062'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'greenMax',
+                                                           'offset' => '6',
+                                                           'type' => '1062'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'blueMax',
+                                                           'offset' => '8',
+                                                           'type' => '1062'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'redShift',
+                                                           'offset' => '16',
+                                                           'type' => '1045'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'greenShift',
+                                                           'offset' => '17',
+                                                           'type' => '1045'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'blueShift',
+                                                           'offset' => '18',
+                                                           'type' => '1045'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbPixelFormat',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '16450' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1220',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'framebufferWidth',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'framebufferHeigth',
+                                                            'offset' => '4',
+                                                            'type' => '1062'
+                                                          }
+                                                 },
+                                       'Name' => 'struct _rfbResizeFrameBufferMsg',
+                                       'Size' => '6',
+                                       'Type' => 'Struct'
+                                     },
+                          '16521' => {
+                                       'BaseType' => '16450',
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1225',
+                                       'Name' => 'rfbResizeFrameBufferMsg',
+                                       'Size' => '6',
+                                       'Type' => 'Typedef'
+                                     },
+                          '16643' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1247',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '1',
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'desktop_w',
+                                                            'offset' => '2',
+                                                            'type' => '1062'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'desktop_h',
+                                                            'offset' => '4',
+                                                            'type' => '1062'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'buffer_w',
+                                                            'offset' => '6',
+                                                            'type' => '1062'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'buffer_h',
+                                                            'offset' => '8',
+                                                            'type' => '1062'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'pad2',
+                                                            'offset' => '16',
+                                                            'type' => '1062'
+                                                          }
+                                                 },
+                                       'Name' => 'struct rfbPalmVNCReSizeFrameBufferMsg',
+                                       'Size' => '12',
+                                       'Type' => 'Struct'
+                                     },
+                          '16805' => {
+                                       'Header' => 'rfbproto.h',
+                                       'Line' => '1270',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1045'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'fu',
+                                                            'offset' => '0',
+                                                            'type' => '15388'
+                                                          },
+                                                   '10' => {
+                                                             'name' => 'eds',
+                                                             'offset' => '0',
+                                                             'type' => '16218'
+                                                           },
+                                                   '2' => {
+                                                            'name' => 'scme',
+                                                            'offset' => '0',
+                                                            'type' => '15752'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'b',
+                                                            'offset' => '0',
+                                                            'type' => '15790'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'sct',
+                                                            'offset' => '0',
+                                                            'type' => '15870'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'rsfb',
+                                                            'offset' => '0',
+                                                            'type' => '16521'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'prsfb',
+                                                            'offset' => '0',
+                                                            'type' => '16643'
+                                                          },
+                                                   '7' => {
+                                                            'name' => 'ft',
+                                                            'offset' => '0',
+                                                            'type' => '15982'
+                                                          },
+                                                   '8' => {
+                                                            'name' => 'tc',
+                                                            'offset' => '0',
+                                                            'type' => '16066'
+                                                          },
+                                                   '9' => {
+                                                            'name' => 'xvp',
+                                                            'offset' => '0',
+                                                            'type' => '16146'
+                                                          }
+                                                 },
+                                       'Name' => 'union rfbServerToClientMsg',
+                                       'Size' => '12',
+                                       'Type' => 'Union'
+                                     },
+                          '1710' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '376',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'framebufferWidth',
+                                                           'offset' => '0',
+                                                           'type' => '1062'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'framebufferHeight',
+                                                           'offset' => '2',
+                                                           'type' => '1062'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'format',
+                                                           'offset' => '4',
+                                                           'type' => '1631'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'nameLength',
+                                                           'offset' => '32',
+                                                           'type' => '1074'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbServerInitMsg',
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '175' => {
+                                     'BaseType' => '156',
+                                     'Header' => 'types.h',
+                                     'Line' => '153',
+                                     'Name' => '__off64_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1762' => {
+                                      'BaseType' => '1045',
+                                      'Name' => 'uint8_t[32]',
+                                      'Size' => '32',
+                                      'Type' => 'Array'
+                                    },
+                          '1778' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '591',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'client2server',
+                                                           'offset' => '0',
+                                                           'type' => '1762'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'server2client',
+                                                           'offset' => '50',
+                                                           'type' => '1762'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbSupportedMessages',
+                                      'Size' => '64',
+                                      'Type' => 'Struct'
+                                    },
+                          '187' => {
+                                     'BaseType' => '156',
+                                     'Header' => 'types.h',
+                                     'Line' => '160',
+                                     'Name' => '__time_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1899' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1171',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'id',
+                                                           'offset' => '0',
+                                                           'type' => '1074'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'x',
+                                                           'offset' => '4',
+                                                           'type' => '1062'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'y',
+                                                           'offset' => '6',
+                                                           'type' => '1062'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'width',
+                                                           'offset' => '8',
+                                                           'type' => '1062'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'height',
+                                                           'offset' => '16',
+                                                           'type' => '1062'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '18',
+                                                           'type' => '1074'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbExtDesktopScreen',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '199' => {
+                                     'BaseType' => '156',
+                                     'Header' => 'types.h',
+                                     'Line' => '162',
+                                     'Name' => '__suseconds_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1993' => {
+                                      'BaseType' => '1899',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1178',
+                                      'Name' => 'rfbExtDesktopScreen',
+                                      'Size' => '16',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2067' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '109',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'file',
+                                                           'offset' => '0',
+                                                           'type' => '717'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'tv',
+                                                           'offset' => '8',
+                                                           'type' => '742'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'readTimestamp',
+                                                           'offset' => '36',
+                                                           'type' => '1453'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'doNotSleep',
+                                                           'offset' => '37',
+                                                           'type' => '1453'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbVNCRec',
+                                      'Size' => '32',
+                                      'Type' => 'Struct'
+                                    },
+                          '20721' => {
+                                       'Header' => 'rfbclient.h',
+                                       'Line' => '679',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'encodings',
+                                                            'offset' => '0',
+                                                            'type' => '10969'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'handleEncoding',
+                                                            'offset' => '8',
+                                                            'type' => '20858'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'handleMessage',
+                                                            'offset' => '22',
+                                                            'type' => '20890'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'next',
+                                                            'offset' => '36',
+                                                            'type' => '20896'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'securityTypes',
+                                                            'offset' => '50',
+                                                            'type' => '20902'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'handleAuthentication',
+                                                            'offset' => '64',
+                                                            'type' => '20928'
+                                                          }
+                                                 },
+                                       'Name' => 'struct _rfbClientProtocolExtension',
+                                       'Size' => '48',
+                                       'Type' => 'Struct'
+                                     },
+                          '2079' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '113',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'tag',
+                                                           'offset' => '0',
+                                                           'type' => '71'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'data',
+                                                           'offset' => '8',
+                                                           'type' => '71'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'next',
+                                                           'offset' => '22',
+                                                           'type' => '2132'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbClientData',
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '20852' => {
+                                       'BaseType' => '15438',
+                                       'Name' => 'rfbFramebufferUpdateRectHeader*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '20858' => {
+                                       'Name' => 'rfbBool(*)(rfbClient*, rfbFramebufferUpdateRectHeader*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '4962'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '20852'
+                                                           }
+                                                  },
+                                       'Return' => '1453',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '20884' => {
+                                       'BaseType' => '16805',
+                                       'Name' => 'rfbServerToClientMsg*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '20890' => {
+                                       'Name' => 'rfbBool(*)(rfbClient*, rfbServerToClientMsg*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '4962'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '20884'
+                                                           }
+                                                  },
+                                       'Return' => '1453',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '20896' => {
+                                       'BaseType' => '20721',
+                                       'Name' => 'struct _rfbClientProtocolExtension*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '20902' => {
+                                       'BaseType' => '14492',
+                                       'Name' => 'uint32_t const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '20928' => {
+                                       'Name' => 'rfbBool(*)(rfbClient*, uint32_t)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '4962'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '1074'
+                                                           }
+                                                  },
+                                       'Return' => '1453',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '20934' => {
+                                       'BaseType' => '20721',
+                                       'Header' => 'rfbclient.h',
+                                       'Line' => '691',
+                                       'Name' => 'rfbClientProtocolExtension',
+                                       'Size' => '48',
+                                       'Type' => 'Typedef'
+                                     },
+                          '21060' => {
+                                       'BaseType' => '20934',
+                                       'Name' => 'rfbClientProtocolExtension*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '211' => {
+                                     'BaseType' => '217',
+                                     'Name' => 'char*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '2132' => {
+                                      'BaseType' => '2079',
+                                      'Name' => 'struct rfbClientData*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2138' => {
+                                      'BaseType' => '2079',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '117',
+                                      'Name' => 'rfbClientData',
+                                      'Size' => '24',
+                                      'Type' => 'Typedef'
+                                    },
+                          '21490' => {
+                                       'Name' => 'double',
+                                       'Size' => '8',
+                                       'Type' => 'Intrinsic'
+                                     },
+                          '217' => {
+                                     'Name' => 'char',
+                                     'Size' => '1',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '224' => {
+                                     'BaseType' => '217',
+                                     'Name' => 'char const',
+                                     'Size' => '1',
+                                     'Type' => 'Const'
+                                   },
+                          '229' => {
+                                     'Header' => 'struct_FILE.h',
+                                     'Line' => '49',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '_flags',
+                                                          'offset' => '0',
+                                                          'type' => '137'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '_IO_read_ptr',
+                                                          'offset' => '8',
+                                                          'type' => '211'
+                                                        },
+                                                 '10' => {
+                                                           'name' => '_IO_backup_base',
+                                                           'offset' => '128',
+                                                           'type' => '211'
+                                                         },
+                                                 '11' => {
+                                                           'name' => '_IO_save_end',
+                                                           'offset' => '136',
+                                                           'type' => '211'
+                                                         },
+                                                 '12' => {
+                                                           'name' => '_markers',
+                                                           'offset' => '150',
+                                                           'type' => '645'
+                                                         },
+                                                 '13' => {
+                                                           'name' => '_chain',
+                                                           'offset' => '260',
+                                                           'type' => '651'
+                                                         },
+                                                 '14' => {
+                                                           'name' => '_fileno',
+                                                           'offset' => '274',
+                                                           'type' => '137'
+                                                         },
+                                                 '15' => {
+                                                           'name' => '_flags2',
+                                                           'offset' => '278',
+                                                           'type' => '137'
+                                                         },
+                                                 '16' => {
+                                                           'name' => '_old_offset',
+                                                           'offset' => '288',
+                                                           'type' => '163'
+                                                         },
+                                                 '17' => {
+                                                           'name' => '_cur_column',
+                                                           'offset' => '296',
+                                                           'type' => '80'
+                                                         },
+                                                 '18' => {
+                                                           'name' => '_vtable_offset',
+                                                           'offset' => '304',
+                                                           'type' => '99'
+                                                         },
+                                                 '19' => {
+                                                           'name' => '_shortbuf',
+                                                           'offset' => '305',
+                                                           'type' => '657'
+                                                         },
+                                                 '2' => {
+                                                          'name' => '_IO_read_end',
+                                                          'offset' => '22',
+                                                          'type' => '211'
+                                                        },
+                                                 '20' => {
+                                                           'name' => '_lock',
+                                                           'offset' => '310',
+                                                           'type' => '673'
+                                                         },
+                                                 '21' => {
+                                                           'name' => '_offset',
+                                                           'offset' => '324',
+                                                           'type' => '175'
+                                                         },
+                                                 '22' => {
+                                                           'name' => '_codecvt',
+                                                           'offset' => '338',
+                                                           'type' => '684'
+                                                         },
+                                                 '23' => {
+                                                           'name' => '_wide_data',
+                                                           'offset' => '352',
+                                                           'type' => '695'
+                                                         },
+                                                 '24' => {
+                                                           'name' => '_freeres_list',
+                                                           'offset' => '360',
+                                                           'type' => '651'
+                                                         },
+                                                 '25' => {
+                                                           'name' => '_freeres_buf',
+                                                           'offset' => '374',
+                                                           'type' => '71'
+                                                         },
+                                                 '26' => {
+                                                           'name' => '__pad5',
+                                                           'offset' => '388',
+                                                           'type' => '45'
+                                                         },
+                                                 '27' => {
+                                                           'name' => '_mode',
+                                                           'offset' => '402',
+                                                           'type' => '137'
+                                                         },
+                                                 '28' => {
+                                                           'name' => '_unused2',
+                                                           'offset' => '406',
+                                                           'type' => '701'
+                                                         },
+                                                 '3' => {
+                                                          'name' => '_IO_read_base',
+                                                          'offset' => '36',
+                                                          'type' => '211'
+                                                        },
+                                                 '4' => {
+                                                          'name' => '_IO_write_base',
+                                                          'offset' => '50',
+                                                          'type' => '211'
+                                                        },
+                                                 '5' => {
+                                                          'name' => '_IO_write_ptr',
+                                                          'offset' => '64',
+                                                          'type' => '211'
+                                                        },
+                                                 '6' => {
+                                                          'name' => '_IO_write_end',
+                                                          'offset' => '72',
+                                                          'type' => '211'
+                                                        },
+                                                 '7' => {
+                                                          'name' => '_IO_buf_base',
+                                                          'offset' => '86',
+                                                          'type' => '211'
+                                                        },
+                                                 '8' => {
+                                                          'name' => '_IO_buf_end',
+                                                          'offset' => '100',
+                                                          'type' => '211'
+                                                        },
+                                                 '9' => {
+                                                          'name' => '_IO_save_base',
+                                                          'offset' => '114',
+                                                          'type' => '211'
+                                                        }
+                                               },
+                                     'Name' => 'struct _IO_FILE',
+                                     'PrivateABI' => 1,
+                                     'Size' => '216',
+                                     'Type' => 'Struct'
+                                   },
+                          '2342' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '139',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'shareDesktop',
+                                                           'offset' => '0',
+                                                           'type' => '1453'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'viewOnly',
+                                                           'offset' => '1',
+                                                           'type' => '1453'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'enableJPEG',
+                                                            'offset' => '64',
+                                                            'type' => '1453'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'useRemoteCursor',
+                                                            'offset' => '65',
+                                                            'type' => '1453'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'palmVNC',
+                                                            'offset' => '66',
+                                                            'type' => '1453'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'scaleSetting',
+                                                            'offset' => '68',
+                                                            'type' => '137'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'encodingsString',
+                                                           'offset' => '8',
+                                                           'type' => '1039'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'useBGR233',
+                                                           'offset' => '22',
+                                                           'type' => '1453'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'nColours',
+                                                           'offset' => '32',
+                                                           'type' => '137'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'forceOwnCmap',
+                                                           'offset' => '36',
+                                                           'type' => '1453'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'forceTrueColour',
+                                                           'offset' => '37',
+                                                           'type' => '1453'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'requestedDepth',
+                                                           'offset' => '40',
+                                                           'type' => '137'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'compressLevel',
+                                                           'offset' => '50',
+                                                           'type' => '137'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'qualityLevel',
+                                                           'offset' => '54',
+                                                           'type' => '137'
+                                                         }
+                                                },
+                                      'Name' => 'struct AppData',
+                                      'Size' => '48',
+                                      'Type' => 'Struct'
+                                    },
+                          '2354' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '145',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'x509CACertFile',
+                                                           'offset' => '0',
+                                                           'type' => '211'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'x509CACrlFile',
+                                                           'offset' => '8',
+                                                           'type' => '211'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'x509ClientCertFile',
+                                                           'offset' => '22',
+                                                           'type' => '211'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'x509ClientKeyFile',
+                                                           'offset' => '36',
+                                                           'type' => '211'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'x509CrlVerifyMode',
+                                                           'offset' => '50',
+                                                           'type' => '1045'
+                                                         }
+                                                },
+                                      'Name' => 'anon-struct-rfbclient.h-145',
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '23594' => {
+                                       'BaseType' => '1631',
+                                       'Name' => 'rfbPixelFormat*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '2429' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '154',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'username',
+                                                           'offset' => '0',
+                                                           'type' => '211'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'password',
+                                                           'offset' => '8',
+                                                           'type' => '211'
+                                                         }
+                                                },
+                                      'Name' => 'anon-struct-rfbclient.h-154',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '2465' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '142',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'x509Credential',
+                                                           'offset' => '0',
+                                                           'type' => '2354'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'userCredential',
+                                                           'offset' => '0',
+                                                           'type' => '2429'
+                                                         }
+                                                },
+                                      'Name' => 'union _rfbCredential',
+                                      'Size' => '40',
+                                      'Type' => 'Union'
+                                    },
+                          '2503' => {
+                                      'BaseType' => '2465',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '159',
+                                      'Name' => 'rfbCredential',
+                                      'Size' => '40',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2515' => {
+                                      'BaseType' => '2527',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '183',
+                                      'Name' => 'HandleTextChatProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2527' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, char*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '211'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '2554' => {
+                                      'BaseType' => '2560',
+                                      'Name' => 'struct _rfbClient*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2560' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '241',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'frameBuffer',
+                                                           'offset' => '0',
+                                                           'type' => '4795'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'width',
+                                                           'offset' => '8',
+                                                           'type' => '137'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'flashPort',
+                                                            'offset' => '256',
+                                                            'type' => '137'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'updateRect',
+                                                            'offset' => '260',
+                                                            'type' => '4737'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'buffer',
+                                                            'offset' => '288',
+                                                            'type' => '4801'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'sock',
+                                                            'offset' => '3175200',
+                                                            'type' => '137'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'canUseCoRRE',
+                                                            'offset' => '3175204',
+                                                            'type' => '1453'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'canUseHextile',
+                                                            'offset' => '3175205',
+                                                            'type' => '1453'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'desktopName',
+                                                            'offset' => '3175208',
+                                                            'type' => '211'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'format',
+                                                            'offset' => '3175222',
+                                                            'type' => '1631'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'si',
+                                                            'offset' => '3175250',
+                                                            'type' => '1710'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'buf',
+                                                            'offset' => '3175286',
+                                                            'type' => '4820'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'height',
+                                                           'offset' => '18',
+                                                           'type' => '137'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'bufoutptr',
+                                                            'offset' => '3233128',
+                                                            'type' => '211'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'buffered',
+                                                            'offset' => '3233142',
+                                                            'type' => '64'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'ultra_buffer_size',
+                                                            'offset' => '3233152',
+                                                            'type' => '137'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'ultra_buffer',
+                                                            'offset' => '3233156',
+                                                            'type' => '211'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'raw_buffer_size',
+                                                            'offset' => '3233170',
+                                                            'type' => '137'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'raw_buffer',
+                                                            'offset' => '3233280',
+                                                            'type' => '211'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'decompStream',
+                                                            'offset' => '3233288',
+                                                            'type' => '1441'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'decompStreamInited',
+                                                            'offset' => '3233568',
+                                                            'type' => '1453'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'zlib_buffer',
+                                                            'offset' => '3233569',
+                                                            'type' => '4837'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'zlibStream',
+                                                            'offset' => '3430184',
+                                                            'type' => '4854'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'endianTest',
+                                                           'offset' => '22',
+                                                           'type' => '137'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'zlibStreamActive',
+                                                            'offset' => '3432822',
+                                                            'type' => '4870'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'cutZeros',
+                                                            'offset' => '3432832',
+                                                            'type' => '1453'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'rectWidth',
+                                                            'offset' => '3432836',
+                                                            'type' => '137'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'rectColors',
+                                                            'offset' => '3432840',
+                                                            'type' => '137'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'tightPalette',
+                                                            'offset' => '3432850',
+                                                            'type' => '4886'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'tightPrevRow',
+                                                            'offset' => '3437078',
+                                                            'type' => '4903'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'jpegError',
+                                                            'offset' => '3511556',
+                                                            'type' => '1453'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'jpegSrcManager',
+                                                            'offset' => '3511570',
+                                                            'type' => '4925'
+                                                          },
+                                                  '38' => {
+                                                            'name' => 'jpegBufferPtr',
+                                                            'offset' => '3511584',
+                                                            'type' => '71'
+                                                          },
+                                                  '39' => {
+                                                            'name' => 'jpegBufferLen',
+                                                            'offset' => '3511592',
+                                                            'type' => '45'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'appData',
+                                                           'offset' => '36',
+                                                           'type' => '2342'
+                                                         },
+                                                  '40' => {
+                                                            'name' => 'rcSource',
+                                                            'offset' => '3511606',
+                                                            'type' => '4795'
+                                                          },
+                                                  '41' => {
+                                                            'name' => 'rcMask',
+                                                            'offset' => '3511620',
+                                                            'type' => '4795'
+                                                          },
+                                                  '42' => {
+                                                            'name' => 'clientData',
+                                                            'offset' => '3511634',
+                                                            'type' => '4931'
+                                                          },
+                                                  '43' => {
+                                                            'name' => 'vncRec',
+                                                            'offset' => '3511648',
+                                                            'type' => '4937'
+                                                          },
+                                                  '44' => {
+                                                            'name' => 'KeyboardLedStateEnabled',
+                                                            'offset' => '3511656',
+                                                            'type' => '137'
+                                                          },
+                                                  '45' => {
+                                                            'name' => 'CurrentKeyboardLedState',
+                                                            'offset' => '3511666',
+                                                            'type' => '137'
+                                                          },
+                                                  '46' => {
+                                                            'name' => 'canHandleNewFBSize',
+                                                            'offset' => '3511670',
+                                                            'type' => '137'
+                                                          },
+                                                  '47' => {
+                                                            'name' => 'HandleTextChat',
+                                                            'offset' => '3511684',
+                                                            'type' => '2515'
+                                                          },
+                                                  '48' => {
+                                                            'name' => 'HandleKeyboardLedState',
+                                                            'offset' => '3511698',
+                                                            'type' => '4078'
+                                                          },
+                                                  '49' => {
+                                                            'name' => 'HandleCursorPos',
+                                                            'offset' => '3511808',
+                                                            'type' => '4117'
+                                                          },
+                                                  '5' => {
+                                                           'name' => 'programName',
+                                                           'offset' => '114',
+                                                           'type' => '1039'
+                                                         },
+                                                  '50' => {
+                                                            'name' => 'SoftCursorLockArea',
+                                                            'offset' => '3511816',
+                                                            'type' => '4160'
+                                                          },
+                                                  '51' => {
+                                                            'name' => 'SoftCursorUnlockScreen',
+                                                            'offset' => '3511830',
+                                                            'type' => '4209'
+                                                          },
+                                                  '52' => {
+                                                            'name' => 'GotFrameBufferUpdate',
+                                                            'offset' => '3511844',
+                                                            'type' => '4238'
+                                                          },
+                                                  '53' => {
+                                                            'name' => 'GetPassword',
+                                                            'offset' => '3511858',
+                                                            'type' => '4262'
+                                                          },
+                                                  '54' => {
+                                                            'name' => 'MallocFrameBuffer',
+                                                            'offset' => '3511872',
+                                                            'type' => '4339'
+                                                          },
+                                                  '55' => {
+                                                            'name' => 'GotXCutText',
+                                                            'offset' => '3511880',
+                                                            'type' => '4372'
+                                                          },
+                                                  '56' => {
+                                                            'name' => 'Bell',
+                                                            'offset' => '3511894',
+                                                            'type' => '4411'
+                                                          },
+                                                  '57' => {
+                                                            'name' => 'GotCursorShape',
+                                                            'offset' => '3511908',
+                                                            'type' => '4423'
+                                                          },
+                                                  '58' => {
+                                                            'name' => 'GotCopyRect',
+                                                            'offset' => '3511922',
+                                                            'type' => '4477'
+                                                          },
+                                                  '59' => {
+                                                            'name' => 'supportedMessages',
+                                                            'offset' => '3511936',
+                                                            'type' => '1778'
+                                                          },
+                                                  '6' => {
+                                                           'name' => 'serverHost',
+                                                           'offset' => '128',
+                                                           'type' => '211'
+                                                         },
+                                                  '60' => {
+                                                            'name' => 'major',
+                                                            'offset' => '3512132',
+                                                            'type' => '137'
+                                                          },
+                                                  '61' => {
+                                                            'name' => 'minor',
+                                                            'offset' => '3512136',
+                                                            'type' => '137'
+                                                          },
+                                                  '62' => {
+                                                            'name' => 'authScheme',
+                                                            'offset' => '3512146',
+                                                            'type' => '1074'
+                                                          },
+                                                  '63' => {
+                                                            'name' => 'subAuthScheme',
+                                                            'offset' => '3512150',
+                                                            'type' => '1074'
+                                                          },
+                                                  '64' => {
+                                                            'name' => 'tlsSession',
+                                                            'offset' => '3512160',
+                                                            'type' => '71'
+                                                          },
+                                                  '65' => {
+                                                            'name' => 'GetCredential',
+                                                            'offset' => '3512168',
+                                                            'type' => '4295'
+                                                          },
+                                                  '66' => {
+                                                            'name' => 'clientAuthSchemes',
+                                                            'offset' => '3512182',
+                                                            'type' => '4943'
+                                                          },
+                                                  '67' => {
+                                                            'name' => 'destHost',
+                                                            'offset' => '3512196',
+                                                            'type' => '211'
+                                                          },
+                                                  '68' => {
+                                                            'name' => 'destPort',
+                                                            'offset' => '3512210',
+                                                            'type' => '137'
+                                                          },
+                                                  '69' => {
+                                                            'name' => 'QoS_DSCP',
+                                                            'offset' => '3512214',
+                                                            'type' => '137'
+                                                          },
+                                                  '7' => {
+                                                           'name' => 'serverPort',
+                                                           'offset' => '136',
+                                                           'type' => '137'
+                                                         },
+                                                  '70' => {
+                                                            'name' => 'HandleXvpMsg',
+                                                            'offset' => '3512320',
+                                                            'type' => '4039'
+                                                          },
+                                                  '71' => {
+                                                            'name' => 'listenSock',
+                                                            'offset' => '3512328',
+                                                            'type' => '137'
+                                                          },
+                                                  '72' => {
+                                                            'name' => 'FinishedFrameBufferUpdate',
+                                                            'offset' => '3512342',
+                                                            'type' => '4250'
+                                                          },
+                                                  '73' => {
+                                                            'name' => 'listenAddress',
+                                                            'offset' => '3512356',
+                                                            'type' => '211'
+                                                          },
+                                                  '74' => {
+                                                            'name' => 'listen6Sock',
+                                                            'offset' => '3512370',
+                                                            'type' => '137'
+                                                          },
+                                                  '75' => {
+                                                            'name' => 'listen6Address',
+                                                            'offset' => '3512384',
+                                                            'type' => '211'
+                                                          },
+                                                  '76' => {
+                                                            'name' => 'listen6Port',
+                                                            'offset' => '3512392',
+                                                            'type' => '137'
+                                                          },
+                                                  '77' => {
+                                                            'name' => 'outputWindow',
+                                                            'offset' => '3512406',
+                                                            'type' => '57'
+                                                          },
+                                                  '78' => {
+                                                            'name' => 'LockWriteToTLS',
+                                                            'offset' => '3512420',
+                                                            'type' => '4713'
+                                                          },
+                                                  '79' => {
+                                                            'name' => 'UnlockWriteToTLS',
+                                                            'offset' => '3512434',
+                                                            'type' => '4725'
+                                                          },
+                                                  '8' => {
+                                                           'name' => 'listenSpecified',
+                                                           'offset' => '146',
+                                                           'type' => '1453'
+                                                         },
+                                                  '80' => {
+                                                            'name' => 'GotFillRect',
+                                                            'offset' => '3512448',
+                                                            'type' => '4536'
+                                                          },
+                                                  '81' => {
+                                                            'name' => 'GotBitmap',
+                                                            'offset' => '3512456',
+                                                            'type' => '4590'
+                                                          },
+                                                  '82' => {
+                                                            'name' => 'GotJpeg',
+                                                            'offset' => '3512470',
+                                                            'type' => '4650'
+                                                          },
+                                                  '83' => {
+                                                            'name' => 'tjhnd',
+                                                            'offset' => '3512580',
+                                                            'type' => '71'
+                                                          },
+                                                  '84' => {
+                                                            'name' => 'connectTimeout',
+                                                            'offset' => '3512594',
+                                                            'type' => '64'
+                                                          },
+                                                  '85' => {
+                                                            'name' => 'readTimeout',
+                                                            'offset' => '3512598',
+                                                            'type' => '64'
+                                                          },
+                                                  '86' => {
+                                                            'name' => 'tlsRwMutex',
+                                                            'offset' => '3512608',
+                                                            'type' => '1027'
+                                                          },
+                                                  '87' => {
+                                                            'name' => 'requestedResize',
+                                                            'offset' => '3512672',
+                                                            'type' => '1453'
+                                                          },
+                                                  '88' => {
+                                                            'name' => 'screen',
+                                                            'offset' => '3512676',
+                                                            'type' => '1993'
+                                                          },
+                                                  '9' => {
+                                                           'name' => 'listenPort',
+                                                           'offset' => '150',
+                                                           'type' => '137'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbClient',
+                                      'Size' => '359984',
+                                      'Type' => 'Struct'
+                                    },
+                          '4039' => {
+                                      'BaseType' => '4051',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '193',
+                                      'Name' => 'HandleXvpMsgProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4051' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, uint8_t, uint8_t)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1045'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '1045'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4078' => {
+                                      'BaseType' => '4090',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '194',
+                                      'Name' => 'HandleKeyboardLedStateProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4090' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4117' => {
+                                      'BaseType' => '4129',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '195',
+                                      'Name' => 'HandleCursorPosProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4129' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClient*, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1453',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4160' => {
+                                      'BaseType' => '4172',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '196',
+                                      'Name' => 'SoftCursorLockAreaProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4172' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4209' => {
+                                      'BaseType' => '4221',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '197',
+                                      'Name' => 'SoftCursorUnlockScreenProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4221' => {
+                                      'Name' => 'void(*)(struct _rfbClient*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4238' => {
+                                      'BaseType' => '4172',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '208',
+                                      'Name' => 'GotFrameBufferUpdateProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4250' => {
+                                      'BaseType' => '4221',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '215',
+                                      'Name' => 'FinishedFrameBufferUpdateProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4262' => {
+                                      'BaseType' => '4274',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '216',
+                                      'Name' => 'GetPasswordProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4274' => {
+                                      'Name' => 'char*(*)(struct _rfbClient*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          }
+                                                 },
+                                      'Return' => '211',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4295' => {
+                                      'BaseType' => '4307',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '217',
+                                      'Name' => 'GetCredentialProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4307' => {
+                                      'Name' => 'rfbCredential*(*)(struct _rfbClient*, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '4333',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4333' => {
+                                      'BaseType' => '2503',
+                                      'Name' => 'rfbCredential*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4339' => {
+                                      'BaseType' => '4351',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '218',
+                                      'Name' => 'MallocFrameBufferProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4351' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClient*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          }
+                                                 },
+                                      'Return' => '1453',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4372' => {
+                                      'BaseType' => '4384',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '219',
+                                      'Name' => 'GotXCutTextProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4384' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, char const*, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1039'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4411' => {
+                                      'BaseType' => '4221',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '220',
+                                      'Name' => 'BellProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4423' => {
+                                      'BaseType' => '4435',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '228',
+                                      'Name' => 'GotCursorShapeProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4435' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, int, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4477' => {
+                                      'BaseType' => '4489',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '229',
+                                      'Name' => 'GotCopyRectProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4489' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, int, int, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '6' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '45' => {
+                                    'BaseType' => '57',
+                                    'Header' => 'stddef.h',
+                                    'Line' => '209',
+                                    'Name' => 'size_t',
+                                    'PrivateABI' => 1,
+                                    'Size' => '8',
+                                    'Type' => 'Typedef'
+                                  },
+                          '4536' => {
+                                      'BaseType' => '4548',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '230',
+                                      'Name' => 'GotFillRectProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4548' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, int, int, int, int, uint32_t)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '1074'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4590' => {
+                                      'BaseType' => '4602',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '231',
+                                      'Name' => 'GotBitmapProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4602' => {
+                                      'Name' => 'void(*)(struct _rfbClient*, uint8_t const*, int, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '4644'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4644' => {
+                                      'BaseType' => '1057',
+                                      'Name' => 'uint8_t const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4650' => {
+                                      'BaseType' => '4662',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '232',
+                                      'Name' => 'GotJpegProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4662' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClient*, uint8_t const*, int, int, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2554'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '4644'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '137'
+                                                          },
+                                                   '6' => {
+                                                            'type' => '137'
+                                                          }
+                                                 },
+                                      'Return' => '1453',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4713' => {
+                                      'BaseType' => '4351',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '233',
+                                      'Name' => 'LockWriteToTLSProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4725' => {
+                                      'BaseType' => '4351',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '234',
+                                      'Name' => 'UnlockWriteToTLSProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4737' => {
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '255',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'x',
+                                                           'offset' => '0',
+                                                           'type' => '137'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'y',
+                                                           'offset' => '4',
+                                                           'type' => '137'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'w',
+                                                           'offset' => '8',
+                                                           'type' => '137'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'h',
+                                                           'offset' => '18',
+                                                           'type' => '137'
+                                                         }
+                                                },
+                                      'Name' => 'anon-struct-rfbclient.h-255',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '4795' => {
+                                      'BaseType' => '1045',
+                                      'Name' => 'uint8_t*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4801' => {
+                                      'BaseType' => '217',
+                                      'Name' => 'char[307200]',
+                                      'Size' => '307200',
+                                      'Type' => 'Array'
+                                    },
+                          '4820' => {
+                                      'BaseType' => '217',
+                                      'Name' => 'char[8192]',
+                                      'Size' => '8192',
+                                      'Type' => 'Array'
+                                    },
+                          '4837' => {
+                                      'BaseType' => '217',
+                                      'Name' => 'char[30000]',
+                                      'Size' => '30000',
+                                      'Type' => 'Array'
+                                    },
+                          '4854' => {
+                                      'BaseType' => '1441',
+                                      'Name' => 'z_stream[4]',
+                                      'Size' => '448',
+                                      'Type' => 'Array'
+                                    },
+                          '4870' => {
+                                      'BaseType' => '1453',
+                                      'Name' => 'rfbBool[4]',
+                                      'Size' => '4',
+                                      'Type' => 'Array'
+                                    },
+                          '4886' => {
+                                      'BaseType' => '217',
+                                      'Name' => 'char[1024]',
+                                      'Size' => '1024',
+                                      'Type' => 'Array'
+                                    },
+                          '4903' => {
+                                      'BaseType' => '1045',
+                                      'Name' => 'uint8_t[12288]',
+                                      'Size' => '12288',
+                                      'Type' => 'Array'
+                                    },
+                          '4920' => {
+                                      'Header' => 'jpeglib.h',
+                                      'Line' => '802',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'next_input_byte',
+                                                           'offset' => '0',
+                                                           'type' => '138212'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'bytes_in_buffer',
+                                                           'offset' => '8',
+                                                           'type' => '45'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'init_source',
+                                                           'offset' => '22',
+                                                           'type' => '138229'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'fill_input_buffer',
+                                                           'offset' => '36',
+                                                           'type' => '138250'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'skip_input_data',
+                                                           'offset' => '50',
+                                                           'type' => '138272'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'resync_to_restart',
+                                                           'offset' => '64',
+                                                           'type' => '138298'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'term_source',
+                                                           'offset' => '72',
+                                                           'type' => '138229'
+                                                         }
+                                                },
+                                      'Name' => 'struct jpeg_source_mgr',
+                                      'PrivateABI' => 1,
+                                      'Size' => '56',
+                                      'Type' => 'Struct'
+                                    },
+                          '4925' => {
+                                      'BaseType' => '4920',
+                                      'Name' => 'struct jpeg_source_mgr*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4931' => {
+                                      'BaseType' => '2138',
+                                      'Name' => 'rfbClientData*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4937' => {
+                                      'BaseType' => '2067',
+                                      'Name' => 'rfbVNCRec*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4943' => {
+                                      'BaseType' => '1074',
+                                      'Name' => 'uint32_t*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4949' => {
+                                      'BaseType' => '2560',
+                                      'Header' => 'rfbclient.h',
+                                      'Line' => '480',
+                                      'Name' => 'rfbClient',
+                                      'Size' => '359984',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4962' => {
+                                      'BaseType' => '4949',
+                                      'Name' => 'rfbClient*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '57' => {
+                                    'Name' => 'unsigned long',
+                                    'Size' => '8',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '620' => {
+                                     'BaseType' => '229',
+                                     'Header' => 'FILE.h',
+                                     'Line' => '7',
+                                     'Name' => 'FILE',
+                                     'PrivateABI' => 1,
+                                     'Size' => '216',
+                                     'Type' => 'Typedef'
+                                   },
+                          '632' => {
+                                     'BaseType' => '1',
+                                     'Header' => 'struct_FILE.h',
+                                     'Line' => '43',
+                                     'Name' => '_IO_lock_t',
+                                     'PrivateABI' => 1,
+                                     'Type' => 'Typedef'
+                                   },
+                          '64' => {
+                                    'Name' => 'unsigned int',
+                                    'Size' => '4',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '640' => {
+                                     'Name' => 'struct _IO_marker',
+                                     'PrivateABI' => 1,
+                                     'Type' => 'Struct'
+                                   },
+                          '645' => {
+                                     'BaseType' => '640',
+                                     'Name' => 'struct _IO_marker*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '651' => {
+                                     'BaseType' => '229',
+                                     'Name' => 'struct _IO_FILE*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '657' => {
+                                     'BaseType' => '217',
+                                     'Name' => 'char[1]',
+                                     'Size' => '1',
+                                     'Type' => 'Array'
+                                   },
+                          '673' => {
+                                     'BaseType' => '632',
+                                     'Name' => '_IO_lock_t*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '679' => {
+                                     'Name' => 'struct _IO_codecvt',
+                                     'PrivateABI' => 1,
+                                     'Type' => 'Struct'
+                                   },
+                          '684' => {
+                                     'BaseType' => '679',
+                                     'Name' => 'struct _IO_codecvt*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '690' => {
+                                     'Name' => 'struct _IO_wide_data',
+                                     'PrivateABI' => 1,
+                                     'Type' => 'Struct'
+                                   },
+                          '695' => {
+                                     'BaseType' => '690',
+                                     'Name' => 'struct _IO_wide_data*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '701' => {
+                                     'BaseType' => '217',
+                                     'Name' => 'char[20]',
+                                     'Size' => '20',
+                                     'Type' => 'Array'
+                                   },
+                          '71' => {
+                                    'BaseType' => '1',
+                                    'Name' => 'void*',
+                                    'Size' => '8',
+                                    'Type' => 'Pointer'
+                                  },
+                          '717' => {
+                                     'BaseType' => '620',
+                                     'Name' => 'FILE*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '73' => {
+                                    'Name' => 'unsigned char',
+                                    'Size' => '1',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '730' => {
+                                     'BaseType' => '87',
+                                     'Header' => 'stdint-intn.h',
+                                     'Line' => '24',
+                                     'Name' => 'int8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '742' => {
+                                     'Header' => 'struct_timeval.h',
+                                     'Line' => '8',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => 'tv_sec',
+                                                          'offset' => '0',
+                                                          'type' => '187'
+                                                        },
+                                                 '1' => {
+                                                          'name' => 'tv_usec',
+                                                          'offset' => '8',
+                                                          'type' => '199'
+                                                        }
+                                               },
+                                     'Name' => 'struct timeval',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Struct'
+                                   },
+                          '789' => {
+                                     'Header' => 'thread-shared-types.h',
+                                     'Line' => '51',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '__prev',
+                                                          'offset' => '0',
+                                                          'type' => '829'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '__next',
+                                                          'offset' => '8',
+                                                          'type' => '829'
+                                                        }
+                                               },
+                                     'Name' => 'struct __pthread_internal_list',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Struct'
+                                   },
+                          '80' => {
+                                    'Name' => 'unsigned short',
+                                    'Size' => '2',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '829' => {
+                                     'BaseType' => '789',
+                                     'Name' => 'struct __pthread_internal_list*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '835' => {
+                                     'BaseType' => '789',
+                                     'Header' => 'thread-shared-types.h',
+                                     'Line' => '55',
+                                     'Name' => '__pthread_list_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Typedef'
+                                   },
+                          '847' => {
+                                     'Header' => 'struct_mutex.h',
+                                     'Line' => '22',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '__lock',
+                                                          'offset' => '0',
+                                                          'type' => '137'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '__count',
+                                                          'offset' => '4',
+                                                          'type' => '64'
+                                                        },
+                                                 '2' => {
+                                                          'name' => '__owner',
+                                                          'offset' => '8',
+                                                          'type' => '137'
+                                                        },
+                                                 '3' => {
+                                                          'name' => '__nusers',
+                                                          'offset' => '18',
+                                                          'type' => '64'
+                                                        },
+                                                 '4' => {
+                                                          'name' => '__kind',
+                                                          'offset' => '22',
+                                                          'type' => '137'
+                                                        },
+                                                 '5' => {
+                                                          'name' => '__spins',
+                                                          'offset' => '32',
+                                                          'type' => '118'
+                                                        },
+                                                 '6' => {
+                                                          'name' => '__elision',
+                                                          'offset' => '34',
+                                                          'type' => '118'
+                                                        },
+                                                 '7' => {
+                                                          'name' => '__list',
+                                                          'offset' => '36',
+                                                          'type' => '835'
+                                                        }
+                                               },
+                                     'Name' => 'struct __pthread_mutex_s',
+                                     'PrivateABI' => 1,
+                                     'Size' => '40',
+                                     'Type' => 'Struct'
+                                   },
+                          '87' => {
+                                    'BaseType' => '99',
+                                    'Header' => 'types.h',
+                                    'Line' => '37',
+                                    'Name' => '__int8_t',
+                                    'PrivateABI' => 1,
+                                    'Size' => '1',
+                                    'Type' => 'Typedef'
+                                  },
+                          '99' => {
+                                    'Name' => 'signed char',
+                                    'Size' => '1',
+                                    'Type' => 'Intrinsic'
+                                  }
+                        },
+          'UndefinedSymbols' => {
+                                  'libvncclient.so.0.9.14' => {
+                                                                '_ITM_deregisterTMCloneTable' => 0,
+                                                                '_ITM_registerTMCloneTable' => 0,
+                                                                '__cxa_finalize@GLIBC_2.2.5' => 0,
+                                                                '__errno_location@GLIBC_2.2.5' => 0,
+                                                                '__fdelt_chk@GLIBC_2.15' => 0,
+                                                                '__fread_chk@GLIBC_2.7' => 0,
+                                                                '__gmon_start__' => 0,
+                                                                '__isoc99_sscanf@GLIBC_2.7' => 0,
+                                                                '__longjmp_chk@GLIBC_2.11' => 0,
+                                                                '__memcpy_chk@GLIBC_2.3.4' => 0,
+                                                                '__read_chk@GLIBC_2.4' => 0,
+                                                                '__snprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '__sprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '__stack_chk_fail@GLIBC_2.4' => 0,
+                                                                '__strcpy_chk@GLIBC_2.3.4' => 0,
+                                                                '__strncat_chk@GLIBC_2.3.4' => 0,
+                                                                '__vfprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '_setjmp@GLIBC_2.2.5' => 0,
+                                                                'accept@GLIBC_2.2.5' => 0,
+                                                                'bind@GLIBC_2.2.5' => 0,
+                                                                'calloc@GLIBC_2.2.5' => 0,
+                                                                'close@GLIBC_2.2.5' => 0,
+                                                                'connect@GLIBC_2.2.5' => 0,
+                                                                'fclose@GLIBC_2.2.5' => 0,
+                                                                'fcntl@GLIBC_2.2.5' => 0,
+                                                                'fflush@GLIBC_2.2.5' => 0,
+                                                                'fgetc@GLIBC_2.2.5' => 0,
+                                                                'fileno@GLIBC_2.2.5' => 0,
+                                                                'fopen@GLIBC_2.2.5' => 0,
+                                                                'fork@GLIBC_2.2.5' => 0,
+                                                                'fputs@GLIBC_2.2.5' => 0,
+                                                                'fread@GLIBC_2.2.5' => 0,
+                                                                'free@GLIBC_2.2.5' => 0,
+                                                                'freeaddrinfo@GLIBC_2.2.5' => 0,
+                                                                'fwrite@GLIBC_2.2.5' => 0,
+                                                                'gai_strerror@GLIBC_2.2.5' => 0,
+                                                                'gcry_cipher_close@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_decrypt@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_encrypt@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_open@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_setkey@GCRYPT_1.6' => 0,
+                                                                'gcry_md_close@GCRYPT_1.6' => 0,
+                                                                'gcry_md_get_algo_dlen@GCRYPT_1.6' => 0,
+                                                                'gcry_md_open@GCRYPT_1.6' => 0,
+                                                                'gcry_md_read@GCRYPT_1.6' => 0,
+                                                                'gcry_md_write@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_new@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_powm@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_print@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_randomize@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_release@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_scan@GCRYPT_1.6' => 0,
+                                                                'gcry_randomize@GCRYPT_1.6' => 0,
+                                                                'getaddrinfo@GLIBC_2.2.5' => 0,
+                                                                'getpeername@GLIBC_2.2.5' => 0,
+                                                                'getsockname@GLIBC_2.2.5' => 0,
+                                                                'getsockopt@GLIBC_2.2.5' => 0,
+                                                                'gnutls_anon_allocate_client_credentials@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_allocate_credentials@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_free_credentials@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_get_peers@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_dh_params@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_verify_function@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_x509_crl_file@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_x509_key_file@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_x509_trust_file@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_type_get@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_verify_peers2@GNUTLS_3_4' => 0,
+                                                                'gnutls_check_version@GNUTLS_3_4' => 0,
+                                                                'gnutls_credentials_set@GNUTLS_3_4' => 0,
+                                                                'gnutls_deinit@GNUTLS_3_4' => 0,
+                                                                'gnutls_dh_params_generate2@GNUTLS_3_4' => 0,
+                                                                'gnutls_dh_params_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_error_is_fatal@GNUTLS_3_4' => 0,
+                                                                'gnutls_global_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_handshake@GNUTLS_3_4' => 0,
+                                                                'gnutls_handshake_set_timeout@GNUTLS_3_4' => 0,
+                                                                'gnutls_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_priority_set_direct@GNUTLS_3_4' => 0,
+                                                                'gnutls_record_recv@GNUTLS_3_4' => 0,
+                                                                'gnutls_record_send@GNUTLS_3_4' => 0,
+                                                                'gnutls_session_get_ptr@GNUTLS_3_4' => 0,
+                                                                'gnutls_session_set_ptr@GNUTLS_3_4' => 0,
+                                                                'gnutls_strerror@GNUTLS_3_4' => 0,
+                                                                'gnutls_system_recv_timeout@GNUTLS_3_4' => 0,
+                                                                'gnutls_transport_set_ptr@GNUTLS_3_4' => 0,
+                                                                'gnutls_transport_set_pull_function@GNUTLS_3_4' => 0,
+                                                                'gnutls_transport_set_pull_timeout_function@GNUTLS_3_4' => 0,
+                                                                'gnutls_transport_set_push_function@GNUTLS_3_4' => 0,
+                                                                'gnutls_x509_crt_check_hostname@GNUTLS_3_4' => 0,
+                                                                'gnutls_x509_crt_deinit@GNUTLS_3_4' => 0,
+                                                                'gnutls_x509_crt_import@GNUTLS_3_4' => 0,
+                                                                'gnutls_x509_crt_init@GNUTLS_3_4' => 0,
+                                                                'inet_addr@GLIBC_2.2.5' => 0,
+                                                                'inflate' => 0,
+                                                                'inflateEnd' => 0,
+                                                                'inflateInit_' => 0,
+                                                                'jpeg_CreateCompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_CreateDecompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_abort_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_abort_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_destroy_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_destroy_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_finish_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_finish_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_read_header@LIBJPEG_8.0' => 0,
+                                                                'jpeg_read_scanlines@LIBJPEG_8.0' => 0,
+                                                                'jpeg_resync_to_restart@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_colorspace@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_defaults@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_quality@LIBJPEG_8.0' => 0,
+                                                                'jpeg_start_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_start_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_std_error@LIBJPEG_8.0' => 0,
+                                                                'jpeg_write_scanlines@LIBJPEG_8.0' => 0,
+                                                                'listen@GLIBC_2.2.5' => 0,
+                                                                'localtime@GLIBC_2.2.5' => 0,
+                                                                'lzo1x_decompress_safe' => 0,
+                                                                'malloc@GLIBC_2.2.5' => 0,
+                                                                'memcpy@GLIBC_2.14' => 0,
+                                                                'memmove@GLIBC_2.2.5' => 0,
+                                                                'memset@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_destroy@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_init@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_lock@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_unlock@GLIBC_2.2.5' => 0,
+                                                                'putenv@GLIBC_2.2.5' => 0,
+                                                                'rand@GLIBC_2.2.5' => 0,
+                                                                'select@GLIBC_2.2.5' => 0,
+                                                                'setbuf@GLIBC_2.2.5' => 0,
+                                                                'setsockopt@GLIBC_2.2.5' => 0,
+                                                                'sleep@GLIBC_2.2.5' => 0,
+                                                                'socket@GLIBC_2.2.5' => 0,
+                                                                'srand@GLIBC_2.2.5' => 0,
+                                                                'stat@GLIBC_2.33' => 0,
+                                                                'stderr@GLIBC_2.2.5' => 0,
+                                                                'stdin@GLIBC_2.2.5' => 0,
+                                                                'strchr@GLIBC_2.2.5' => 0,
+                                                                'strcmp@GLIBC_2.2.5' => 0,
+                                                                'strdup@GLIBC_2.2.5' => 0,
+                                                                'strerror@GLIBC_2.2.5' => 0,
+                                                                'strftime@GLIBC_2.2.5' => 0,
+                                                                'strlen@GLIBC_2.2.5' => 0,
+                                                                'strncasecmp@GLIBC_2.2.5' => 0,
+                                                                'strncmp@GLIBC_2.2.5' => 0,
+                                                                'strncpy@GLIBC_2.2.5' => 0,
+                                                                'strrchr@GLIBC_2.2.5' => 0,
+                                                                'strtol@GLIBC_2.2.5' => 0,
+                                                                'tcgetattr@GLIBC_2.2.5' => 0,
+                                                                'tcsetattr@GLIBC_2.2.5' => 0,
+                                                                'time@GLIBC_2.2.5' => 0,
+                                                                'usleep@GLIBC_2.2.5' => 0,
+                                                                'wait4@GLIBC_2.2.5' => 0,
+                                                                'write@GLIBC_2.2.5' => 0
+                                                              }
+                                },
+          'WordSize' => '8'
+        };

--- a/utils/abi/server-abi-v1.dump
+++ b/utils/abi/server-abi-v1.dump
@@ -1,0 +1,8527 @@
+$VAR1 = {
+          'ABI_DUMPER_VERSION' => '1.2',
+          'ABI_DUMP_VERSION' => '3.5',
+          'Arch' => 'x86_64',
+          'GccVersion' => '11.3.0',
+          'Headers' => {
+                         'rfb.h' => 1,
+                         'rfbproto.h' => 1,
+                         'rfbregion.h' => 1
+                       },
+          'Language' => 'C',
+          'LibraryName' => 'libvncserver.so.0.9.14',
+          'LibraryVersion' => 'v1',
+          'NameSpaces' => {},
+          'Needed' => {
+                        'libc.so.6' => 1,
+                        'libgcrypt.so.20' => 1,
+                        'libgnutls.so.30' => 1,
+                        'libjpeg.so.8' => 1,
+                        'liblzo2.so.2' => 1,
+                        'libpng16.so.16' => 1,
+                        'libz.so.1' => 1
+                      },
+          'PublicABI' => '1',
+          'Sources' => {
+                         'auth.c' => 1,
+                         'cargs.c' => 1,
+                         'corre.c' => 1,
+                         'cursor.c' => 1,
+                         'cutpaste.c' => 1,
+                         'draw.c' => 1,
+                         'font.c' => 1,
+                         'hextile.c' => 1,
+                         'httpd.c' => 1,
+                         'main.c' => 1,
+                         'rfbregion.c' => 1,
+                         'rfbserver.c' => 1,
+                         'rfbtightserver.c' => 1,
+                         'rre.c' => 1,
+                         'selbox.c' => 1,
+                         'sockets.c' => 1,
+                         'stats.c' => 1,
+                         'tight.c' => 1,
+                         'translate.c' => 1,
+                         'ultra.c' => 1,
+                         'vncauth.c' => 1,
+                         'websockets.c' => 1,
+                         'zlib.c' => 1,
+                         'zrle.c' => 1
+                       },
+          'SymbolInfo' => {
+                            '10106' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '797',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'sock',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '9551',
+                                         'ShortName' => 'rfbNewClient',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '534'
+                                       },
+                            '10272' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '845',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbHttpCheckFds',
+                                         'Source' => 'httpd.c',
+                                         'SourceLine' => '156'
+                                       },
+                            '10291' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '764',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'usec',
+                                                               'type' => '259'
+                                                             }
+                                                    },
+                                         'Return' => '240',
+                                         'ShortName' => 'rfbCheckFds',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '344'
+                                       },
+                            '103514' => {
+                                          'Data' => 1,
+                                          'Header' => 'rfb.h',
+                                          'Line' => '754',
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbMaxClientWait',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '101'
+                                        },
+                            '10352' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '757',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbShutdownSockets',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '297'
+                                       },
+                            '10371' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '844',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbHttpShutdownSockets',
+                                         'Source' => 'httpd.c',
+                                         'SourceLine' => '130'
+                                       },
+                            '10417' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '843',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbHttpInitSockets',
+                                         'Source' => 'httpd.c',
+                                         'SourceLine' => '93'
+                                       },
+                            '10436' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '756',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbInitSockets',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '159'
+                                       },
+                            '104424' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '778',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'src',
+                                                                'type' => '1759'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'dst',
+                                                                'type' => '1884'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'webSocketsEncode',
+                                          'Source' => 'websockets.c',
+                                          'SourceLine' => '428'
+                                        },
+                            '10455' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '946',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cursor',
+                                                               'type' => '9614'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbFreeCursor',
+                                         'Source' => 'cursor.c',
+                                         'SourceLine' => '367'
+                                       },
+                            '104791' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '779',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'dst',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'webSocketsDecode',
+                                          'Source' => 'websockets.c',
+                                          'SourceLine' => '434'
+                                        },
+                            '105925' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'port',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'iface',
+                                                                'type' => '2352'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbListenOnUDPPort',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '1185'
+                                        },
+                            '106312' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'host',
+                                                                'type' => '354'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'port',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbConnectToTcpAddr',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '1085'
+                                        },
+                            '10633' => {
+                                         'Header' => 'rfbproto.h',
+                                         'Line' => '1558',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'fname',
+                                                               'type' => '354'
+                                                             }
+                                                    },
+                                         'Return' => '354',
+                                         'ShortName' => 'rfbDecryptPasswdFromFile',
+                                         'Source' => 'vncauth.c',
+                                         'SourceLine' => '123'
+                                       },
+                            '10656' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '789',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbClientListInit',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '154'
+                                       },
+                            '10675' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '837',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSetTranslateFunction',
+                                         'Source' => 'translate.c',
+                                         'SourceLine' => '245'
+                                       },
+                            '10698' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1013',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'argc',
+                                                               'type' => '8704'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'argv',
+                                                               'type' => '1884'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbProcessArguments',
+                                         'Source' => 'cargs.c',
+                                         'SourceLine' => '81'
+                                       },
+                            '107060' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '768',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'port',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'iface',
+                                                                'type' => '1759'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbListenOnTCP6Port',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '1008'
+                                        },
+                            '10763' => {
+                                         'Header' => 'rfbproto.h',
+                                         'Line' => '1560',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'bytes',
+                                                               'type' => '2192'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'passwd',
+                                                               'type' => '354'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbEncryptBytes',
+                                         'Source' => 'vncauth.c',
+                                         'SourceLine' => '184'
+                                       },
+                            '10787' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '759',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbCloseClient',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '546'
+                                       },
+                            '108008' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '767',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'port',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'iface',
+                                                                'type' => '2352'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbListenOnTCPPort',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '974'
+                                        },
+                            '108497' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'str',
+                                                                'type' => '354'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'addr',
+                                                                'type' => '108719'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStringToAddr',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '956'
+                                        },
+                            '10920' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '794',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDecrClientRef',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '130'
+                                       },
+                            '10939' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '805',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'givenUpdateRegion',
+                                                               'type' => '9035'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendFramebufferUpdate',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3108'
+                                       },
+                            '109543' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '762',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'buf',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'timeout',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbPeekExactTimeout',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '757'
+                                        },
+                            '10967' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '793',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbIncrClientRef',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '123'
+                                       },
+                            '110300' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '761',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'buf',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'timeout',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbReadExactTimeout',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '657'
+                                        },
+                            '11048' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '800',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbClientConnectionGone',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '553'
+                                       },
+                            '11117' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '780',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'webSocketsHasDataInBuffer',
+                                         'Source' => 'websockets.c',
+                                         'SourceLine' => '456'
+                                       },
+                            '11140' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '801',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbProcessClientMessage',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '667'
+                                       },
+                            '11159' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '820',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendFileTransferChunk',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1544'
+                                       },
+                            '111815' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              }
+                                                     },
+                                          'Return' => '2501',
+                                          'ShortName' => 'rfbProcessNewConnection',
+                                          'Source' => 'sockets.c',
+                                          'SourceLine' => '474'
+                                        },
+                            '11449' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '53',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'i',
+                                                               'type' => '11467'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnReleaseIterator',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '781'
+                                       },
+                            '11473' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '52',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'i',
+                                                               'type' => '11467'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'r',
+                                                               'type' => '11500'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraRgnIteratorNext',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '741'
+                                       },
+                            '11506' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '51',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 's',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'reverseX',
+                                                               'type' => '2501'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'reverseY',
+                                                               'type' => '2501'
+                                                             }
+                                                    },
+                                         'Return' => '11467',
+                                         'ShortName' => 'sraRgnGetReverseIterator',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '715'
+                                       },
+                            '11544' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '792',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'iterator',
+                                                               'type' => '9577'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbReleaseClientIterator',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '234'
+                                       },
+                            '11563' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '791',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'i',
+                                                               'type' => '9577'
+                                                             }
+                                                    },
+                                         'Return' => '9551',
+                                         'ShortName' => 'rfbClientIteratorNext',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '208'
+                                       },
+                            '11609' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '23',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'x1',
+                                                               'type' => '240'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'y1',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'x2',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'y2',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '11538',
+                                         'ShortName' => 'sraRgnCreateRect',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '520'
+                                       },
+                            '11646' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '26',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11538'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnDestroy',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '545'
+                                       },
+                            '11664' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '28',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'dst',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'src',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraRgnAnd',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '557'
+                                       },
+                            '11697' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '32',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'dst',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'dy',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi',
+                                                    '2' => 'rdx'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnOffset',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '572'
+                                       },
+                            '11725' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '24',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'src',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '11538',
+                                         'ShortName' => 'sraRgnCreateRgn',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '540'
+                                       },
+                            '11747' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '27',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11538'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnMakeEmpty',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '550'
+                                       },
+                            '11765' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '29',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'dst',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'src',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnOr',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '562'
+                                       },
+                            '11788' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '38',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraRgnEmpty',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '682'
+                                       },
+                            '11810' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '790',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '9577',
+                                         'ShortName' => 'rfbGetClientIterator',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '167'
+                                       },
+                            '12203' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'usec',
+                                                               'type' => '259'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'runInBackground',
+                                                               'type' => '2501'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbRunEventLoop',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1347'
+                                       },
+                            '12452' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screenInfo',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbIsActive',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1343'
+                                       },
+                            '12503' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbUpdateClient',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1292'
+                                       },
+                            '126355' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '1' => 'rsi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetEncodingCountRcvd',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '346'
+                                        },
+                            '126441' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '1' => 'rsi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetEncodingCountSent',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '338'
+                                        },
+                            '126527' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '1' => 'rsi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetMessageCountRcvd',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '329'
+                                        },
+                            '126613' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '1' => 'rsi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetMessageCountSent',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '321'
+                                        },
+                            '126699' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetRcvdBytesIfRaw',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '309'
+                                        },
+                            '126791' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetRcvdBytes',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '297'
+                                        },
+                            '126883' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetSentBytesIfRaw',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '285'
+                                        },
+                            '126975' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbStatGetSentBytes',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '273'
+                                        },
+                            '127389' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'byteCount',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'byteIfRaw',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbStatRecordEncodingRcvd',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '233'
+                                        },
+                            '127705' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '1095',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'byteCount',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbStatRecordEncodingSentAdd',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '210'
+                                        },
+                            '127843' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Return' => '126234',
+                                          'ShortName' => 'rfbStatLookupMessage',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '189'
+                                        },
+                            '128035' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              }
+                                                     },
+                                          'Return' => '126234',
+                                          'ShortName' => 'rfbStatLookupEncoding',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '167'
+                                        },
+                            '12889' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1071',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'usec',
+                                                               'type' => '259'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbProcessEvents',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1261'
+                                       },
+                            '13259' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'disconnectClients',
+                                                               'type' => '2501'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbShutdownServer',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1194'
+                                       },
+                            '134284' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'buf',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '354',
+                                          'ShortName' => 'messageNameClient2Server',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '64'
+                                        },
+                            '136197' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'type',
+                                                                'type' => '1794'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'buf',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '354',
+                                          'ShortName' => 'messageNameServer2Client',
+                                          'Source' => 'stats.c',
+                                          'SourceLine' => '46'
+                                        },
+                            '13691' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbInitServerWithPthreadsAndZRLE',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1184'
+                                       },
+                            '13816' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbScreenCleanup',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1149'
+                                       },
+                            '14209' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'framebuffer',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'width',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'height',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'bitsPerSample',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'samplesPerPixel',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'bytesPerPixel',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbNewFramebuffer',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '1065'
+                                       },
+                            '14972' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'argc',
+                                                               'type' => '8704'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'argv',
+                                                               'type' => '1884'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'width',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'height',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'bitsPerSample',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'samplesPerPixel',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'bytesPerPixel',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '8951',
+                                         'ShortName' => 'rfbGetScreen',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '918'
+                                       },
+                            '15897' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1031',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDoNothingWithClient',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '837'
+                                       },
+                            '15943' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1043',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'response',
+                                                               'type' => '1759'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbCheckPasswordByList',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '815'
+                                       },
+                            '16669' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'buttonMask',
+                                                               'type' => '240'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDefaultPtrAddEvent',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '719'
+                                       },
+                            '17033' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbRefuseOnHoldClient',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '707'
+                                       },
+                            '17129' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1061',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbStartOnHoldClient',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '684'
+                                       },
+                            '185509' => {
+                                          'Data' => 1,
+                                          'Header' => 'rfb.h',
+                                          'Line' => '830',
+                                          'Return' => '2501',
+                                          'ShortName' => 'rfbEconomicTranslate',
+                                          'Source' => 'translate.c',
+                                          'SourceLine' => '32'
+                                        },
+                            '186371' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'firstColour',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'nColours',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbSetClientColourMaps',
+                                          'Source' => 'translate.c',
+                                          'SourceLine' => '451'
+                                        },
+                            '20034' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1029',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x1',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y1',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'x2',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'y2',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbMarkRectAsModified',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '429'
+                                       },
+                            '20339' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'modRegion',
+                                                               'type' => '9035'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbMarkRegionAsModified',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '412'
+                                       },
+                            '20621' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x1',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y1',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'x2',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'y2',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'dy',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbScheduleCopyRect',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '405'
+                                       },
+                            '20920' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1026',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x1',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y1',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'x2',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'y2',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'dy',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDoCopyRect',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '398'
+                                       },
+                            '211644' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'str',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'len',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbGotXCutText',
+                                          'Source' => 'cutpaste.c',
+                                          'SourceLine' => '35'
+                                        },
+                            '21219' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'copyRegion',
+                                                               'type' => '9035'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'dy',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDoCopyRegion',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '369'
+                                       },
+                            '21891' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'copyRegion',
+                                                               'type' => '9035'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'dy',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbScheduleCopyRegion',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '280'
+                                       },
+                            '23003' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1021',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'str',
+                                                               'type' => '1759'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbLogPerror',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '266'
+                                       },
+                            '23625' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'enabled',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbLogEnable',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '226'
+                                       },
+                            '23670' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1040',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'extension',
+                                                               'type' => '8904'
+                                                             }
+                                                    },
+                                         'Return' => '169',
+                                         'ShortName' => 'rfbGetExtensionClientData',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '206'
+                                       },
+                            '23787' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1039',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'extension',
+                                                               'type' => '8904'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbDisableExtension',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '185'
+                                       },
+                            '23914' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1037',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'extension',
+                                                               'type' => '8904'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'data',
+                                                               'type' => '169'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbEnableExtension',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '164'
+                                       },
+                            '239199' => {
+                                          'Data' => 1,
+                                          'Header' => 'rfb.h',
+                                          'Line' => '936',
+                                          'Return' => '239183',
+                                          'ShortName' => 'rfbReverseByte',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '209'
+                                        },
+                            '239708' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'c',
+                                                                'type' => '9614'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbSetCursor',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '762'
+                                        },
+                            '24052' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1036',
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbReleaseExtensionIterator',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '159'
+                                       },
+                            '24110' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1035',
+                                         'Return' => '8904',
+                                         'ShortName' => 'rfbGetExtensionIterator',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '148'
+                                       },
+                            '24208' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1034',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'extension',
+                                                               'type' => '8904'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbUnregisterProtocolExtension',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '110'
+                                       },
+                            '242602' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'cursor',
+                                                                'type' => '9614'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbMakeRichCursorFromXCursor',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '469'
+                                        },
+                            '243157' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'cursor',
+                                                                'type' => '9614'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbMakeXCursorFromRichCursor',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '391'
+                                        },
+                            '243882' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'width',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'height',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'alphaSource',
+                                                                'type' => '2192'
+                                                              }
+                                                     },
+                                          'Return' => '354',
+                                          'ShortName' => 'rfbMakeMaskFromAlphaSource',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '325'
+                                        },
+                            '244321' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'width',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'height',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'source',
+                                                                'type' => '354'
+                                                              }
+                                                     },
+                                          'Return' => '354',
+                                          'ShortName' => 'rfbMakeMaskForXCursor',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '297'
+                                        },
+                            '24446' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1033',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'extension',
+                                                               'type' => '8904'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbRegisterProtocolExtension',
+                                         'Source' => 'main.c',
+                                         'SourceLine' => '71'
+                                       },
+                            '244555' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'width',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'height',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'cursorString',
+                                                                'type' => '354'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'maskString',
+                                                                'type' => '354'
+                                                              }
+                                                     },
+                                          'Return' => '9614',
+                                          'ShortName' => 'rfbMakeXCursor',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '254'
+                                        },
+                            '244973' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'width',
+                                                                'type' => '240'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'height',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'bitmap',
+                                                                'type' => '2192'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '2' => 'rdx'
+                                                   },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbConvertLSBCursorBitmapOrMask',
+                                          'Source' => 'cursor.c',
+                                          'SourceLine' => '245'
+                                        },
+                            '255374' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'f',
+                                                                'type' => '255131'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbFreeFont',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '198'
+                                        },
+                            '255469' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'filename',
+                                                                'type' => '354'
+                                                              }
+                                                     },
+                                          'Return' => '255131',
+                                          'ShortName' => 'rfbLoadConsoleFont',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '164'
+                                        },
+                            '255955' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '983',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x1',
+                                                                'type' => '8704'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'y1',
+                                                                'type' => '8704'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'x2',
+                                                                'type' => '8704'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'y2',
+                                                                'type' => '8704'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '4' => 'r8'
+                                                   },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbWholeFontBBox',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '143'
+                                        },
+                            '256112' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'c',
+                                                                'type' => '176'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'x1',
+                                                                'type' => '8704'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'y1',
+                                                                'type' => '8704'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'x2',
+                                                                'type' => '8704'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'y2',
+                                                                'type' => '8704'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '3' => 'rcx',
+                                                     '4' => 'r8',
+                                                     '5' => 'r9'
+                                                   },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbFontBBox',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '131'
+                                        },
+                            '256233' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'c',
+                                                                'type' => '176'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi',
+                                                     '1' => 'rsi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbWidthOfChar',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '126'
+                                        },
+                            '256294' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '979',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'string',
+                                                                'type' => '1759'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbWidthOfString',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '116'
+                                        },
+                            '256381' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '978',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '10' => {
+                                                                 'name' => 'backColour',
+                                                                 'offset' => '32',
+                                                                 'type' => '2525'
+                                                               },
+                                                       '2' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'string',
+                                                                'type' => '1759'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'x1',
+                                                                'type' => '240'
+                                                              },
+                                                       '6' => {
+                                                                'name' => 'y1',
+                                                                'offset' => '0',
+                                                                'type' => '240'
+                                                              },
+                                                       '7' => {
+                                                                'name' => 'x2',
+                                                                'offset' => '8',
+                                                                'type' => '240'
+                                                              },
+                                                       '8' => {
+                                                                'name' => 'y2',
+                                                                'offset' => '16',
+                                                                'type' => '240'
+                                                              },
+                                                       '9' => {
+                                                                'name' => 'colour',
+                                                                'offset' => '24',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbDrawStringWithClip',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '104'
+                                        },
+                            '256653' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '10' => {
+                                                                 'name' => 'bcol',
+                                                                 'type' => '2525'
+                                                               },
+                                                       '2' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'c',
+                                                                'type' => '176'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'x1',
+                                                                'type' => '240'
+                                                              },
+                                                       '6' => {
+                                                                'name' => 'y1',
+                                                                'type' => '240'
+                                                              },
+                                                       '7' => {
+                                                                'name' => 'x2',
+                                                                'offset' => '8',
+                                                                'type' => '240'
+                                                              },
+                                                       '8' => {
+                                                                'name' => 'y2',
+                                                                'offset' => '16',
+                                                                'type' => '240'
+                                                              },
+                                                       '9' => {
+                                                                'name' => 'col',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbDrawCharWithClip',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '48'
+                                        },
+                            '257304' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '975',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'string',
+                                                                'type' => '1759'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'colour',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbDrawString',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '37'
+                                        },
+                            '257495' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'c',
+                                                                'type' => '176'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'col',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbDrawChar',
+                                          'Source' => 'font.c',
+                                          'SourceLine' => '3'
+                                        },
+                            '266482' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 's',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x1',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'y1',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'x2',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'y2',
+                                                                'type' => '240'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'col',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbDrawLine',
+                                          'Source' => 'draw.c',
+                                          'SourceLine' => '31'
+                                        },
+                            '267047' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 's',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'col',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbDrawPixel',
+                                          'Source' => 'draw.c',
+                                          'SourceLine' => '20'
+                                        },
+                            '267346' => {
+                                          'Header' => 'rfb.h',
+                                          'Line' => '992',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 's',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x1',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'y1',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'x2',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'y2',
+                                                                'type' => '240'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'col',
+                                                                'type' => '2525'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbFillRect',
+                                          'Source' => 'draw.c',
+                                          'SourceLine' => '3'
+                                        },
+                            '277139' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'rfbScreen',
+                                                                'type' => '8951'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'font',
+                                                                'type' => '255131'
+                                                              },
+                                                       '10' => {
+                                                                 'name' => 'selChangedHook',
+                                                                 'offset' => '32',
+                                                                 'type' => '276295'
+                                                               },
+                                                       '2' => {
+                                                                'name' => 'list',
+                                                                'type' => '1884'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'x1',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'y1',
+                                                                'type' => '240'
+                                                              },
+                                                       '5' => {
+                                                                'name' => 'x2',
+                                                                'type' => '240'
+                                                              },
+                                                       '6' => {
+                                                                'name' => 'y2',
+                                                                'offset' => '0',
+                                                                'type' => '240'
+                                                              },
+                                                       '7' => {
+                                                                'name' => 'colour',
+                                                                'offset' => '8',
+                                                                'type' => '2525'
+                                                              },
+                                                       '8' => {
+                                                                'name' => 'backColour',
+                                                                'offset' => '16',
+                                                                'type' => '2525'
+                                                              },
+                                                       '9' => {
+                                                                'name' => 'border',
+                                                                'offset' => '24',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbSelectBox',
+                                          'Source' => 'selbox.c',
+                                          'SourceLine' => '203'
+                                        },
+                            '282518' => {
+                                          'Header' => 'rfbproto.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'passwd',
+                                                                'type' => '354'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'fname',
+                                                                'type' => '354'
+                                                              }
+                                                     },
+                                          'Return' => '240',
+                                          'ShortName' => 'rfbEncryptAndStorePasswd',
+                                          'Source' => 'vncauth.c',
+                                          'SourceLine' => '79'
+                                        },
+                            '293430' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'width',
+                                                                'type' => '8704'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'height',
+                                                                'type' => '8704'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'bpp',
+                                                                'type' => '8704'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'argc',
+                                                                'type' => '8704'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'argv',
+                                                                'type' => '1884'
+                                                              }
+                                                     },
+                                          'Return' => '2501',
+                                          'ShortName' => 'rfbProcessSizeArguments',
+                                          'Source' => 'cargs.c',
+                                          'SourceLine' => '244'
+                                        },
+                            '296127' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'argc',
+                                                                'type' => '8704'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'position',
+                                                                'type' => '8704'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'count',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'argv',
+                                                                'type' => '1884'
+                                                              }
+                                                     },
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbPurgeArguments',
+                                          'Source' => 'cargs.c',
+                                          'SourceLine' => '72'
+                                        },
+                            '296345' => {
+                                          'Header' => 'rfb.h',
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbUsage',
+                                          'Source' => 'cargs.c',
+                                          'SourceLine' => '20'
+                                        },
+                            '36238' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '758',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbDisconnectUDPSock',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '538'
+                                       },
+                            '36319' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '915',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingTightPng',
+                                         'Source' => 'tight.c',
+                                         'SourceLine' => '235'
+                                       },
+                            '36362' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '910',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingTight',
+                                         'Source' => 'tight.c',
+                                         'SourceLine' => '224'
+                                       },
+                            '36405' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '954',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingZRLE',
+                                         'Source' => 'zrle.c',
+                                         'SourceLine' => '104'
+                                       },
+                            '36448' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '899',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingZlib',
+                                         'Source' => 'zlib.c',
+                                         'SourceLine' => '241'
+                                       },
+                            '36491' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '881',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingUltra',
+                                         'Source' => 'ultra.c',
+                                         'SourceLine' => '179'
+                                       },
+                            '36534' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '869',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingHextile',
+                                         'Source' => 'hextile.c',
+                                         'SourceLine' => '40'
+                                       },
+                            '36577' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '864',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingCoRRE',
+                                         'Source' => 'corre.c',
+                                         'SourceLine' => '53'
+                                       },
+                            '36620' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '859',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingRRE',
+                                         'Source' => 'rre.c',
+                                         'SourceLine' => '49'
+                                       },
+                            '36663' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '939',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendCursorPos',
+                                         'Source' => 'cursor.c',
+                                         'SourceLine' => '181'
+                                       },
+                            '36686' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '938',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendCursorShape',
+                                         'Source' => 'cursor.c',
+                                         'SourceLine' => '36'
+                                       },
+                            '36709' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '37',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '57',
+                                         'ShortName' => 'sraRgnCountRects',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '676'
+                                       },
+                            '36737' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '908',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '4' => 'r8'
+                                                  },
+                                         'Return' => '240',
+                                         'ShortName' => 'rfbNumCodedRectsTight',
+                                         'Source' => 'tight.c',
+                                         'SourceLine' => '200'
+                                       },
+                            '36831' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '50',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 's',
+                                                               'type' => '11538'
+                                                             }
+                                                    },
+                                         'Return' => '11467',
+                                         'ShortName' => 'sraRgnGetIterator',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '687'
+                                       },
+                            '36966' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '34',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'rect',
+                                                               'type' => '11500'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'flags',
+                                                               'type' => '57'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraRgnPopRect',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '624'
+                                       },
+                            '36998' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '40',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'src',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '11538',
+                                         'ShortName' => 'sraRgnBBox',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '591'
+                                       },
+                            '37845' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1094',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'type',
+                                                               'type' => '1794'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'byteCount',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'byteIfRaw',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbStatRecordEncodingSent',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '220'
+                                       },
+                            '38072' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1097',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'type',
+                                                               'type' => '1794'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'byteCount',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'byteIfRaw',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbStatRecordMessageSent',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '246'
+                                       },
+                            '38220' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '30',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'dst',
+                                                               'type' => '11538'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'src',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraRgnSubtract',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '567'
+                                       },
+                            '38247' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '838',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'firstColour',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'nColours',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSetClientColourMap',
+                                         'Source' => 'translate.c',
+                                         'SourceLine' => '418'
+                                       },
+                            '38303' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1088',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'type',
+                                                               'type' => '1794'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'buf',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '354',
+                                         'ShortName' => 'encodingName',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '93'
+                                       },
+                            '38359' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1098',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'type',
+                                                               'type' => '1794'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'byteCount',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'byteIfRaw',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbStatRecordMessageRcvd',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '259'
+                                       },
+                            '38444' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '851',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbAuthNewClient',
+                                         'Source' => 'auth.c',
+                                         'SourceLine' => '300'
+                                       },
+                            '38496' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '760',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'buf',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '240',
+                                         'ShortName' => 'rfbReadExact',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '741'
+                                       },
+                            '38529' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '853',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbAuthProcessClientMessage',
+                                         'Source' => 'auth.c',
+                                         'SourceLine' => '370'
+                                       },
+                            '38548' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '852',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbProcessClientSecurityType',
+                                         'Source' => 'auth.c',
+                                         'SourceLine' => '332'
+                                       },
+                            '38567' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1100',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbPrintStats',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '377'
+                                       },
+                            '38832' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '763',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'buf',
+                                                               'type' => '1759'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '240',
+                                         'ShortName' => 'rfbWriteExact',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '841'
+                                       },
+                            '38884' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '776',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'webSocketsCheck',
+                                         'Source' => 'websockets.c',
+                                         'SourceLine' => '117'
+                                       },
+                            '38907' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '832',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'table',
+                                                               'type' => '354'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'in',
+                                                               'type' => '9029'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'out',
+                                                               'type' => '9029'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'iptr',
+                                                               'type' => '354'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'optr',
+                                                               'type' => '354'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'bytesBetweenInputLines',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'width',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             },
+                                                      '7' => {
+                                                               'name' => 'height',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbTranslateNone',
+                                         'Source' => 'translate.c',
+                                         'SourceLine' => '225'
+                                       },
+                            '38998' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '22',
+                                         'Return' => '11538',
+                                         'ShortName' => 'sraRgnCreate',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '515'
+                                       },
+                            '39159' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '771',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'sock',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSetNonBlocking',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '1215'
+                                       },
+                            '39349' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '1099',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbResetStats',
+                                         'Source' => 'stats.c',
+                                         'SourceLine' => '358'
+                                       },
+                            '39415' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '765',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'host',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'port',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '240',
+                                         'ShortName' => 'rfbConnect',
+                                         'Source' => 'sockets.c',
+                                         'SourceLine' => '612'
+                                       },
+                            '39593' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '804',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbProcessUDPInput',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '4123'
+                                       },
+                            '40066' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '803',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'sock',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbNewUDPConnection',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '4107'
+                                       },
+                            '40210' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'str',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'fallbackLatin1Str',
+                                                               'type' => '354'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'latin1Len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbSendServerCutTextUTF8',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '4036'
+                                       },
+                            '41225' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '808',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'str',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'len',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbSendServerCutText',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '4004'
+                                       },
+                            '417703' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'buf',
+                                                                'type' => '354'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'compressedLen',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '2501',
+                                          'ShortName' => 'rfbSendCompressedDataTight',
+                                          'Source' => 'tight.c',
+                                          'SourceLine' => '1055'
+                                        },
+                            '41836' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbSendBell',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3978'
+                                       },
+                            '420690' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'x',
+                                                                'type' => '240'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'y',
+                                                                'type' => '240'
+                                                              },
+                                                       '3' => {
+                                                                'name' => 'w',
+                                                                'type' => '240'
+                                                              },
+                                                       '4' => {
+                                                                'name' => 'h',
+                                                                'type' => '240'
+                                                              }
+                                                     },
+                                          'Return' => '2501',
+                                          'ShortName' => 'rfbSendTightHeader',
+                                          'Source' => 'tight.c',
+                                          'SourceLine' => '733'
+                                        },
+                            '42205' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '816',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'firstColour',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'nColours',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendSetColourMapEntries',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3916'
+                                       },
+                            '42776' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '807',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendUpdateBuf',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3895'
+                                       },
+                            '42914' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendExtDesktopSize',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3801'
+                                       },
+                            '43565' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendNewFBSize',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3762'
+                                       },
+                            '43910' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendLastRectMarker',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3731'
+                                       },
+                            '44139' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '806',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'x',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'y',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'w',
+                                                               'type' => '240'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'h',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendRectEncodingRaw',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3653'
+                                       },
+                            '44615' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'reg',
+                                                               'type' => '9035'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'dx',
+                                                               'type' => '240'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'dy',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendCopyRegion',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '3597'
+                                       },
+                            '451654' => {
+                                          'Header' => 'rfb.h',
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbUnregisterTightVNCFileTransferExtension',
+                                          'Source' => 'rfbtightserver.c',
+                                          'SourceLine' => '550'
+                                        },
+                            '451744' => {
+                                          'Header' => 'rfb.h',
+                                          'Return' => '1',
+                                          'ShortName' => 'rfbRegisterTightVNCFileTransferExtension',
+                                          'Source' => 'rfbtightserver.c',
+                                          'SourceLine' => '539'
+                                        },
+                            '511062' => {
+                                          'Header' => 'rfb.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'cl',
+                                                                'type' => '9551'
+                                                              }
+                                                     },
+                                          'Reg' => {
+                                                     '0' => 'rdi'
+                                                   },
+                                          'Return' => '2501',
+                                          'ShortName' => 'webSocketCheckDisconnect',
+                                          'Source' => 'websockets.c',
+                                          'SourceLine' => '446'
+                                        },
+                            '57837' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'contentType',
+                                                               'type' => '1770'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'contentParam',
+                                                               'type' => '1770'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'size',
+                                                               'type' => '1794'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'length',
+                                                               'type' => '1794'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbProcessFileTransfer',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1643'
+                                       },
+                            '62623' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'length',
+                                                               'type' => '1794'
+                                                             }
+                                                    },
+                                         'Return' => '354',
+                                         'ShortName' => 'rfbProcessFileTransferReadBuffer',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1503'
+                                       },
+                            '63016' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'length',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'buffer',
+                                                               'type' => '354'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendDirContent',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1361'
+                                       },
+                            '65344' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'contentType',
+                                                               'type' => '1770'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'contentParam',
+                                                               'type' => '1770'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'size',
+                                                               'type' => '1794'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'length',
+                                                               'type' => '1794'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'buffer',
+                                                               'type' => '1759'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendFileTransferMessage',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1240'
+                                       },
+                            '65937' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'length',
+                                                               'type' => '1794'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'buffer',
+                                                               'type' => '354'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'rfbSendTextChatMessage',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1189'
+                                       },
+                            '67404' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'screen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'fmt',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'type' => '-1'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbSetServerVersionIdentity',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '1104'
+                                       },
+                            '70113' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '802',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'cl',
+                                                               'type' => '9551'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'reason',
+                                                               'type' => '1759'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbClientConnFailed',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '771'
+                                       },
+                            '72481' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '798',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             }
+                                                    },
+                                         'Return' => '9551',
+                                         'ShortName' => 'rfbNewUDPClient',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '541'
+                                       },
+                            '74374' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'major_',
+                                                               'type' => '240'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'minor_',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbSetProtocolVersion',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '283'
+                                       },
+                            '74492' => {
+                                         'Header' => 'rfb.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'host',
+                                                               'type' => '354'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'port',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '9551',
+                                         'ShortName' => 'rfbReverseConnection',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '260'
+                                       },
+                            '74714' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '796',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rfbScreen',
+                                                               'type' => '8951'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'sock',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbNewClientConnection',
+                                         'Source' => 'rfbserver.c',
+                                         'SourceLine' => '247'
+                                       },
+                            '76995' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Line' => '62',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'x',
+                                                               'type' => '8704'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'y',
+                                                               'type' => '8704'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'x2',
+                                                               'type' => '8704'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'y2',
+                                                               'type' => '8704'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'cx',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'cy',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'cx2',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             },
+                                                      '7' => {
+                                                               'name' => 'cy2',
+                                                               'offset' => '8',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '1' => 'rsi',
+                                                    '2' => 'rdx',
+                                                    '3' => 'rcx'
+                                                  },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraClipRect2',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '813'
+                                       },
+                            '77163' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'x',
+                                                               'type' => '8704'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'y',
+                                                               'type' => '8704'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'w',
+                                                               'type' => '8704'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'h',
+                                                               'type' => '8704'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'cx',
+                                                               'type' => '240'
+                                                             },
+                                                      '5' => {
+                                                               'name' => 'cy',
+                                                               'type' => '240'
+                                                             },
+                                                      '6' => {
+                                                               'name' => 'cw',
+                                                               'offset' => '0',
+                                                               'type' => '240'
+                                                             },
+                                                      '7' => {
+                                                               'name' => 'ch',
+                                                               'offset' => '8',
+                                                               'type' => '240'
+                                                             }
+                                                    },
+                                         'Return' => '2501',
+                                         'ShortName' => 'sraClipRect',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '793'
+                                       },
+                            '77345' => {
+                                         'Header' => 'rfbregion.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'rgn',
+                                                               'type' => '11691'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'sraRgnPrint',
+                                         'Source' => 'rfbregion.c',
+                                         'SourceLine' => '788'
+                                       },
+                            '92053' => {
+                                         'Header' => 'rfbproto.h',
+                                         'Line' => '1559',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'bytes',
+                                                               'type' => '2192'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbRandomBytes',
+                                         'Source' => 'vncauth.c',
+                                         'SourceLine' => '162'
+                                       },
+                            '94261' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '855',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'handler',
+                                                               'type' => '91928'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbUnregisterSecurityHandler',
+                                         'Source' => 'auth.c',
+                                         'SourceLine' => '79'
+                                       },
+                            '94370' => {
+                                         'Header' => 'rfb.h',
+                                         'Line' => '854',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'handler',
+                                                               'type' => '91928'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'rfbRegisterSecurityHandler',
+                                         'Source' => 'auth.c',
+                                         'SourceLine' => '49'
+                                       },
+                            '9564' => {
+                                        'Data' => 1,
+                                        'Header' => 'rfb.h',
+                                        'Line' => '741',
+                                        'Return' => '365',
+                                        'ShortName' => 'rfbEndianTest',
+                                        'Source' => 'main.c',
+                                        'SourceLine' => '55'
+                                      },
+                            '9658' => {
+                                        'Data' => 1,
+                                        'Header' => 'rfb.h',
+                                        'Line' => '1020',
+                                        'Return' => '9627',
+                                        'ShortName' => 'rfbLog',
+                                        'Source' => 'main.c',
+                                        'SourceLine' => '263'
+                                      },
+                            '9671' => {
+                                        'Data' => 1,
+                                        'Header' => 'rfb.h',
+                                        'Line' => '1020',
+                                        'Return' => '9627',
+                                        'ShortName' => 'rfbErr',
+                                        'Source' => 'main.c',
+                                        'SourceLine' => '264'
+                                      }
+                          },
+          'SymbolVersion' => {},
+          'Symbols' => {
+                         'libvncserver.so.0.9.14' => {
+                                                       'AddFileListItemInfo' => 1,
+                                                       'ChkFileDownloadErr' => 1,
+                                                       'ChkFileUploadErr' => 1,
+                                                       'ChkFileUploadWriteErr' => 1,
+                                                       'CloseUndoneFileDownload' => 1,
+                                                       'CloseUndoneFileUpload' => 1,
+                                                       'ConvertPath' => 1,
+                                                       'CreateDirectory' => 1,
+                                                       'CreateFileDownloadBlockSizeDataMsg' => 1,
+                                                       'CreateFileDownloadErrMsg' => 1,
+                                                       'CreateFileDownloadZeroSizeDataMsg' => 1,
+                                                       'CreateFileListErrMsg' => 1,
+                                                       'CreateFileListInfo' => 1,
+                                                       'CreateFileListMsg' => 1,
+                                                       'CreateFileUploadErrMsg' => 1,
+                                                       'DB' => -4,
+                                                       'DisplayFileList' => 1,
+                                                       'EnableFileTransfer' => 1,
+                                                       'FileUpdateComplete' => 1,
+                                                       'FreeFileListInfo' => 1,
+                                                       'FreeFileTransferMsg' => 1,
+                                                       'FreeHomeDir' => 1,
+                                                       'GetFileDataAt' => 1,
+                                                       'GetFileDownLoadErrMsg' => 1,
+                                                       'GetFileDownloadLengthErrResponseMsg' => 1,
+                                                       'GetFileDownloadReadDataErrMsg' => 1,
+                                                       'GetFileDownloadResponseMsgInBlocks' => 1,
+                                                       'GetFileListResponseMsg' => 1,
+                                                       'GetFileNameAt' => 1,
+                                                       'GetFileSizeAt' => 1,
+                                                       'GetFileUploadCompressedLevelErrMsg' => 1,
+                                                       'GetFileUploadLengthErrResponseMsg' => 1,
+                                                       'GetFtpRoot' => 1,
+                                                       'GetHomeDir' => 1,
+                                                       'GetSumOfFileNamesLength' => 1,
+                                                       'HandleFileCreateDirRequest' => 1,
+                                                       'HandleFileDownload' => 1,
+                                                       'HandleFileDownloadCancelRequest' => 1,
+                                                       'HandleFileDownloadLengthError' => 1,
+                                                       'HandleFileDownloadRequest' => 1,
+                                                       'HandleFileListRequest' => 1,
+                                                       'HandleFileUpload' => 1,
+                                                       'HandleFileUploadDataRequest' => 1,
+                                                       'HandleFileUploadFailedRequest' => 1,
+                                                       'HandleFileUploadLengthError' => 1,
+                                                       'HandleFileUploadRequest' => 1,
+                                                       'HandleFileUploadWrite' => 1,
+                                                       'InitFileTransfer' => 1,
+                                                       'IsFileTransferEnabled' => 1,
+                                                       'RunFileDownloadThread' => 1,
+                                                       'ScaleX' => 1,
+                                                       'ScaleY' => 1,
+                                                       'SendFileDownloadLengthErrMsg' => 1,
+                                                       'SendFileUploadLengthErrMsg' => 1,
+                                                       'SetFtpRoot' => 1,
+                                                       'TJBUFSIZE' => 1,
+                                                       '__b64_ntop' => 1,
+                                                       '__b64_pton' => 1,
+                                                       'decrypt_rfbdes' => 1,
+                                                       'dh_compute_shared_key' => 1,
+                                                       'dh_generate_keypair' => 1,
+                                                       'encodingName' => 1,
+                                                       'encrypt_aes128ecb' => 1,
+                                                       'encrypt_rfbdes' => 1,
+                                                       'hash_md5' => 1,
+                                                       'hash_sha1' => 1,
+                                                       'hybiDecodeCleanupComplete' => 1,
+                                                       'messageNameClient2Server' => 1,
+                                                       'messageNameServer2Client' => 1,
+                                                       'random_bytes' => 1,
+                                                       'rfbAuthNewClient' => 1,
+                                                       'rfbAuthProcessClientMessage' => 1,
+                                                       'rfbCheckFds' => 1,
+                                                       'rfbCheckPasswordByList' => 1,
+                                                       'rfbClientConnFailed' => 1,
+                                                       'rfbClientConnectionGone' => 1,
+                                                       'rfbClientIteratorHead' => 1,
+                                                       'rfbClientIteratorNext' => 1,
+                                                       'rfbClientListInit' => 1,
+                                                       'rfbClientSendString' => 1,
+                                                       'rfbCloseClient' => 1,
+                                                       'rfbConnect' => 1,
+                                                       'rfbConnectToTcpAddr' => 1,
+                                                       'rfbConvertLSBCursorBitmapOrMask' => 1,
+                                                       'rfbDecrClientRef' => 1,
+                                                       'rfbDecryptPasswdFromFile' => 1,
+                                                       'rfbDefaultPtrAddEvent' => 1,
+                                                       'rfbDisableExtension' => 1,
+                                                       'rfbDisconnectUDPSock' => 1,
+                                                       'rfbDoCopyRect' => 1,
+                                                       'rfbDoCopyRegion' => 1,
+                                                       'rfbDoNothingWithClient' => 1,
+                                                       'rfbDrawChar' => 1,
+                                                       'rfbDrawCharWithClip' => 1,
+                                                       'rfbDrawLine' => 1,
+                                                       'rfbDrawPixel' => 1,
+                                                       'rfbDrawString' => 1,
+                                                       'rfbDrawStringWithClip' => 1,
+                                                       'rfbEconomicTranslate' => -1,
+                                                       'rfbEnableExtension' => 1,
+                                                       'rfbEncryptAndStorePasswd' => 1,
+                                                       'rfbEncryptBytes' => 1,
+                                                       'rfbEncryptBytes2' => 1,
+                                                       'rfbEndianTest' => -1,
+                                                       'rfbErr' => -8,
+                                                       'rfbFilenameTranslate2DOS' => 1,
+                                                       'rfbFilenameTranslate2UNIX' => 1,
+                                                       'rfbFillRect' => 1,
+                                                       'rfbFontBBox' => 1,
+                                                       'rfbFreeCursor' => 1,
+                                                       'rfbFreeFont' => 1,
+                                                       'rfbFreeTightData' => 1,
+                                                       'rfbFreeUltraData' => 1,
+                                                       'rfbFreeZrleData' => 1,
+                                                       'rfbGetClientIterator' => 1,
+                                                       'rfbGetClientIteratorWithClosed' => 1,
+                                                       'rfbGetExtensionClientData' => 1,
+                                                       'rfbGetExtensionIterator' => 1,
+                                                       'rfbGetScreen' => 1,
+                                                       'rfbGetTightClientData' => 1,
+                                                       'rfbGotXCutText' => 1,
+                                                       'rfbHandleSecTypeTight' => 1,
+                                                       'rfbHideCursor' => 1,
+                                                       'rfbHttpCheckFds' => 1,
+                                                       'rfbHttpInitSockets' => 1,
+                                                       'rfbHttpShutdownSockets' => 1,
+                                                       'rfbIncrClientRef' => 1,
+                                                       'rfbInitServerWithPthreadsAndZRLE' => 1,
+                                                       'rfbInitSockets' => 1,
+                                                       'rfbIsActive' => 1,
+                                                       'rfbListenOnTCP6Port' => 1,
+                                                       'rfbListenOnTCPPort' => 1,
+                                                       'rfbListenOnUDPPort' => 1,
+                                                       'rfbLoadConsoleFont' => 1,
+                                                       'rfbLog' => -8,
+                                                       'rfbLogEnable' => 1,
+                                                       'rfbLogPerror' => 1,
+                                                       'rfbMakeMaskForXCursor' => 1,
+                                                       'rfbMakeMaskFromAlphaSource' => 1,
+                                                       'rfbMakeRichCursorFromXCursor' => 1,
+                                                       'rfbMakeXCursor' => 1,
+                                                       'rfbMakeXCursorFromRichCursor' => 1,
+                                                       'rfbMarkRectAsModified' => 1,
+                                                       'rfbMarkRegionAsModified' => 1,
+                                                       'rfbMaxClientWait' => -4,
+                                                       'rfbNewClient' => 1,
+                                                       'rfbNewClientConnection' => 1,
+                                                       'rfbNewFramebuffer' => 1,
+                                                       'rfbNewUDPClient' => 1,
+                                                       'rfbNewUDPConnection' => 1,
+                                                       'rfbNumCodedRectsTight' => 1,
+                                                       'rfbPeekExactTimeout' => 1,
+                                                       'rfbPrintStats' => 1,
+                                                       'rfbProcessArguments' => 1,
+                                                       'rfbProcessClientAuthType' => 1,
+                                                       'rfbProcessClientMessage' => 1,
+                                                       'rfbProcessClientSecurityType' => 1,
+                                                       'rfbProcessClientTunnelingType' => 1,
+                                                       'rfbProcessEvents' => 1,
+                                                       'rfbProcessFileTransfer' => 1,
+                                                       'rfbProcessFileTransferReadBuffer' => 1,
+                                                       'rfbProcessNewConnection' => 1,
+                                                       'rfbProcessSizeArguments' => 1,
+                                                       'rfbProcessUDPInput' => 1,
+                                                       'rfbPurgeArguments' => 1,
+                                                       'rfbRandomBytes' => 1,
+                                                       'rfbReadExact' => 1,
+                                                       'rfbReadExactTimeout' => 1,
+                                                       'rfbRedrawAfterHideCursor' => 1,
+                                                       'rfbRefuseOnHoldClient' => 1,
+                                                       'rfbRegisterProtocolExtension' => 1,
+                                                       'rfbRegisterSecurityHandler' => 1,
+                                                       'rfbRegisterTightVNCFileTransferExtension' => 1,
+                                                       'rfbReleaseClientIterator' => 1,
+                                                       'rfbReleaseExtensionIterator' => 1,
+                                                       'rfbResetStats' => 1,
+                                                       'rfbReverseByte' => -256,
+                                                       'rfbReverseConnection' => 1,
+                                                       'rfbRunEventLoop' => 1,
+                                                       'rfbScaledCorrection' => 1,
+                                                       'rfbScaledScreenAllocate' => 1,
+                                                       'rfbScaledScreenUpdate' => 1,
+                                                       'rfbScaledScreenUpdateRect' => 1,
+                                                       'rfbScalingFind' => 1,
+                                                       'rfbScalingSetup' => 1,
+                                                       'rfbScheduleCopyRect' => 1,
+                                                       'rfbScheduleCopyRegion' => 1,
+                                                       'rfbScreenCleanup' => 1,
+                                                       'rfbSelectBox' => 1,
+                                                       'rfbSendBell' => 1,
+                                                       'rfbSendCompressedDataTight' => 1,
+                                                       'rfbSendCopyRegion' => 1,
+                                                       'rfbSendCursorPos' => 1,
+                                                       'rfbSendCursorShape' => 1,
+                                                       'rfbSendDirContent' => 1,
+                                                       'rfbSendExtDesktopSize' => 1,
+                                                       'rfbSendFileTransferChunk' => 1,
+                                                       'rfbSendFileTransferMessage' => 1,
+                                                       'rfbSendFramebufferUpdate' => 1,
+                                                       'rfbSendInteractionCaps' => 1,
+                                                       'rfbSendKeyboardLedState' => 1,
+                                                       'rfbSendLastRectMarker' => 1,
+                                                       'rfbSendNewFBSize' => 1,
+                                                       'rfbSendNewScaleSize' => 1,
+                                                       'rfbSendRectEncodingCoRRE' => 1,
+                                                       'rfbSendRectEncodingHextile' => 1,
+                                                       'rfbSendRectEncodingRRE' => 1,
+                                                       'rfbSendRectEncodingRaw' => 1,
+                                                       'rfbSendRectEncodingTight' => 1,
+                                                       'rfbSendRectEncodingTightPng' => 1,
+                                                       'rfbSendRectEncodingUltra' => 1,
+                                                       'rfbSendRectEncodingZRLE' => 1,
+                                                       'rfbSendRectEncodingZlib' => 1,
+                                                       'rfbSendServerCutText' => 1,
+                                                       'rfbSendServerCutTextUTF8' => 1,
+                                                       'rfbSendServerIdentity' => 1,
+                                                       'rfbSendSetColourMapEntries' => 1,
+                                                       'rfbSendSupportedEncodings' => 1,
+                                                       'rfbSendSupportedMessages' => 1,
+                                                       'rfbSendTextChatMessage' => 1,
+                                                       'rfbSendTightHeader' => 1,
+                                                       'rfbSendUpdateBuf' => 1,
+                                                       'rfbSendXvp' => 1,
+                                                       'rfbSetClientColourMap' => 1,
+                                                       'rfbSetClientColourMaps' => 1,
+                                                       'rfbSetCursor' => 1,
+                                                       'rfbSetNonBlocking' => 1,
+                                                       'rfbSetProtocolVersion' => 1,
+                                                       'rfbSetServerVersionIdentity' => 1,
+                                                       'rfbSetTranslateFunction' => 1,
+                                                       'rfbShowCursor' => 1,
+                                                       'rfbShutdownServer' => 1,
+                                                       'rfbShutdownSockets' => 1,
+                                                       'rfbStartOnHoldClient' => 1,
+                                                       'rfbStatGetEncodingCountRcvd' => 1,
+                                                       'rfbStatGetEncodingCountSent' => 1,
+                                                       'rfbStatGetMessageCountRcvd' => 1,
+                                                       'rfbStatGetMessageCountSent' => 1,
+                                                       'rfbStatGetRcvdBytes' => 1,
+                                                       'rfbStatGetRcvdBytesIfRaw' => 1,
+                                                       'rfbStatGetSentBytes' => 1,
+                                                       'rfbStatGetSentBytesIfRaw' => 1,
+                                                       'rfbStatLookupEncoding' => 1,
+                                                       'rfbStatLookupMessage' => 1,
+                                                       'rfbStatRecordEncodingRcvd' => 1,
+                                                       'rfbStatRecordEncodingSent' => 1,
+                                                       'rfbStatRecordEncodingSentAdd' => 1,
+                                                       'rfbStatRecordMessageRcvd' => 1,
+                                                       'rfbStatRecordMessageSent' => 1,
+                                                       'rfbStringToAddr' => 1,
+                                                       'rfbTightExtensionClientClose' => 1,
+                                                       'rfbTightExtensionInit' => 1,
+                                                       'rfbTightExtensionMsgHandler' => 1,
+                                                       'rfbTightProcessArg' => 1,
+                                                       'rfbTightUsage' => 1,
+                                                       'rfbTranslateNone' => 1,
+                                                       'rfbUnregisterProtocolExtension' => 1,
+                                                       'rfbUnregisterSecurityHandler' => 1,
+                                                       'rfbUnregisterTightVNCFileTransferExtension' => 1,
+                                                       'rfbUpdateClient' => 1,
+                                                       'rfbUsage' => 1,
+                                                       'rfbWholeFontBBox' => 1,
+                                                       'rfbWidthOfChar' => 1,
+                                                       'rfbWidthOfString' => 1,
+                                                       'rfbWriteExact' => 1,
+                                                       'rfbssl_destroy' => 1,
+                                                       'rfbssl_init' => 1,
+                                                       'rfbssl_init_global' => 1,
+                                                       'rfbssl_log_func' => 1,
+                                                       'rfbssl_peek' => 1,
+                                                       'rfbssl_pending' => 1,
+                                                       'rfbssl_read' => 1,
+                                                       'rfbssl_write' => 1,
+                                                       'sock_set_nonblocking' => 1,
+                                                       'sock_wait_for_connected' => 1,
+                                                       'sraClipRect' => 1,
+                                                       'sraClipRect2' => 1,
+                                                       'sraRgnAnd' => 1,
+                                                       'sraRgnBBox' => 1,
+                                                       'sraRgnCountRects' => 1,
+                                                       'sraRgnCreate' => 1,
+                                                       'sraRgnCreateRect' => 1,
+                                                       'sraRgnCreateRgn' => 1,
+                                                       'sraRgnDestroy' => 1,
+                                                       'sraRgnEmpty' => 1,
+                                                       'sraRgnGetIterator' => 1,
+                                                       'sraRgnGetReverseIterator' => 1,
+                                                       'sraRgnIteratorNext' => 1,
+                                                       'sraRgnMakeEmpty' => 1,
+                                                       'sraRgnOffset' => 1,
+                                                       'sraRgnOr' => 1,
+                                                       'sraRgnPopRect' => 1,
+                                                       'sraRgnPrint' => 1,
+                                                       'sraRgnReleaseIterator' => 1,
+                                                       'sraRgnSubtract' => 1,
+                                                       'sraSpanListDestroy' => 1,
+                                                       'sraSpanListDup' => 1,
+                                                       'tightVncFileTransferExtension' => -72,
+                                                       'tjBufSize' => 1,
+                                                       'tjCompress' => 1,
+                                                       'tjCompress2' => 1,
+                                                       'tjDecompress' => 1,
+                                                       'tjDecompress2' => 1,
+                                                       'tjDecompressHeader' => 1,
+                                                       'tjDecompressHeader2' => 1,
+                                                       'tjDestroy' => 1,
+                                                       'tjGetErrorStr' => 1,
+                                                       'tjGetScalingFactors' => 1,
+                                                       'tjInitCompress' => 1,
+                                                       'tjInitDecompress' => 1,
+                                                       'webSocketCheckDisconnect' => 1,
+                                                       'webSocketsCheck' => 1,
+                                                       'webSocketsDecode' => 1,
+                                                       'webSocketsDecodeHybi' => 1,
+                                                       'webSocketsEncode' => 1,
+                                                       'webSocketsHasDataInBuffer' => 1,
+                                                       'zrleEncodeTile15BE' => 1,
+                                                       'zrleEncodeTile15LE' => 1,
+                                                       'zrleEncodeTile16BE' => 1,
+                                                       'zrleEncodeTile16LE' => 1,
+                                                       'zrleEncodeTile24ABE' => 1,
+                                                       'zrleEncodeTile24ALE' => 1,
+                                                       'zrleEncodeTile24BBE' => 1,
+                                                       'zrleEncodeTile24BLE' => 1,
+                                                       'zrleEncodeTile32BE' => 1,
+                                                       'zrleEncodeTile32LE' => 1,
+                                                       'zrleEncodeTile8NE' => 1,
+                                                       'zrleOutStreamFlush' => 1,
+                                                       'zrleOutStreamFree' => 1,
+                                                       'zrleOutStreamNew' => 1,
+                                                       'zrleOutStreamWriteBytes' => 1,
+                                                       'zrleOutStreamWriteOpaque16' => 1,
+                                                       'zrleOutStreamWriteOpaque24A' => 1,
+                                                       'zrleOutStreamWriteOpaque24B' => 1,
+                                                       'zrleOutStreamWriteOpaque32' => 1,
+                                                       'zrleOutStreamWriteOpaque8' => 1,
+                                                       'zrleOutStreamWriteU8' => 1,
+                                                       'zrlePaletteHelperInit' => 1,
+                                                       'zrlePaletteHelperInsert' => 1,
+                                                       'zrlePaletteHelperLookup' => 1,
+                                                       'zywrleAnalyze15BE' => 1,
+                                                       'zywrleAnalyze15LE' => 1,
+                                                       'zywrleAnalyze16BE' => 1,
+                                                       'zywrleAnalyze16LE' => 1,
+                                                       'zywrleAnalyze32BE' => 1,
+                                                       'zywrleAnalyze32LE' => 1
+                                                     }
+                       },
+          'Target' => 'unix',
+          'TypeInfo' => {
+                          '-1' => {
+                                    'Name' => '...',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '1' => {
+                                   'Name' => 'void',
+                                   'Type' => 'Intrinsic'
+                                 },
+                          '1016' => {
+                                      'BaseType' => '259',
+                                      'Header' => 'select.h',
+                                      'Line' => '49',
+                                      'Name' => '__fd_mask',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1051' => {
+                                      'BaseType' => '1016',
+                                      'Name' => '__fd_mask[16]',
+                                      'Size' => '128',
+                                      'Type' => 'Array'
+                                    },
+                          '1067' => {
+                                      'Header' => 'select.h',
+                                      'Line' => '70',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__fds_bits',
+                                                           'offset' => '0',
+                                                           'type' => '1051'
+                                                         }
+                                                },
+                                      'Name' => 'struct fd_set',
+                                      'PrivateABI' => 1,
+                                      'Size' => '128',
+                                      'Type' => 'Struct'
+                                    },
+                          '1079' => {
+                                      'Header' => 'atomic_wide_counter.h',
+                                      'Line' => '28',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__low',
+                                                           'offset' => '0',
+                                                           'type' => '162'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__high',
+                                                           'offset' => '4',
+                                                           'type' => '162'
+                                                         }
+                                                },
+                                      'Name' => 'anon-struct-atomic_wide_counter.h-28',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '108719' => {
+                                        'BaseType' => '2352',
+                                        'Name' => 'in_addr_t*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '11467' => {
+                                       'BaseType' => '9871',
+                                       'Name' => 'sraRectangleIterator*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1149' => {
+                                      'Name' => 'unsigned long long',
+                                      'Size' => '8',
+                                      'Type' => 'Intrinsic'
+                                    },
+                          '11500' => {
+                                       'BaseType' => '9746',
+                                       'Name' => 'sraRect*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '11538' => {
+                                       'BaseType' => '9758',
+                                       'Name' => 'sraRegion*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1156' => {
+                                      'Header' => 'atomic_wide_counter.h',
+                                      'Line' => '33',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__value64',
+                                                           'offset' => '0',
+                                                           'type' => '1149'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__value32',
+                                                           'offset' => '0',
+                                                           'type' => '1079'
+                                                         }
+                                                },
+                                      'Name' => 'union __atomic_wide_counter',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Union'
+                                    },
+                          '1168' => {
+                                      'Header' => 'thread-shared-types.h',
+                                      'Line' => '51',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__prev',
+                                                           'offset' => '0',
+                                                           'type' => '1208'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__next',
+                                                           'offset' => '8',
+                                                           'type' => '1208'
+                                                         }
+                                                },
+                                      'Name' => 'struct __pthread_internal_list',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '11691' => {
+                                       'BaseType' => '9770',
+                                       'Name' => 'sraRegion const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1208' => {
+                                      'BaseType' => '1168',
+                                      'Name' => 'struct __pthread_internal_list*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1214' => {
+                                      'BaseType' => '1168',
+                                      'Header' => 'thread-shared-types.h',
+                                      'Line' => '55',
+                                      'Name' => '__pthread_list_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1226' => {
+                                      'Header' => 'struct_mutex.h',
+                                      'Line' => '22',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__lock',
+                                                           'offset' => '0',
+                                                           'type' => '240'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__count',
+                                                           'offset' => '4',
+                                                           'type' => '162'
+                                                         },
+                                                  '2' => {
+                                                           'name' => '__owner',
+                                                           'offset' => '8',
+                                                           'type' => '240'
+                                                         },
+                                                  '3' => {
+                                                           'name' => '__nusers',
+                                                           'offset' => '18',
+                                                           'type' => '162'
+                                                         },
+                                                  '4' => {
+                                                           'name' => '__kind',
+                                                           'offset' => '22',
+                                                           'type' => '240'
+                                                         },
+                                                  '5' => {
+                                                           'name' => '__spins',
+                                                           'offset' => '32',
+                                                           'type' => '221'
+                                                         },
+                                                  '6' => {
+                                                           'name' => '__elision',
+                                                           'offset' => '34',
+                                                           'type' => '221'
+                                                         },
+                                                  '7' => {
+                                                           'name' => '__list',
+                                                           'offset' => '36',
+                                                           'type' => '1214'
+                                                         }
+                                                },
+                                      'Name' => 'struct __pthread_mutex_s',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '125037' => {
+                                        'BaseType' => '9224',
+                                        'Header' => 'rfb.h',
+                                        'Line' => '420',
+                                        'Name' => 'rfbStatList',
+                                        'Size' => '40',
+                                        'Type' => 'Typedef'
+                                      },
+                          '126234' => {
+                                        'BaseType' => '125037',
+                                        'Name' => 'rfbStatList*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '1344' => {
+                                      'Header' => 'thread-shared-types.h',
+                                      'Line' => '94',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__wseq',
+                                                           'offset' => '0',
+                                                           'type' => '1156'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__g1_start',
+                                                           'offset' => '8',
+                                                           'type' => '1156'
+                                                         },
+                                                  '2' => {
+                                                           'name' => '__g_refs',
+                                                           'offset' => '22',
+                                                           'type' => '1449'
+                                                         },
+                                                  '3' => {
+                                                           'name' => '__g_size',
+                                                           'offset' => '36',
+                                                           'type' => '1449'
+                                                         },
+                                                  '4' => {
+                                                           'name' => '__g1_orig_size',
+                                                           'offset' => '50',
+                                                           'type' => '162'
+                                                         },
+                                                  '5' => {
+                                                           'name' => '__wrefs',
+                                                           'offset' => '54',
+                                                           'type' => '162'
+                                                         },
+                                                  '6' => {
+                                                           'name' => '__g_signals',
+                                                           'offset' => '64',
+                                                           'type' => '1449'
+                                                         }
+                                                },
+                                      'Name' => 'struct __pthread_cond_s',
+                                      'PrivateABI' => 1,
+                                      'Size' => '48',
+                                      'Type' => 'Struct'
+                                    },
+                          '1449' => {
+                                      'BaseType' => '162',
+                                      'Name' => 'unsigned int[2]',
+                                      'Size' => '8',
+                                      'Type' => 'Array'
+                                    },
+                          '1465' => {
+                                      'BaseType' => '57',
+                                      'Header' => 'pthreadtypes.h',
+                                      'Line' => '27',
+                                      'Name' => 'pthread_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '162' => {
+                                     'Name' => 'unsigned int',
+                                     'Size' => '4',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '1645' => {
+                                      'BaseType' => '365',
+                                      'Name' => 'char[40]',
+                                      'Size' => '40',
+                                      'Type' => 'Array'
+                                    },
+                          '1661' => {
+                                      'Header' => 'pthreadtypes.h',
+                                      'Line' => '72',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__data',
+                                                           'offset' => '0',
+                                                           'type' => '1226'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__size',
+                                                           'offset' => '0',
+                                                           'type' => '1645'
+                                                         },
+                                                  '2' => {
+                                                           'name' => '__align',
+                                                           'offset' => '0',
+                                                           'type' => '259'
+                                                         }
+                                                },
+                                      'Name' => 'union pthread_mutex_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Union'
+                                    },
+                          '169' => {
+                                     'BaseType' => '1',
+                                     'Name' => 'void*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '1719' => {
+                                      'BaseType' => '365',
+                                      'Name' => 'char[48]',
+                                      'Size' => '48',
+                                      'Type' => 'Array'
+                                    },
+                          '1735' => {
+                                      'Header' => 'pthreadtypes.h',
+                                      'Line' => '80',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '__data',
+                                                           'offset' => '0',
+                                                           'type' => '1344'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '__size',
+                                                           'offset' => '0',
+                                                           'type' => '1719'
+                                                         },
+                                                  '2' => {
+                                                           'name' => '__align',
+                                                           'offset' => '0',
+                                                           'type' => '940'
+                                                         }
+                                                },
+                                      'Name' => 'union pthread_cond_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '48',
+                                      'Type' => 'Union'
+                                    },
+                          '1759' => {
+                                      'BaseType' => '372',
+                                      'Name' => 'char const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '176' => {
+                                     'Name' => 'unsigned char',
+                                     'Size' => '1',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '1770' => {
+                                      'BaseType' => '209',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '24',
+                                      'Name' => 'uint8_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1782' => {
+                                      'BaseType' => '228',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '25',
+                                      'Name' => 'uint16_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1794' => {
+                                      'BaseType' => '247',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '26',
+                                      'Name' => 'uint32_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1806' => {
+                                      'BaseType' => '176',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '391',
+                                      'Name' => 'Byte',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1819' => {
+                                      'BaseType' => '162',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '393',
+                                      'Name' => 'uInt',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '183' => {
+                                     'Name' => 'unsigned short',
+                                     'Size' => '2',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '1832' => {
+                                      'BaseType' => '57',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '394',
+                                      'Name' => 'uLong',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1845' => {
+                                      'BaseType' => '1806',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '400',
+                                      'Name' => 'Bytef',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1858' => {
+                                      'BaseType' => '169',
+                                      'Header' => 'zconf.h',
+                                      'Line' => '409',
+                                      'Name' => 'voidpf',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1884' => {
+                                      'BaseType' => '354',
+                                      'Name' => 'char**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1890' => {
+                                      'BaseType' => '1902',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '81',
+                                      'Name' => 'alloc_func',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '190' => {
+                                     'BaseType' => '202',
+                                     'Header' => 'types.h',
+                                     'Line' => '37',
+                                     'Name' => '__int8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1902' => {
+                                      'Name' => 'voidpf(*)(voidpf, uInt, uInt)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '1858'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1819'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '1819'
+                                                          }
+                                                 },
+                                      'Return' => '1858',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '1933' => {
+                                      'BaseType' => '1945',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '82',
+                                      'Name' => 'free_func',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1945' => {
+                                      'Name' => 'void(*)(voidpf, voidpf)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '1858'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1858'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '1967' => {
+                                      'Header' => 'zlib.h',
+                                      'Line' => '86',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'next_in',
+                                                           'offset' => '0',
+                                                           'type' => '2163'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'avail_in',
+                                                           'offset' => '8',
+                                                           'type' => '1819'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'opaque',
+                                                            'offset' => '128',
+                                                            'type' => '1858'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'data_type',
+                                                            'offset' => '136',
+                                                            'type' => '240'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'adler',
+                                                            'offset' => '150',
+                                                            'type' => '1832'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'reserved',
+                                                            'offset' => '260',
+                                                            'type' => '1832'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'total_in',
+                                                           'offset' => '22',
+                                                           'type' => '1832'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'next_out',
+                                                           'offset' => '36',
+                                                           'type' => '2163'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'avail_out',
+                                                           'offset' => '50',
+                                                           'type' => '1819'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'total_out',
+                                                           'offset' => '64',
+                                                           'type' => '1832'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'msg',
+                                                           'offset' => '72',
+                                                           'type' => '354'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'state',
+                                                           'offset' => '86',
+                                                           'type' => '2174'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'zalloc',
+                                                           'offset' => '100',
+                                                           'type' => '1890'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'zfree',
+                                                           'offset' => '114',
+                                                           'type' => '1933'
+                                                         }
+                                                },
+                                      'Name' => 'struct z_stream_s',
+                                      'PrivateABI' => 1,
+                                      'Size' => '112',
+                                      'Type' => 'Struct'
+                                    },
+                          '202' => {
+                                     'Name' => 'signed char',
+                                     'Size' => '1',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '209' => {
+                                     'BaseType' => '176',
+                                     'Header' => 'types.h',
+                                     'Line' => '38',
+                                     'Name' => '__uint8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '2163' => {
+                                      'BaseType' => '1845',
+                                      'Name' => 'Bytef*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2169' => {
+                                      'Name' => 'struct internal_state',
+                                      'PrivateABI' => 1,
+                                      'Type' => 'Struct'
+                                    },
+                          '2174' => {
+                                      'BaseType' => '2169',
+                                      'Name' => 'struct internal_state*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2180' => {
+                                      'BaseType' => '1967',
+                                      'Header' => 'zlib.h',
+                                      'Line' => '106',
+                                      'Name' => 'z_stream',
+                                      'PrivateABI' => 1,
+                                      'Size' => '112',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2192' => {
+                                      'BaseType' => '176',
+                                      'Name' => 'unsigned char*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2198' => {
+                                      'BaseType' => '183',
+                                      'Header' => 'sockaddr.h',
+                                      'Line' => '28',
+                                      'Name' => 'sa_family_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '221' => {
+                                     'Name' => 'short',
+                                     'Size' => '2',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '228' => {
+                                     'BaseType' => '183',
+                                     'Header' => 'types.h',
+                                     'Line' => '40',
+                                     'Name' => '__uint16_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '2',
+                                     'Type' => 'Typedef'
+                                   },
+                          '2335' => {
+                                      'Name' => 'void(*)(int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '2352' => {
+                                      'BaseType' => '1794',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '30',
+                                      'Name' => 'in_addr_t',
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2364' => {
+                                      'Header' => 'in.h',
+                                      'Line' => '31',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 's_addr',
+                                                           'offset' => '0',
+                                                           'type' => '2352'
+                                                         }
+                                                },
+                                      'Name' => 'struct in_addr',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '2391' => {
+                                      'BaseType' => '1782',
+                                      'Header' => 'in.h',
+                                      'Line' => '123',
+                                      'Name' => 'in_port_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '239183' => {
+                                        'BaseType' => '176',
+                                        'Name' => 'unsigned char[256]',
+                                        'Size' => '256',
+                                        'Type' => 'Array'
+                                      },
+                          '240' => {
+                                     'Name' => 'int',
+                                     'Size' => '4',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '2403' => {
+                                      'BaseType' => '1770',
+                                      'Name' => 'uint8_t[16]',
+                                      'Size' => '16',
+                                      'Type' => 'Array'
+                                    },
+                          '2419' => {
+                                      'Header' => 'in.h',
+                                      'Line' => '245',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'sin_family',
+                                                           'offset' => '0',
+                                                           'type' => '2198'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'sin_port',
+                                                           'offset' => '2',
+                                                           'type' => '2391'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'sin_addr',
+                                                           'offset' => '4',
+                                                           'type' => '2364'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'sin_zero',
+                                                           'offset' => '8',
+                                                           'type' => '2485'
+                                                         }
+                                                },
+                                      'Name' => 'struct sockaddr_in',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '247' => {
+                                     'BaseType' => '162',
+                                     'Header' => 'types.h',
+                                     'Line' => '42',
+                                     'Name' => '__uint32_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '4',
+                                     'Type' => 'Typedef'
+                                   },
+                          '2485' => {
+                                      'BaseType' => '176',
+                                      'Name' => 'unsigned char[8]',
+                                      'Size' => '8',
+                                      'Type' => 'Array'
+                                    },
+                          '2501' => {
+                                      'BaseType' => '964',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '108',
+                                      'Name' => 'rfbBool',
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2513' => {
+                                      'BaseType' => '1794',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '122',
+                                      'Name' => 'rfbKeySym',
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2525' => {
+                                      'BaseType' => '1794',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '123',
+                                      'Name' => 'rfbPixel',
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '255088' => {
+                                        'Header' => 'rfb.h',
+                                        'Line' => '964',
+                                        'Memb' => {
+                                                    '0' => {
+                                                             'name' => 'data',
+                                                             'offset' => '0',
+                                                             'type' => '2192'
+                                                           },
+                                                    '1' => {
+                                                             'name' => 'metaData',
+                                                             'offset' => '8',
+                                                             'type' => '8704'
+                                                           }
+                                                  },
+                                        'Name' => 'struct rfbFontData',
+                                        'Size' => '16',
+                                        'Type' => 'Struct'
+                                      },
+                          '255131' => {
+                                        'BaseType' => '255144',
+                                        'Header' => 'rfb.h',
+                                        'Line' => '972',
+                                        'Name' => 'rfbFontDataPtr',
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '255144' => {
+                                        'BaseType' => '255088',
+                                        'Name' => 'struct rfbFontData*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '259' => {
+                                     'Name' => 'long',
+                                     'Size' => '8',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '2703' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '207',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'bitsPerPixel',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'depth',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'pad1',
+                                                            'offset' => '19',
+                                                            'type' => '1770'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'pad2',
+                                                            'offset' => '20',
+                                                            'type' => '1782'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'bigEndian',
+                                                           'offset' => '2',
+                                                           'type' => '1770'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'trueColour',
+                                                           'offset' => '3',
+                                                           'type' => '1770'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'redMax',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'greenMax',
+                                                           'offset' => '6',
+                                                           'type' => '1782'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'blueMax',
+                                                           'offset' => '8',
+                                                           'type' => '1782'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'redShift',
+                                                           'offset' => '16',
+                                                           'type' => '1770'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'greenShift',
+                                                           'offset' => '17',
+                                                           'type' => '1770'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'blueShift',
+                                                           'offset' => '18',
+                                                           'type' => '1770'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbPixelFormat',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '2715' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1026',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'contentType',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'contentParam',
+                                                           'offset' => '2',
+                                                           'type' => '1770'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '3',
+                                                           'type' => '1770'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'size',
+                                                           'offset' => '4',
+                                                           'type' => '1794'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'length',
+                                                           'offset' => '8',
+                                                           'type' => '1794'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbFileTransferMsg',
+                                      'Size' => '12',
+                                      'Type' => 'Struct'
+                                    },
+                          '276295' => {
+                                        'BaseType' => '2335',
+                                        'Header' => 'rfb.h',
+                                        'Line' => '1002',
+                                        'Name' => 'SelectionChangedHookPtr',
+                                        'Size' => '8',
+                                        'Type' => 'Typedef'
+                                      },
+                          '2814' => {
+                                      'BaseType' => '2715',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1035',
+                                      'Name' => 'rfbFileTransferMsg',
+                                      'Size' => '12',
+                                      'Type' => 'Typedef'
+                                    },
+                          '2827' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1102',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad1',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad2',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'length',
+                                                           'offset' => '4',
+                                                           'type' => '1794'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbTextChatMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '2898' => {
+                                      'BaseType' => '2827',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1108',
+                                      'Name' => 'rfbTextChatMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '290' => {
+                                     'BaseType' => '240',
+                                     'Name' => 'int[2]',
+                                     'Size' => '8',
+                                     'Type' => 'Array'
+                                   },
+                          '2978' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1144',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'version',
+                                                           'offset' => '2',
+                                                           'type' => '1770'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'code',
+                                                           'offset' => '3',
+                                                           'type' => '1770'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbXvpMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '2991' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1171',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'id',
+                                                           'offset' => '0',
+                                                           'type' => '1794'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'x',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'y',
+                                                           'offset' => '6',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'width',
+                                                           'offset' => '8',
+                                                           'type' => '1782'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'height',
+                                                           'offset' => '16',
+                                                           'type' => '1782'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '18',
+                                                           'type' => '1794'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbExtDesktopScreen',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '306' => {
+                                     'BaseType' => '259',
+                                     'Header' => 'types.h',
+                                     'Line' => '160',
+                                     'Name' => '__time_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '3098' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1201',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad1',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'width',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'height',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'numberOfScreens',
+                                                           'offset' => '6',
+                                                           'type' => '1770'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'pad2',
+                                                           'offset' => '7',
+                                                           'type' => '1770'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbSetDesktopSizeMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '3197' => {
+                                      'BaseType' => '3098',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1210',
+                                      'Name' => 'rfbSetDesktopSizeMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '3277' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1306',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad1',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad2',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'format',
+                                                           'offset' => '4',
+                                                           'type' => '2703'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbSetPixelFormatMsg',
+                                      'Size' => '20',
+                                      'Type' => 'Struct'
+                                    },
+                          '330' => {
+                                     'BaseType' => '259',
+                                     'Header' => 'types.h',
+                                     'Line' => '162',
+                                     'Name' => '__suseconds_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '3357' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1327',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'firstColour',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'nColours',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbFixColourMapEntriesMsg',
+                                      'Size' => '6',
+                                      'Type' => 'Struct'
+                                    },
+                          '3423' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1343',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'nEncodings',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbSetEncodingsMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '3523' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1361',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'incremental',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'x',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'y',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'w',
+                                                           'offset' => '6',
+                                                           'type' => '1782'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'h',
+                                                           'offset' => '8',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbFramebufferUpdateRequestMsg',
+                                      'Size' => '10',
+                                      'Type' => 'Struct'
+                                    },
+                          '354' => {
+                                     'BaseType' => '365',
+                                     'Name' => 'char*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '3603' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1402',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'down',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'key',
+                                                           'offset' => '4',
+                                                           'type' => '1794'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbKeyEventMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '365' => {
+                                     'Name' => 'char',
+                                     'Size' => '1',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '3679' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1427',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'buttonMask',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'x',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'y',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbPointerEventMsg',
+                                      'Size' => '6',
+                                      'Type' => 'Struct'
+                                    },
+                          '372' => {
+                                     'BaseType' => '365',
+                                     'Name' => 'char const',
+                                     'Size' => '1',
+                                     'Type' => 'Const'
+                                   },
+                          '3759' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1452',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'pad1',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad2',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'length',
+                                                           'offset' => '4',
+                                                           'type' => '1794'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbClientCutTextMsg',
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '3772' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1473',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'scale',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbSetScaleMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '3829' => {
+                                      'BaseType' => '3772',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1477',
+                                      'Name' => 'rfbSetScaleMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '3895' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1493',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'scale',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad2',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbPalmVNCSetScaleFactorMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '3908' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1503',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'status',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pad',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbSetServerInputMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Struct'
+                                    },
+                          '3965' => {
+                                      'BaseType' => '3908',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1507',
+                                      'Name' => 'rfbSetServerInputMsg',
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '3978' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1516',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'status',
+                                                           'offset' => '1',
+                                                           'type' => '1770'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'x',
+                                                           'offset' => '2',
+                                                           'type' => '1782'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'y',
+                                                           'offset' => '4',
+                                                           'type' => '1782'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbSetSWMsg',
+                                      'Size' => '6',
+                                      'Type' => 'Struct'
+                                    },
+                          '4045' => {
+                                      'BaseType' => '3978',
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1521',
+                                      'Name' => 'rfbSetSWMsg',
+                                      'Size' => '6',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4271' => {
+                                      'Header' => 'rfbproto.h',
+                                      'Line' => '1548',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1770'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'spf',
+                                                           'offset' => '0',
+                                                           'type' => '3277'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'sim',
+                                                            'offset' => '0',
+                                                            'type' => '3965'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'ft',
+                                                            'offset' => '0',
+                                                            'type' => '2814'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'sw',
+                                                            'offset' => '0',
+                                                            'type' => '4045'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'tc',
+                                                            'offset' => '0',
+                                                            'type' => '2898'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'xvp',
+                                                            'offset' => '0',
+                                                            'type' => '2978'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'sdm',
+                                                            'offset' => '0',
+                                                            'type' => '3197'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'fcme',
+                                                           'offset' => '0',
+                                                           'type' => '3357'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'se',
+                                                           'offset' => '0',
+                                                           'type' => '3423'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'fur',
+                                                           'offset' => '0',
+                                                           'type' => '3523'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'ke',
+                                                           'offset' => '0',
+                                                           'type' => '3603'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'pe',
+                                                           'offset' => '0',
+                                                           'type' => '3679'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'cct',
+                                                           'offset' => '0',
+                                                           'type' => '3759'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ssc',
+                                                           'offset' => '0',
+                                                           'type' => '3829'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'pssf',
+                                                           'offset' => '0',
+                                                           'type' => '3895'
+                                                         }
+                                                },
+                                      'Name' => 'union rfbClientToServerMsg',
+                                      'Size' => '20',
+                                      'Type' => 'Union'
+                                    },
+                          '4284' => {
+                                      'BaseType' => '4271',
+                                      'Name' => 'rfbClientToServerMsg const',
+                                      'Size' => '20',
+                                      'Type' => 'Const'
+                                    },
+                          '4450' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '91',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'RFB_CLIENT_ACCEPT',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'RFB_CLIENT_ON_HOLD',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'RFB_CLIENT_REFUSE',
+                                                           'value' => '2'
+                                                         }
+                                                },
+                                      'Name' => 'enum rfbNewClientAction',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '4487' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '97',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'RFB_SOCKET_INIT',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'RFB_SOCKET_READY',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'RFB_SOCKET_SHUTDOWN',
+                                                           'value' => '2'
+                                                         }
+                                                },
+                                      'Name' => 'enum rfbSocketState',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '4524' => {
+                                      'BaseType' => '4536',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '103',
+                                      'Name' => 'rfbKbdAddEventProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '4536' => {
+                                      'Name' => 'void(*)(rfbBool, rfbKeySym, struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '2501'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '2513'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '4563' => {
+                                      'BaseType' => '4569',
+                                      'Name' => 'struct _rfbClientRec*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4569' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '425',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'screen',
+                                                           'offset' => '0',
+                                                           'type' => '8951'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'scaledScreen',
+                                                           'offset' => '8',
+                                                           'type' => '8951'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'state',
+                                                            'offset' => '114',
+                                                            'type' => '9393'
+                                                          },
+                                                  '100' => {
+                                                             'name' => 'extClipboardData',
+                                                             'offset' => '328978',
+                                                             'type' => '354'
+                                                           },
+                                                  '101' => {
+                                                             'name' => 'extClipboardDataSize',
+                                                             'offset' => '328992',
+                                                             'type' => '240'
+                                                           },
+                                                  '102' => {
+                                                             'name' => 'tightUsePixelFormat24',
+                                                             'offset' => '328996',
+                                                             'type' => '2501'
+                                                           },
+                                                  '103' => {
+                                                             'name' => 'tightTJ',
+                                                             'offset' => '329000',
+                                                             'type' => '169'
+                                                           },
+                                                  '104' => {
+                                                             'name' => 'tightPngDstDataLen',
+                                                             'offset' => '329014',
+                                                             'type' => '240'
+                                                           },
+                                                  '11' => {
+                                                            'name' => 'reverseConnection',
+                                                            'offset' => '118',
+                                                            'type' => '2501'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'onHold',
+                                                            'offset' => '119',
+                                                            'type' => '2501'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'readyForSetColourMapEntries',
+                                                            'offset' => '120',
+                                                            'type' => '2501'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'useCopyRect',
+                                                            'offset' => '121',
+                                                            'type' => '2501'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'preferredEncoding',
+                                                            'offset' => '128',
+                                                            'type' => '240'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'correMaxWidth',
+                                                            'offset' => '132',
+                                                            'type' => '240'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'correMaxHeight',
+                                                            'offset' => '136',
+                                                            'type' => '240'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'viewOnly',
+                                                            'offset' => '146',
+                                                            'type' => '2501'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'authChallenge',
+                                                            'offset' => '147',
+                                                            'type' => '2403'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'PalmVNC',
+                                                           'offset' => '22',
+                                                           'type' => '2501'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'copyRegion',
+                                                            'offset' => '274',
+                                                            'type' => '9035'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'copyDX',
+                                                            'offset' => '288',
+                                                            'type' => '240'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'copyDY',
+                                                            'offset' => '292',
+                                                            'type' => '240'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'modifiedRegion',
+                                                            'offset' => '296',
+                                                            'type' => '9035'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'requestedRegion',
+                                                            'offset' => '310',
+                                                            'type' => '9035'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'startDeferring',
+                                                            'offset' => '324',
+                                                            'type' => '976'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'startPtrDeferring',
+                                                            'offset' => '352',
+                                                            'type' => '976'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'lastPtrX',
+                                                            'offset' => '374',
+                                                            'type' => '240'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'lastPtrY',
+                                                            'offset' => '384',
+                                                            'type' => '240'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'lastPtrButtons',
+                                                            'offset' => '388',
+                                                            'type' => '240'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'clientData',
+                                                           'offset' => '36',
+                                                           'type' => '169'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'translateFn',
+                                                            'offset' => '402',
+                                                            'type' => '8964'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'translateLookupTable',
+                                                            'offset' => '512',
+                                                            'type' => '354'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'format',
+                                                            'offset' => '520',
+                                                            'type' => '2703'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'updateBuf',
+                                                            'offset' => '548',
+                                                            'type' => '9451'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'ublen',
+                                                            'offset' => '207250',
+                                                            'type' => '240'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'statEncList',
+                                                            'offset' => '208896',
+                                                            'type' => '9351'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'statMsgList',
+                                                            'offset' => '208904',
+                                                            'type' => '9351'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'rawBytesEquivalent',
+                                                            'offset' => '208918',
+                                                            'type' => '240'
+                                                          },
+                                                  '38' => {
+                                                            'name' => 'bytesSent',
+                                                            'offset' => '208928',
+                                                            'type' => '240'
+                                                          },
+                                                  '39' => {
+                                                            'name' => 'compStream',
+                                                            'offset' => '208932',
+                                                            'type' => '1967'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'clientGoneHook',
+                                                           'offset' => '50',
+                                                           'type' => '9059'
+                                                         },
+                                                  '40' => {
+                                                            'name' => 'compStreamInited',
+                                                            'offset' => '209206',
+                                                            'type' => '2501'
+                                                          },
+                                                  '41' => {
+                                                            'name' => 'zlibCompressLevel',
+                                                            'offset' => '209216',
+                                                            'type' => '1794'
+                                                          },
+                                                  '42' => {
+                                                            'name' => 'tightQualityLevel',
+                                                            'offset' => '209220',
+                                                            'type' => '240'
+                                                          },
+                                                  '43' => {
+                                                            'name' => 'zsStruct',
+                                                            'offset' => '209234',
+                                                            'type' => '9468'
+                                                          },
+                                                  '44' => {
+                                                            'name' => 'zsActive',
+                                                            'offset' => '210432',
+                                                            'type' => '9484'
+                                                          },
+                                                  '45' => {
+                                                            'name' => 'zsLevel',
+                                                            'offset' => '210436',
+                                                            'type' => '9500'
+                                                          },
+                                                  '46' => {
+                                                            'name' => 'tightCompressLevel',
+                                                            'offset' => '210464',
+                                                            'type' => '240'
+                                                          },
+                                                  '47' => {
+                                                            'name' => 'compStreamInitedLZO',
+                                                            'offset' => '210468',
+                                                            'type' => '2501'
+                                                          },
+                                                  '48' => {
+                                                            'name' => 'lzoWrkMem',
+                                                            'offset' => '210482',
+                                                            'type' => '354'
+                                                          },
+                                                  '49' => {
+                                                            'name' => 'fileTransfer',
+                                                            'offset' => '210496',
+                                                            'type' => '9211'
+                                                          },
+                                                  '5' => {
+                                                           'name' => 'sock',
+                                                           'offset' => '64',
+                                                           'type' => '240'
+                                                         },
+                                                  '50' => {
+                                                            'name' => 'lastKeyboardLedState',
+                                                            'offset' => '210532',
+                                                            'type' => '240'
+                                                          },
+                                                  '51' => {
+                                                            'name' => 'enableSupportedMessages',
+                                                            'offset' => '210536',
+                                                            'type' => '2501'
+                                                          },
+                                                  '52' => {
+                                                            'name' => 'enableSupportedEncodings',
+                                                            'offset' => '210537',
+                                                            'type' => '2501'
+                                                          },
+                                                  '53' => {
+                                                            'name' => 'enableServerIdentity',
+                                                            'offset' => '210544',
+                                                            'type' => '2501'
+                                                          },
+                                                  '54' => {
+                                                            'name' => 'enableKeyboardLedState',
+                                                            'offset' => '210545',
+                                                            'type' => '2501'
+                                                          },
+                                                  '55' => {
+                                                            'name' => 'enableLastRectEncoding',
+                                                            'offset' => '210546',
+                                                            'type' => '2501'
+                                                          },
+                                                  '56' => {
+                                                            'name' => 'enableCursorShapeUpdates',
+                                                            'offset' => '210547',
+                                                            'type' => '2501'
+                                                          },
+                                                  '57' => {
+                                                            'name' => 'enableCursorPosUpdates',
+                                                            'offset' => '210548',
+                                                            'type' => '2501'
+                                                          },
+                                                  '58' => {
+                                                            'name' => 'useRichCursorEncoding',
+                                                            'offset' => '210549',
+                                                            'type' => '2501'
+                                                          },
+                                                  '59' => {
+                                                            'name' => 'cursorWasChanged',
+                                                            'offset' => '210550',
+                                                            'type' => '2501'
+                                                          },
+                                                  '6' => {
+                                                           'name' => 'host',
+                                                           'offset' => '72',
+                                                           'type' => '354'
+                                                         },
+                                                  '60' => {
+                                                            'name' => 'cursorWasMoved',
+                                                            'offset' => '210551',
+                                                            'type' => '2501'
+                                                          },
+                                                  '61' => {
+                                                            'name' => 'cursorX',
+                                                            'offset' => '210560',
+                                                            'type' => '240'
+                                                          },
+                                                  '62' => {
+                                                            'name' => 'cursorY',
+                                                            'offset' => '210564',
+                                                            'type' => '240'
+                                                          },
+                                                  '63' => {
+                                                            'name' => 'useNewFBSize',
+                                                            'offset' => '210568',
+                                                            'type' => '2501'
+                                                          },
+                                                  '64' => {
+                                                            'name' => 'newFBSizePending',
+                                                            'offset' => '210569',
+                                                            'type' => '2501'
+                                                          },
+                                                  '65' => {
+                                                            'name' => 'prev',
+                                                            'offset' => '210582',
+                                                            'type' => '4563'
+                                                          },
+                                                  '66' => {
+                                                            'name' => 'next',
+                                                            'offset' => '210692',
+                                                            'type' => '4563'
+                                                          },
+                                                  '67' => {
+                                                            'name' => 'refCount',
+                                                            'offset' => '210706',
+                                                            'type' => '240'
+                                                          },
+                                                  '68' => {
+                                                            'name' => 'refCountMutex',
+                                                            'offset' => '210720',
+                                                            'type' => '1661'
+                                                          },
+                                                  '69' => {
+                                                            'name' => 'deleteCond',
+                                                            'offset' => '210784',
+                                                            'type' => '1735'
+                                                          },
+                                                  '7' => {
+                                                           'name' => 'protocolMajorVersion',
+                                                           'offset' => '86',
+                                                           'type' => '240'
+                                                         },
+                                                  '70' => {
+                                                            'name' => 'outputMutex',
+                                                            'offset' => '210952',
+                                                            'type' => '1661'
+                                                          },
+                                                  '71' => {
+                                                            'name' => 'updateMutex',
+                                                            'offset' => '211016',
+                                                            'type' => '1661'
+                                                          },
+                                                  '72' => {
+                                                            'name' => 'updateCond',
+                                                            'offset' => '211080',
+                                                            'type' => '1735'
+                                                          },
+                                                  '73' => {
+                                                            'name' => 'zrleData',
+                                                            'offset' => '211254',
+                                                            'type' => '169'
+                                                          },
+                                                  '74' => {
+                                                            'name' => 'zywrleLevel',
+                                                            'offset' => '211268',
+                                                            'type' => '240'
+                                                          },
+                                                  '75' => {
+                                                            'name' => 'zywrleBuf',
+                                                            'offset' => '211272',
+                                                            'type' => '9516'
+                                                          },
+                                                  '76' => {
+                                                            'name' => 'progressiveSliceY',
+                                                            'offset' => '328498',
+                                                            'type' => '240'
+                                                          },
+                                                  '77' => {
+                                                            'name' => 'extensions',
+                                                            'offset' => '328502',
+                                                            'type' => '9533'
+                                                          },
+                                                  '78' => {
+                                                            'name' => 'zrleBeforeBuf',
+                                                            'offset' => '328516',
+                                                            'type' => '354'
+                                                          },
+                                                  '79' => {
+                                                            'name' => 'paletteHelper',
+                                                            'offset' => '328530',
+                                                            'type' => '169'
+                                                          },
+                                                  '8' => {
+                                                           'name' => 'protocolMinorVersion',
+                                                           'offset' => '96',
+                                                           'type' => '240'
+                                                         },
+                                                  '80' => {
+                                                            'name' => 'sendMutex',
+                                                            'offset' => '328544',
+                                                            'type' => '1661'
+                                                          },
+                                                  '81' => {
+                                                            'name' => 'beforeEncBuf',
+                                                            'offset' => '328704',
+                                                            'type' => '354'
+                                                          },
+                                                  '82' => {
+                                                            'name' => 'beforeEncBufSize',
+                                                            'offset' => '328712',
+                                                            'type' => '240'
+                                                          },
+                                                  '83' => {
+                                                            'name' => 'afterEncBuf',
+                                                            'offset' => '328726',
+                                                            'type' => '354'
+                                                          },
+                                                  '84' => {
+                                                            'name' => 'afterEncBufSize',
+                                                            'offset' => '328740',
+                                                            'type' => '240'
+                                                          },
+                                                  '85' => {
+                                                            'name' => 'afterEncBufLen',
+                                                            'offset' => '328744',
+                                                            'type' => '240'
+                                                          },
+                                                  '86' => {
+                                                            'name' => 'tightEncoding',
+                                                            'offset' => '328754',
+                                                            'type' => '1794'
+                                                          },
+                                                  '87' => {
+                                                            'name' => 'turboSubsampLevel',
+                                                            'offset' => '328758',
+                                                            'type' => '240'
+                                                          },
+                                                  '88' => {
+                                                            'name' => 'turboQualityLevel',
+                                                            'offset' => '328768',
+                                                            'type' => '240'
+                                                          },
+                                                  '89' => {
+                                                            'name' => 'sslctx',
+                                                            'offset' => '328776',
+                                                            'type' => '9539'
+                                                          },
+                                                  '9' => {
+                                                           'name' => 'client_thread',
+                                                           'offset' => '100',
+                                                           'type' => '1465'
+                                                         },
+                                                  '90' => {
+                                                            'name' => 'wsctx',
+                                                            'offset' => '328790',
+                                                            'type' => '9545'
+                                                          },
+                                                  '91' => {
+                                                            'name' => 'wspath',
+                                                            'offset' => '328804',
+                                                            'type' => '354'
+                                                          },
+                                                  '92' => {
+                                                            'name' => 'pipe_notify_client_thread',
+                                                            'offset' => '328818',
+                                                            'type' => '290'
+                                                          },
+                                                  '93' => {
+                                                            'name' => 'clientFramebufferUpdateRequestHook',
+                                                            'offset' => '328832',
+                                                            'type' => '9072'
+                                                          },
+                                                  '94' => {
+                                                            'name' => 'useExtDesktopSize',
+                                                            'offset' => '328840',
+                                                            'type' => '2501'
+                                                          },
+                                                  '95' => {
+                                                            'name' => 'requestedDesktopSizeChange',
+                                                            'offset' => '328850',
+                                                            'type' => '240'
+                                                          },
+                                                  '96' => {
+                                                            'name' => 'lastDesktopSizeChangeError',
+                                                            'offset' => '328854',
+                                                            'type' => '240'
+                                                          },
+                                                  '97' => {
+                                                            'name' => 'enableExtendedClipboard',
+                                                            'offset' => '328960',
+                                                            'type' => '2501'
+                                                          },
+                                                  '98' => {
+                                                            'name' => 'extClipboardUserCap',
+                                                            'offset' => '328964',
+                                                            'type' => '1794'
+                                                          },
+                                                  '99' => {
+                                                            'name' => 'extClipboardMaxUnsolicitedSize',
+                                                            'offset' => '328968',
+                                                            'type' => '1794'
+                                                          }
+                                                },
+                                      'Name' => 'struct _rfbClientRec',
+                                      'Size' => '50544',
+                                      'Type' => 'Struct'
+                                    },
+                          '57' => {
+                                    'Name' => 'unsigned long',
+                                    'Size' => '8',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '6126' => {
+                                      'BaseType' => '6138',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '104',
+                                      'Name' => 'rfbKbdReleaseAllKeysProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6138' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6155' => {
+                                      'BaseType' => '6167',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '105',
+                                      'Name' => 'rfbPtrAddEventProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6167' => {
+                                      'Name' => 'void(*)(int, int, int, struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6199' => {
+                                      'BaseType' => '6211',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '106',
+                                      'Name' => 'rfbSetXCutTextProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6211' => {
+                                      'Name' => 'void(*)(char*, int, struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '354'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6238' => {
+                                      'BaseType' => '6211',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '108',
+                                      'Name' => 'rfbSetXCutTextUTF8ProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6250' => {
+                                      'BaseType' => '6262',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '110',
+                                      'Name' => 'rfbGetCursorProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6262' => {
+                                      'Name' => 'struct rfbCursor*(*)(struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '6564',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6268' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '924',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'cleanup',
+                                                           'offset' => '0',
+                                                           'type' => '2501'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'cleanupSource',
+                                                           'offset' => '1',
+                                                           'type' => '2501'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'foreRed',
+                                                            'offset' => '50',
+                                                            'type' => '183'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'foreGreen',
+                                                            'offset' => '52',
+                                                            'type' => '183'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'foreBlue',
+                                                            'offset' => '54',
+                                                            'type' => '183'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'backRed',
+                                                            'offset' => '56',
+                                                            'type' => '183'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'backGreen',
+                                                            'offset' => '64',
+                                                            'type' => '183'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'backBlue',
+                                                            'offset' => '66',
+                                                            'type' => '183'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'richSource',
+                                                            'offset' => '72',
+                                                            'type' => '2192'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'alphaSource',
+                                                            'offset' => '86',
+                                                            'type' => '2192'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'alphaPreMultiplied',
+                                                            'offset' => '100',
+                                                            'type' => '2501'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'cleanupMask',
+                                                           'offset' => '2',
+                                                           'type' => '2501'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'cleanupRichSource',
+                                                           'offset' => '3',
+                                                           'type' => '2501'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'source',
+                                                           'offset' => '8',
+                                                           'type' => '2192'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'mask',
+                                                           'offset' => '22',
+                                                           'type' => '2192'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'width',
+                                                           'offset' => '36',
+                                                           'type' => '183'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'height',
+                                                           'offset' => '38',
+                                                           'type' => '183'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'xhot',
+                                                           'offset' => '40',
+                                                           'type' => '183'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'yhot',
+                                                           'offset' => '48',
+                                                           'type' => '183'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbCursor',
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '6564' => {
+                                      'BaseType' => '6268',
+                                      'Name' => 'struct rfbCursor*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6570' => {
+                                      'BaseType' => '6582',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '111',
+                                      'Name' => 'rfbSetTranslateFunctionProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6582' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6603' => {
+                                      'BaseType' => '6615',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '112',
+                                      'Name' => 'rfbPasswordCheckProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6615' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, char const*, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1759'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6646' => {
+                                      'BaseType' => '6658',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '113',
+                                      'Name' => 'rfbNewClientHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6658' => {
+                                      'Name' => 'enum rfbNewClientAction(*)(struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '4450',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6679' => {
+                                      'BaseType' => '6138',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '114',
+                                      'Name' => 'rfbDisplayHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6691' => {
+                                      'BaseType' => '6703',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '115',
+                                      'Name' => 'rfbDisplayFinishedHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6703' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6725' => {
+                                      'BaseType' => '6737',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '117',
+                                      'Name' => 'rfbGetKeyboardLedStateHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '6737' => {
+                                      'Name' => 'int(*)(struct _rfbScreenInfo*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '6758'
+                                                          }
+                                                 },
+                                      'Return' => '240',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '6758' => {
+                                      'BaseType' => '6764',
+                                      'Name' => 'struct _rfbScreenInfo*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6764' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '201',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'scaledScreenNext',
+                                                           'offset' => '0',
+                                                           'type' => '6758'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'scaledScreenRefCount',
+                                                           'offset' => '8',
+                                                           'type' => '240'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'screenData',
+                                                            'offset' => '72',
+                                                            'type' => '169'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'serverFormat',
+                                                            'offset' => '86',
+                                                            'type' => '2703'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'colourMap',
+                                                            'offset' => '114',
+                                                            'type' => '8503'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'desktopName',
+                                                            'offset' => '136',
+                                                            'type' => '1759'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'thisHost',
+                                                            'offset' => '150',
+                                                            'type' => '8928'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'autoPort',
+                                                            'offset' => '849',
+                                                            'type' => '2501'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'port',
+                                                            'offset' => '850',
+                                                            'type' => '240'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'listenSock',
+                                                            'offset' => '854',
+                                                            'type' => '240'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'maxSock',
+                                                            'offset' => '864',
+                                                            'type' => '240'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'maxFd',
+                                                            'offset' => '868',
+                                                            'type' => '240'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'width',
+                                                           'offset' => '18',
+                                                           'type' => '240'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'allFds',
+                                                            'offset' => '872',
+                                                            'type' => '1067'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'socketState',
+                                                            'offset' => '1174',
+                                                            'type' => '4487'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'inetdSock',
+                                                            'offset' => '1280',
+                                                            'type' => '240'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'inetdInitDone',
+                                                            'offset' => '1284',
+                                                            'type' => '2501'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'udpPort',
+                                                            'offset' => '1288',
+                                                            'type' => '240'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'udpSock',
+                                                            'offset' => '1298',
+                                                            'type' => '240'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'udpClient',
+                                                            'offset' => '1312',
+                                                            'type' => '4563'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'udpSockConnected',
+                                                            'offset' => '1320',
+                                                            'type' => '2501'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'udpRemoteAddr',
+                                                            'offset' => '1330',
+                                                            'type' => '2419'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'maxClientWait',
+                                                            'offset' => '1352',
+                                                            'type' => '240'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'paddedWidthInBytes',
+                                                           'offset' => '22',
+                                                           'type' => '240'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'httpInitDone',
+                                                            'offset' => '1362',
+                                                            'type' => '2501'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'httpEnableProxyConnect',
+                                                            'offset' => '1363',
+                                                            'type' => '2501'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'httpPort',
+                                                            'offset' => '1366',
+                                                            'type' => '240'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'httpDir',
+                                                            'offset' => '1376',
+                                                            'type' => '354'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'httpListenSock',
+                                                            'offset' => '1384',
+                                                            'type' => '240'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'httpSock',
+                                                            'offset' => '1394',
+                                                            'type' => '240'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'passwordCheck',
+                                                            'offset' => '1398',
+                                                            'type' => '6603'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'authPasswdData',
+                                                            'offset' => '1412',
+                                                            'type' => '169'
+                                                          },
+                                                  '38' => {
+                                                            'name' => 'authPasswdFirstViewOnly',
+                                                            'offset' => '1426',
+                                                            'type' => '240'
+                                                          },
+                                                  '39' => {
+                                                            'name' => 'maxRectsPerUpdate',
+                                                            'offset' => '1430',
+                                                            'type' => '240'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'height',
+                                                           'offset' => '32',
+                                                           'type' => '240'
+                                                         },
+                                                  '40' => {
+                                                            'name' => 'deferUpdateTime',
+                                                            'offset' => '1536',
+                                                            'type' => '240'
+                                                          },
+                                                  '41' => {
+                                                            'name' => 'alwaysShared',
+                                                            'offset' => '1540',
+                                                            'type' => '2501'
+                                                          },
+                                                  '42' => {
+                                                            'name' => 'neverShared',
+                                                            'offset' => '1541',
+                                                            'type' => '2501'
+                                                          },
+                                                  '43' => {
+                                                            'name' => 'dontDisconnect',
+                                                            'offset' => '1542',
+                                                            'type' => '2501'
+                                                          },
+                                                  '44' => {
+                                                            'name' => 'clientHead',
+                                                            'offset' => '1544',
+                                                            'type' => '4563'
+                                                          },
+                                                  '45' => {
+                                                            'name' => 'pointerClient',
+                                                            'offset' => '1558',
+                                                            'type' => '4563'
+                                                          },
+                                                  '46' => {
+                                                            'name' => 'cursorX',
+                                                            'offset' => '1572',
+                                                            'type' => '240'
+                                                          },
+                                                  '47' => {
+                                                            'name' => 'cursorY',
+                                                            'offset' => '1576',
+                                                            'type' => '240'
+                                                          },
+                                                  '48' => {
+                                                            'name' => 'underCursorBufferLen',
+                                                            'offset' => '1586',
+                                                            'type' => '240'
+                                                          },
+                                                  '49' => {
+                                                            'name' => 'underCursorBuffer',
+                                                            'offset' => '1600',
+                                                            'type' => '354'
+                                                          },
+                                                  '5' => {
+                                                           'name' => 'depth',
+                                                           'offset' => '36',
+                                                           'type' => '240'
+                                                         },
+                                                  '50' => {
+                                                            'name' => 'dontConvertRichCursorToXCursor',
+                                                            'offset' => '1608',
+                                                            'type' => '2501'
+                                                          },
+                                                  '51' => {
+                                                            'name' => 'cursor',
+                                                            'offset' => '1622',
+                                                            'type' => '6564'
+                                                          },
+                                                  '52' => {
+                                                            'name' => 'frameBuffer',
+                                                            'offset' => '1636',
+                                                            'type' => '354'
+                                                          },
+                                                  '53' => {
+                                                            'name' => 'kbdAddEvent',
+                                                            'offset' => '1650',
+                                                            'type' => '4524'
+                                                          },
+                                                  '54' => {
+                                                            'name' => 'kbdReleaseAllKeys',
+                                                            'offset' => '1664',
+                                                            'type' => '6126'
+                                                          },
+                                                  '55' => {
+                                                            'name' => 'ptrAddEvent',
+                                                            'offset' => '1672',
+                                                            'type' => '6155'
+                                                          },
+                                                  '56' => {
+                                                            'name' => 'setXCutText',
+                                                            'offset' => '1686',
+                                                            'type' => '6199'
+                                                          },
+                                                  '57' => {
+                                                            'name' => 'getCursorPtr',
+                                                            'offset' => '1796',
+                                                            'type' => '6250'
+                                                          },
+                                                  '58' => {
+                                                            'name' => 'setTranslateFunction',
+                                                            'offset' => '1810',
+                                                            'type' => '6570'
+                                                          },
+                                                  '59' => {
+                                                            'name' => 'setSingleWindow',
+                                                            'offset' => '1824',
+                                                            'type' => '8306'
+                                                          },
+                                                  '6' => {
+                                                           'name' => 'bitsPerPixel',
+                                                           'offset' => '40',
+                                                           'type' => '240'
+                                                         },
+                                                  '60' => {
+                                                            'name' => 'setServerInput',
+                                                            'offset' => '1832',
+                                                            'type' => '8345'
+                                                          },
+                                                  '61' => {
+                                                            'name' => 'getFileTransferPermission',
+                                                            'offset' => '1846',
+                                                            'type' => '8357'
+                                                          },
+                                                  '62' => {
+                                                            'name' => 'setTextChat',
+                                                            'offset' => '1860',
+                                                            'type' => '8369'
+                                                          },
+                                                  '63' => {
+                                                            'name' => 'newClientHook',
+                                                            'offset' => '1874',
+                                                            'type' => '6646'
+                                                          },
+                                                  '64' => {
+                                                            'name' => 'displayHook',
+                                                            'offset' => '1888',
+                                                            'type' => '6679'
+                                                          },
+                                                  '65' => {
+                                                            'name' => 'getKeyboardLedStateHook',
+                                                            'offset' => '1896',
+                                                            'type' => '6725'
+                                                          },
+                                                  '66' => {
+                                                            'name' => 'cursorMutex',
+                                                            'offset' => '1910',
+                                                            'type' => '1661'
+                                                          },
+                                                  '67' => {
+                                                            'name' => 'backgroundLoop',
+                                                            'offset' => '2070',
+                                                            'type' => '2501'
+                                                          },
+                                                  '68' => {
+                                                            'name' => 'ignoreSIGPIPE',
+                                                            'offset' => '2071',
+                                                            'type' => '2501'
+                                                          },
+                                                  '69' => {
+                                                            'name' => 'progressiveSliceHeight',
+                                                            'offset' => '2080',
+                                                            'type' => '240'
+                                                          },
+                                                  '7' => {
+                                                           'name' => 'sizeInBytes',
+                                                           'offset' => '50',
+                                                           'type' => '240'
+                                                         },
+                                                  '70' => {
+                                                            'name' => 'listenInterface',
+                                                            'offset' => '2084',
+                                                            'type' => '2352'
+                                                          },
+                                                  '71' => {
+                                                            'name' => 'deferPtrUpdateTime',
+                                                            'offset' => '2088',
+                                                            'type' => '240'
+                                                          },
+                                                  '72' => {
+                                                            'name' => 'handleEventsEagerly',
+                                                            'offset' => '2098',
+                                                            'type' => '2501'
+                                                          },
+                                                  '73' => {
+                                                            'name' => 'versionString',
+                                                            'offset' => '2112',
+                                                            'type' => '354'
+                                                          },
+                                                  '74' => {
+                                                            'name' => 'protocolMajorVersion',
+                                                            'offset' => '2120',
+                                                            'type' => '240'
+                                                          },
+                                                  '75' => {
+                                                            'name' => 'protocolMinorVersion',
+                                                            'offset' => '2130',
+                                                            'type' => '240'
+                                                          },
+                                                  '76' => {
+                                                            'name' => 'permitFileTransfer',
+                                                            'offset' => '2134',
+                                                            'type' => '2501'
+                                                          },
+                                                  '77' => {
+                                                            'name' => 'displayFinishedHook',
+                                                            'offset' => '2148',
+                                                            'type' => '6691'
+                                                          },
+                                                  '78' => {
+                                                            'name' => 'xvpHook',
+                                                            'offset' => '2162',
+                                                            'type' => '8128'
+                                                          },
+                                                  '79' => {
+                                                            'name' => 'sslkeyfile',
+                                                            'offset' => '2176',
+                                                            'type' => '354'
+                                                          },
+                                                  '8' => {
+                                                           'name' => 'blackPixel',
+                                                           'offset' => '54',
+                                                           'type' => '2525'
+                                                         },
+                                                  '80' => {
+                                                            'name' => 'sslcertfile',
+                                                            'offset' => '2184',
+                                                            'type' => '354'
+                                                          },
+                                                  '81' => {
+                                                            'name' => 'ipv6port',
+                                                            'offset' => '2198',
+                                                            'type' => '240'
+                                                          },
+                                                  '82' => {
+                                                            'name' => 'listen6Interface',
+                                                            'offset' => '2308',
+                                                            'type' => '354'
+                                                          },
+                                                  '83' => {
+                                                            'name' => 'listen6Sock',
+                                                            'offset' => '2322',
+                                                            'type' => '240'
+                                                          },
+                                                  '84' => {
+                                                            'name' => 'http6Port',
+                                                            'offset' => '2326',
+                                                            'type' => '240'
+                                                          },
+                                                  '85' => {
+                                                            'name' => 'httpListen6Sock',
+                                                            'offset' => '2336',
+                                                            'type' => '240'
+                                                          },
+                                                  '86' => {
+                                                            'name' => 'setDesktopSizeHook',
+                                                            'offset' => '2344',
+                                                            'type' => '8171'
+                                                          },
+                                                  '87' => {
+                                                            'name' => 'numberOfExtDesktopScreensHook',
+                                                            'offset' => '2358',
+                                                            'type' => '8230'
+                                                          },
+                                                  '88' => {
+                                                            'name' => 'getExtDesktopScreenHook',
+                                                            'offset' => '2372',
+                                                            'type' => '8263'
+                                                          },
+                                                  '89' => {
+                                                            'name' => 'fdQuota',
+                                                            'offset' => '2386',
+                                                            'type' => '8944'
+                                                          },
+                                                  '9' => {
+                                                           'name' => 'whitePixel',
+                                                           'offset' => '64',
+                                                           'type' => '2525'
+                                                         },
+                                                  '90' => {
+                                                            'name' => 'listener_thread',
+                                                            'offset' => '2400',
+                                                            'type' => '1465'
+                                                          },
+                                                  '91' => {
+                                                            'name' => 'pipe_notify_listener_thread',
+                                                            'offset' => '2408',
+                                                            'type' => '290'
+                                                          },
+                                                  '92' => {
+                                                            'name' => 'setXCutTextUTF8',
+                                                            'offset' => '2422',
+                                                            'type' => '6238'
+                                                          }
+                                                },
+                                      'Name' => 'struct _rfbScreenInfo',
+                                      'Size' => '984',
+                                      'Type' => 'Struct'
+                                    },
+                          '76863' => {
+                                       'BaseType' => '9854',
+                                       'Line' => '21',
+                                       'Name' => 'sraSpan',
+                                       'PrivateABI' => 1,
+                                       'Size' => '32',
+                                       'Source' => 'rfbregion.c',
+                                       'Type' => 'Typedef'
+                                     },
+                          '8128' => {
+                                      'BaseType' => '8140',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '118',
+                                      'Name' => 'rfbXvpHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8140' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, uint8_t, uint8_t)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1770'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '1770'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8171' => {
+                                      'BaseType' => '8183',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '119',
+                                      'Name' => 'rfbSetDesktopSizeHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8183' => {
+                                      'Name' => 'int(*)(int, int, int, struct rfbExtDesktopScreen*, struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '8224'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '240',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8224' => {
+                                      'BaseType' => '2991',
+                                      'Name' => 'struct rfbExtDesktopScreen*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8230' => {
+                                      'BaseType' => '8242',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '120',
+                                      'Name' => 'rfbNumberOfExtDesktopScreensPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8242' => {
+                                      'Name' => 'int(*)(struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '240',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8263' => {
+                                      'BaseType' => '8275',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '121',
+                                      'Name' => 'rfbGetExtDesktopScreenPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8275' => {
+                                      'Name' => 'rfbBool(*)(int, struct rfbExtDesktopScreen*, struct _rfbClientRec*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '8224'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '4563'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8306' => {
+                                      'BaseType' => '8318',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '127',
+                                      'Name' => 'rfbSetSingleWindowProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8318' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8345' => {
+                                      'BaseType' => '6703',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '132',
+                                      'Name' => 'rfbSetServerInputProcPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8357' => {
+                                      'BaseType' => '8242',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '137',
+                                      'Name' => 'rfbFileTransferPermitted',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8369' => {
+                                      'BaseType' => '8381',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '139',
+                                      'Name' => 'rfbSetTextChat',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8381' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*, int, char*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '354'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8408' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '144',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'bytes',
+                                                           'offset' => '0',
+                                                           'type' => '8442'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'shorts',
+                                                           'offset' => '0',
+                                                           'type' => '8448'
+                                                         }
+                                                },
+                                      'Name' => 'anon-union-rfb.h-144',
+                                      'Size' => '8',
+                                      'Type' => 'Union'
+                                    },
+                          '8442' => {
+                                      'BaseType' => '1770',
+                                      'Name' => 'uint8_t*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8448' => {
+                                      'BaseType' => '1782',
+                                      'Name' => 'uint16_t*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8503' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '148',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'count',
+                                                           'offset' => '0',
+                                                           'type' => '1794'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'is16',
+                                                           'offset' => '4',
+                                                           'type' => '2501'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'data',
+                                                           'offset' => '8',
+                                                           'type' => '8408'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbColourMap',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '8515' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '164',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'newClient',
+                                                           'offset' => '0',
+                                                           'type' => '8672'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'init',
+                                                           'offset' => '8',
+                                                           'type' => '8698'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pseudoEncodings',
+                                                           'offset' => '22',
+                                                           'type' => '8704'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'enablePseudoEncoding',
+                                                           'offset' => '36',
+                                                           'type' => '8735'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'handleMessage',
+                                                           'offset' => '50',
+                                                           'type' => '8772'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'close',
+                                                           'offset' => '64',
+                                                           'type' => '8794'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'usage',
+                                                           'offset' => '72',
+                                                           'type' => '8801'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'processArgument',
+                                                           'offset' => '86',
+                                                           'type' => '8827'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'next',
+                                                           'offset' => '100',
+                                                           'type' => '8833'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbProtocolExtension',
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '8666' => {
+                                      'BaseType' => '169',
+                                      'Name' => 'void**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8672' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, void**)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '8666'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8698' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, void*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '169'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8704' => {
+                                      'BaseType' => '240',
+                                      'Name' => 'int*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8735' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, void**, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '8666'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8766' => {
+                                      'BaseType' => '4284',
+                                      'Name' => 'rfbClientToServerMsg const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8772' => {
+                                      'Name' => 'rfbBool(*)(struct _rfbClientRec*, void*, rfbClientToServerMsg const*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '169'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '8766'
+                                                          }
+                                                 },
+                                      'Return' => '2501',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8794' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*, void*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '169'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8801' => {
+                                      'Name' => 'void(*)()',
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8827' => {
+                                      'Name' => 'int(*)(int, char**)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '1884'
+                                                          }
+                                                 },
+                                      'Return' => '240',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '8833' => {
+                                      'BaseType' => '8515',
+                                      'Name' => 'struct _rfbProtocolExtension*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8839' => {
+                                      'BaseType' => '8515',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '187',
+                                      'Name' => 'rfbProtocolExtension',
+                                      'Size' => '72',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8851' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '189',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'extension',
+                                                           'offset' => '0',
+                                                           'type' => '8904'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'data',
+                                                           'offset' => '8',
+                                                           'type' => '169'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'next',
+                                                           'offset' => '22',
+                                                           'type' => '8910'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbExtensionData',
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '8904' => {
+                                      'BaseType' => '8839',
+                                      'Name' => 'rfbProtocolExtension*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8910' => {
+                                      'BaseType' => '8851',
+                                      'Name' => 'struct _rfbExtensionData*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8916' => {
+                                      'BaseType' => '8851',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '193',
+                                      'Name' => 'rfbExtensionData',
+                                      'Size' => '24',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8928' => {
+                                      'BaseType' => '365',
+                                      'Name' => 'char[255]',
+                                      'Size' => '255',
+                                      'Type' => 'Array'
+                                    },
+                          '8944' => {
+                                      'Name' => 'float',
+                                      'Size' => '4',
+                                      'Type' => 'Intrinsic'
+                                    },
+                          '8951' => {
+                                      'BaseType' => '6758',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '375',
+                                      'Name' => 'rfbScreenInfoPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8964' => {
+                                      'BaseType' => '8977',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '382',
+                                      'Name' => 'rfbTranslateFnType',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8977' => {
+                                      'Name' => 'void(*)(char*, rfbPixelFormat*, rfbPixelFormat*, char*, char*, int, int, int)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '354'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '9029'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '9029'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '354'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '354'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '6' => {
+                                                            'type' => '240'
+                                                          },
+                                                   '7' => {
+                                                            'type' => '240'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9029' => {
+                                      'BaseType' => '2703',
+                                      'Name' => 'rfbPixelFormat*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9035' => {
+                                      'BaseType' => '9048',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '392',
+                                      'Name' => 'sraRegionPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9048' => {
+                                      'BaseType' => '9054',
+                                      'Name' => 'struct sraRegion*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9054' => {
+                                      'Line' => '23',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'front',
+                                                           'offset' => '0',
+                                                           'type' => '76863'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'back',
+                                                           'offset' => '50',
+                                                           'type' => '76863'
+                                                         }
+                                                },
+                                      'Name' => 'struct sraRegion',
+                                      'PrivateABI' => 1,
+                                      'Size' => '64',
+                                      'Source' => 'rfbregion.c',
+                                      'Type' => 'Struct'
+                                    },
+                          '9059' => {
+                                      'BaseType' => '6138',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '398',
+                                      'Name' => 'ClientGoneHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '90716' => {
+                                       'Header' => 'rfb.h',
+                                       'Line' => '154',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'type',
+                                                            'offset' => '0',
+                                                            'type' => '1770'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'handler',
+                                                            'offset' => '8',
+                                                            'type' => '6138'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'next',
+                                                            'offset' => '22',
+                                                            'type' => '90769'
+                                                          }
+                                                 },
+                                       'Name' => 'struct _rfbSecurity',
+                                       'Size' => '24',
+                                       'Type' => 'Struct'
+                                     },
+                          '9072' => {
+                                      'BaseType' => '9085',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '399',
+                                      'Name' => 'ClientFramebufferUpdateRequestHookPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '90769' => {
+                                       'BaseType' => '90716',
+                                       'Name' => 'struct _rfbSecurity*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '90775' => {
+                                       'BaseType' => '90716',
+                                       'Header' => 'rfb.h',
+                                       'Line' => '158',
+                                       'Name' => 'rfbSecurityHandler',
+                                       'Size' => '24',
+                                       'Type' => 'Typedef'
+                                     },
+                          '9085' => {
+                                      'Name' => 'void(*)(struct _rfbClientRec*, rfbFramebufferUpdateRequestMsg*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '4563'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '9107'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9107' => {
+                                      'BaseType' => '3523',
+                                      'Name' => 'rfbFramebufferUpdateRequestMsg*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9113' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '401',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'fd',
+                                                           'offset' => '0',
+                                                           'type' => '240'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'compressionEnabled',
+                                                           'offset' => '4',
+                                                           'type' => '240'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'fileSize',
+                                                           'offset' => '8',
+                                                           'type' => '240'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'numPackets',
+                                                           'offset' => '18',
+                                                           'type' => '240'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'receiving',
+                                                           'offset' => '22',
+                                                           'type' => '240'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'sending',
+                                                           'offset' => '32',
+                                                           'type' => '240'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbFileTransferData',
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '91928' => {
+                                       'BaseType' => '90775',
+                                       'Name' => 'rfbSecurityHandler*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '9211' => {
+                                      'BaseType' => '9113',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '408',
+                                      'Name' => 'rfbFileTransferData',
+                                      'Size' => '24',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9224' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '411',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '1794'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'sentCount',
+                                                           'offset' => '4',
+                                                           'type' => '1794'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'bytesSent',
+                                                           'offset' => '8',
+                                                           'type' => '1794'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'bytesSentIfRaw',
+                                                           'offset' => '18',
+                                                           'type' => '1794'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'rcvdCount',
+                                                           'offset' => '22',
+                                                           'type' => '1794'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'bytesRcvd',
+                                                           'offset' => '32',
+                                                           'type' => '1794'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'bytesRcvdIfRaw',
+                                                           'offset' => '36',
+                                                           'type' => '1794'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'Next',
+                                                           'offset' => '50',
+                                                           'type' => '9351'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rfbStatList',
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '9351' => {
+                                      'BaseType' => '9224',
+                                      'Name' => 'struct _rfbStatList*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9357' => {
+                                      'BaseType' => '9370',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '422',
+                                      'Name' => 'rfbSslCtx',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9370' => {
+                                      'Name' => 'struct _rfbSslCtx',
+                                      'PrivateABI' => 1,
+                                      'Type' => 'Struct'
+                                    },
+                          '9375' => {
+                                      'BaseType' => '9388',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '423',
+                                      'Name' => 'wsCtx',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9388' => {
+                                      'Name' => 'struct _wsCtx',
+                                      'PrivateABI' => 1,
+                                      'Type' => 'Struct'
+                                    },
+                          '9393' => {
+                                      'Header' => 'rfb.h',
+                                      'Line' => '484',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'RFB_PROTOCOL_VERSION',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'RFB_SECURITY_TYPE',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'RFB_AUTHENTICATION',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'RFB_INITIALISATION',
+                                                           'value' => '3'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'RFB_NORMAL',
+                                                           'value' => '4'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'RFB_INITIALISATION_SHARED',
+                                                           'value' => '5'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'RFB_SHUTDOWN',
+                                                           'value' => '6'
+                                                         }
+                                                },
+                                      'Name' => 'anon-enum-rfb.h-484',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '940' => {
+                                     'Name' => 'long long',
+                                     'Size' => '8',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '9451' => {
+                                      'BaseType' => '365',
+                                      'Name' => 'char[32768]',
+                                      'Size' => '32768',
+                                      'Type' => 'Array'
+                                    },
+                          '9468' => {
+                                      'BaseType' => '2180',
+                                      'Name' => 'z_stream[4]',
+                                      'Size' => '448',
+                                      'Type' => 'Array'
+                                    },
+                          '9484' => {
+                                      'BaseType' => '2501',
+                                      'Name' => 'rfbBool[4]',
+                                      'Size' => '4',
+                                      'Type' => 'Array'
+                                    },
+                          '9500' => {
+                                      'BaseType' => '240',
+                                      'Name' => 'int[4]',
+                                      'Size' => '16',
+                                      'Type' => 'Array'
+                                    },
+                          '9516' => {
+                                      'BaseType' => '240',
+                                      'Name' => 'int[4096]',
+                                      'Size' => '16384',
+                                      'Type' => 'Array'
+                                    },
+                          '9533' => {
+                                      'BaseType' => '8916',
+                                      'Name' => 'rfbExtensionData*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9539' => {
+                                      'BaseType' => '9357',
+                                      'Name' => 'rfbSslCtx*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9545' => {
+                                      'BaseType' => '9375',
+                                      'Name' => 'wsCtx*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9551' => {
+                                      'BaseType' => '4563',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '710',
+                                      'Name' => 'rfbClientPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9577' => {
+                                      'BaseType' => '9590',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '787',
+                                      'Name' => 'rfbClientIteratorPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9590' => {
+                                      'BaseType' => '9596',
+                                      'Name' => 'struct rfbClientIterator*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9596' => {
+                                      'Line' => '147',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'next',
+                                                           'offset' => '0',
+                                                           'type' => '9551'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'screen',
+                                                           'offset' => '8',
+                                                           'type' => '8951'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'closedToo',
+                                                           'offset' => '22',
+                                                           'type' => '2501'
+                                                         }
+                                                },
+                                      'Name' => 'struct rfbClientIterator',
+                                      'PrivateABI' => 1,
+                                      'Size' => '24',
+                                      'Source' => 'rfbserver.c',
+                                      'Type' => 'Struct'
+                                    },
+                          '9614' => {
+                                      'BaseType' => '6564',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '935',
+                                      'Name' => 'rfbCursorPtr',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9627' => {
+                                      'BaseType' => '9640',
+                                      'Header' => 'rfb.h',
+                                      'Line' => '1019',
+                                      'Name' => 'rfbLogProc',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '964' => {
+                                     'BaseType' => '190',
+                                     'Header' => 'stdint-intn.h',
+                                     'Line' => '24',
+                                     'Name' => 'int8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '9640' => {
+                                      'Name' => 'void(*)(char const*, ...)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '1759'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '-1'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9684' => {
+                                      'Header' => 'rfbregion.h',
+                                      'Line' => '11',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'x1',
+                                                           'offset' => '0',
+                                                           'type' => '240'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'y1',
+                                                           'offset' => '4',
+                                                           'type' => '240'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'x2',
+                                                           'offset' => '8',
+                                                           'type' => '240'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'y2',
+                                                           'offset' => '18',
+                                                           'type' => '240'
+                                                         }
+                                                },
+                                      'Name' => 'struct _rect',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '9746' => {
+                                      'BaseType' => '9684',
+                                      'Header' => 'rfbregion.h',
+                                      'Line' => '16',
+                                      'Name' => 'sraRect',
+                                      'Size' => '16',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9758' => {
+                                      'BaseType' => '9054',
+                                      'Header' => 'rfbregion.h',
+                                      'Line' => '18',
+                                      'Name' => 'sraRegion',
+                                      'Type' => 'Typedef'
+                                    },
+                          '976' => {
+                                     'Header' => 'struct_timeval.h',
+                                     'Line' => '8',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => 'tv_sec',
+                                                          'offset' => '0',
+                                                          'type' => '306'
+                                                        },
+                                                 '1' => {
+                                                          'name' => 'tv_usec',
+                                                          'offset' => '8',
+                                                          'type' => '330'
+                                                        }
+                                               },
+                                     'Name' => 'struct timeval',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Struct'
+                                   },
+                          '9770' => {
+                                      'BaseType' => '9758',
+                                      'Name' => 'sraRegion const',
+                                      'Type' => 'Const'
+                                    },
+                          '9775' => {
+                                      'Header' => 'rfbregion.h',
+                                      'Line' => '44',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'reverseX',
+                                                           'offset' => '0',
+                                                           'type' => '2501'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'reverseY',
+                                                           'offset' => '1',
+                                                           'type' => '2501'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ptrSize',
+                                                           'offset' => '4',
+                                                           'type' => '240'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ptrPos',
+                                                           'offset' => '8',
+                                                           'type' => '240'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'sPtrs',
+                                                           'offset' => '22',
+                                                           'type' => '9859'
+                                                         }
+                                                },
+                                      'Name' => 'struct sraRectangleIterator',
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '9854' => {
+                                      'Line' => '15',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => '_next',
+                                                           'offset' => '0',
+                                                           'type' => '9865'
+                                                         },
+                                                  '1' => {
+                                                           'name' => '_prev',
+                                                           'offset' => '8',
+                                                           'type' => '9865'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'start',
+                                                           'offset' => '22',
+                                                           'type' => '240'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'end',
+                                                           'offset' => '32',
+                                                           'type' => '240'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'subspan',
+                                                           'offset' => '36',
+                                                           'type' => '9048'
+                                                         }
+                                                },
+                                      'Name' => 'struct sraSpan',
+                                      'PrivateABI' => 1,
+                                      'Size' => '32',
+                                      'Source' => 'rfbregion.c',
+                                      'Type' => 'Struct'
+                                    },
+                          '9859' => {
+                                      'BaseType' => '9865',
+                                      'Name' => 'struct sraSpan**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9865' => {
+                                      'BaseType' => '9854',
+                                      'Name' => 'struct sraSpan*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9871' => {
+                                      'BaseType' => '9775',
+                                      'Header' => 'rfbregion.h',
+                                      'Line' => '48',
+                                      'Name' => 'sraRectangleIterator',
+                                      'Size' => '24',
+                                      'Type' => 'Typedef'
+                                    }
+                        },
+          'UndefinedSymbols' => {
+                                  'libvncserver.so.0.9.14' => {
+                                                                '_ITM_deregisterTMCloneTable' => 0,
+                                                                '_ITM_registerTMCloneTable' => 0,
+                                                                '__assert_fail@GLIBC_2.2.5' => 0,
+                                                                '__ctype_b_loc@GLIBC_2.3' => 0,
+                                                                '__ctype_tolower_loc@GLIBC_2.3' => 0,
+                                                                '__cxa_finalize@GLIBC_2.2.5' => 0,
+                                                                '__errno_location@GLIBC_2.2.5' => 0,
+                                                                '__fdelt_chk@GLIBC_2.15' => 0,
+                                                                '__fread_chk@GLIBC_2.7' => 0,
+                                                                '__gethostname_chk@GLIBC_2.4' => 0,
+                                                                '__gmon_start__' => 0,
+                                                                '__isoc99_sscanf@GLIBC_2.7' => 0,
+                                                                '__longjmp_chk@GLIBC_2.11' => 0,
+                                                                '__memcpy_chk@GLIBC_2.3.4' => 0,
+                                                                '__printf_chk@GLIBC_2.3.4' => 0,
+                                                                '__read_chk@GLIBC_2.4' => 0,
+                                                                '__recv_chk@GLIBC_2.4' => 0,
+                                                                '__snprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '__sprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '__stack_chk_fail@GLIBC_2.4' => 0,
+                                                                '__strcat_chk@GLIBC_2.3.4' => 0,
+                                                                '__strcpy_chk@GLIBC_2.3.4' => 0,
+                                                                '__vfprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '__vsnprintf_chk@GLIBC_2.3.4' => 0,
+                                                                '_setjmp@GLIBC_2.2.5' => 0,
+                                                                'accept@GLIBC_2.2.5' => 0,
+                                                                'bind@GLIBC_2.2.5' => 0,
+                                                                'calloc@GLIBC_2.2.5' => 0,
+                                                                'close@GLIBC_2.2.5' => 0,
+                                                                'closedir@GLIBC_2.2.5' => 0,
+                                                                'compress' => 0,
+                                                                'compressBound@ZLIB_1.2.0' => 0,
+                                                                'connect@GLIBC_2.2.5' => 0,
+                                                                'creat@GLIBC_2.2.5' => 0,
+                                                                'deflate' => 0,
+                                                                'deflateEnd' => 0,
+                                                                'deflateInit2_' => 0,
+                                                                'deflateInit_' => 0,
+                                                                'deflateParams' => 0,
+                                                                'fchmod@GLIBC_2.2.5' => 0,
+                                                                'fclose@GLIBC_2.2.5' => 0,
+                                                                'fcntl@GLIBC_2.2.5' => 0,
+                                                                'fflush@GLIBC_2.2.5' => 0,
+                                                                'fileno@GLIBC_2.2.5' => 0,
+                                                                'fopen@GLIBC_2.2.5' => 0,
+                                                                'fputc@GLIBC_2.2.5' => 0,
+                                                                'fputs@GLIBC_2.2.5' => 0,
+                                                                'fread@GLIBC_2.2.5' => 0,
+                                                                'free@GLIBC_2.2.5' => 0,
+                                                                'freeaddrinfo@GLIBC_2.2.5' => 0,
+                                                                'fstat@GLIBC_2.33' => 0,
+                                                                'fwrite@GLIBC_2.2.5' => 0,
+                                                                'gai_strerror@GLIBC_2.2.5' => 0,
+                                                                'gcry_cipher_close@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_decrypt@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_encrypt@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_open@GCRYPT_1.6' => 0,
+                                                                'gcry_cipher_setkey@GCRYPT_1.6' => 0,
+                                                                'gcry_md_close@GCRYPT_1.6' => 0,
+                                                                'gcry_md_get_algo_dlen@GCRYPT_1.6' => 0,
+                                                                'gcry_md_open@GCRYPT_1.6' => 0,
+                                                                'gcry_md_read@GCRYPT_1.6' => 0,
+                                                                'gcry_md_write@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_new@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_powm@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_print@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_randomize@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_release@GCRYPT_1.6' => 0,
+                                                                'gcry_mpi_scan@GCRYPT_1.6' => 0,
+                                                                'gcry_randomize@GCRYPT_1.6' => 0,
+                                                                'getaddrinfo@GLIBC_2.2.5' => 0,
+                                                                'getc@GLIBC_2.2.5' => 0,
+                                                                'getenv@GLIBC_2.2.5' => 0,
+                                                                'geteuid@GLIBC_2.2.5' => 0,
+                                                                'gethostbyname@GLIBC_2.2.5' => 0,
+                                                                'getnameinfo@GLIBC_2.2.5' => 0,
+                                                                'getpeername@GLIBC_2.2.5' => 0,
+                                                                'getpid@GLIBC_2.2.5' => 0,
+                                                                'getpwuid@GLIBC_2.2.5' => 0,
+                                                                'getrlimit@GLIBC_2.2.5' => 0,
+                                                                'getsockopt@GLIBC_2.2.5' => 0,
+                                                                'gettimeofday@GLIBC_2.2.5' => 0,
+                                                                'gmtime@GLIBC_2.2.5' => 0,
+                                                                'gnutls_bye@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_allocate_credentials@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_free_credentials@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_dh_params@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_x509_key_file@GNUTLS_3_4' => 0,
+                                                                'gnutls_certificate_set_x509_trust_file@GNUTLS_3_4' => 0,
+                                                                'gnutls_credentials_set@GNUTLS_3_4' => 0,
+                                                                'gnutls_deinit@GNUTLS_3_4' => 0,
+                                                                'gnutls_dh_params_generate2@GNUTLS_3_4' => 0,
+                                                                'gnutls_dh_params_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_global_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_global_set_log_function@GNUTLS_3_4' => 0,
+                                                                'gnutls_global_set_log_level@GNUTLS_3_4' => 0,
+                                                                'gnutls_handshake@GNUTLS_3_4' => 0,
+                                                                'gnutls_init@GNUTLS_3_4' => 0,
+                                                                'gnutls_protocol_get_name@GNUTLS_3_4' => 0,
+                                                                'gnutls_protocol_get_version@GNUTLS_3_4' => 0,
+                                                                'gnutls_record_check_pending@GNUTLS_3_4' => 0,
+                                                                'gnutls_record_recv@GNUTLS_3_4' => 0,
+                                                                'gnutls_record_send@GNUTLS_3_4' => 0,
+                                                                'gnutls_session_enable_compatibility_mode@GNUTLS_3_4' => 0,
+                                                                'gnutls_set_default_priority@GNUTLS_3_4' => 0,
+                                                                'gnutls_strerror@GNUTLS_3_4' => 0,
+                                                                'gnutls_transport_set_ptr@GNUTLS_3_4' => 0,
+                                                                'inet_addr@GLIBC_2.2.5' => 0,
+                                                                'inflate' => 0,
+                                                                'inflateEnd' => 0,
+                                                                'inflateInit_' => 0,
+                                                                'jpeg_CreateCompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_CreateDecompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_abort_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_abort_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_destroy_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_destroy_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_finish_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_finish_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_read_header@LIBJPEG_8.0' => 0,
+                                                                'jpeg_read_scanlines@LIBJPEG_8.0' => 0,
+                                                                'jpeg_resync_to_restart@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_colorspace@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_defaults@LIBJPEG_8.0' => 0,
+                                                                'jpeg_set_quality@LIBJPEG_8.0' => 0,
+                                                                'jpeg_start_compress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_start_decompress@LIBJPEG_8.0' => 0,
+                                                                'jpeg_std_error@LIBJPEG_8.0' => 0,
+                                                                'jpeg_write_scanlines@LIBJPEG_8.0' => 0,
+                                                                'listen@GLIBC_2.2.5' => 0,
+                                                                'localtime@GLIBC_2.2.5' => 0,
+                                                                'lzo1x_1_compress' => 0,
+                                                                'malloc@GLIBC_2.2.5' => 0,
+                                                                'memcmp@GLIBC_2.2.5' => 0,
+                                                                'memcpy@GLIBC_2.14' => 0,
+                                                                'memmove@GLIBC_2.2.5' => 0,
+                                                                'memset@GLIBC_2.2.5' => 0,
+                                                                'mkdir@GLIBC_2.2.5' => 0,
+                                                                'open@GLIBC_2.2.5' => 0,
+                                                                'opendir@GLIBC_2.2.5' => 0,
+                                                                'pipe@GLIBC_2.2.5' => 0,
+                                                                'png_create_info_struct@PNG16_0' => 0,
+                                                                'png_create_write_struct_2@PNG16_0' => 0,
+                                                                'png_destroy_write_struct@PNG16_0' => 0,
+                                                                'png_get_io_ptr@PNG16_0' => 0,
+                                                                'png_set_IHDR@PNG16_0' => 0,
+                                                                'png_set_compression_level@PNG16_0' => 0,
+                                                                'png_set_filter@PNG16_0' => 0,
+                                                                'png_set_write_fn@PNG16_0' => 0,
+                                                                'png_write_end@PNG16_0' => 0,
+                                                                'png_write_info@PNG16_0' => 0,
+                                                                'png_write_row@PNG16_0' => 0,
+                                                                'pthread_cond_destroy@GLIBC_2.3.2' => 0,
+                                                                'pthread_cond_init@GLIBC_2.3.2' => 0,
+                                                                'pthread_cond_signal@GLIBC_2.3.2' => 0,
+                                                                'pthread_cond_wait@GLIBC_2.3.2' => 0,
+                                                                'pthread_create@GLIBC_2.34' => 0,
+                                                                'pthread_join@GLIBC_2.34' => 0,
+                                                                'pthread_mutex_destroy@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_init@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_lock@GLIBC_2.2.5' => 0,
+                                                                'pthread_mutex_unlock@GLIBC_2.2.5' => 0,
+                                                                'putc@GLIBC_2.2.5' => 0,
+                                                                'putchar@GLIBC_2.2.5' => 0,
+                                                                'putenv@GLIBC_2.2.5' => 0,
+                                                                'random@GLIBC_2.2.5' => 0,
+                                                                'read@GLIBC_2.2.5' => 0,
+                                                                'readdir@GLIBC_2.2.5' => 0,
+                                                                'realloc@GLIBC_2.2.5' => 0,
+                                                                'recvfrom@GLIBC_2.2.5' => 0,
+                                                                'rename@GLIBC_2.2.5' => 0,
+                                                                'rmdir@GLIBC_2.2.5' => 0,
+                                                                'select@GLIBC_2.2.5' => 0,
+                                                                'setsockopt@GLIBC_2.2.5' => 0,
+                                                                'signal@GLIBC_2.2.5' => 0,
+                                                                'snprintf@GLIBC_2.2.5' => 0,
+                                                                'socket@GLIBC_2.2.5' => 0,
+                                                                'srandom@GLIBC_2.2.5' => 0,
+                                                                'stat@GLIBC_2.33' => 0,
+                                                                'stderr@GLIBC_2.2.5' => 0,
+                                                                'strcasecmp@GLIBC_2.2.5' => 0,
+                                                                'strcat@GLIBC_2.2.5' => 0,
+                                                                'strchr@GLIBC_2.2.5' => 0,
+                                                                'strcmp@GLIBC_2.2.5' => 0,
+                                                                'strcpy@GLIBC_2.2.5' => 0,
+                                                                'strcspn@GLIBC_2.2.5' => 0,
+                                                                'strdup@GLIBC_2.2.5' => 0,
+                                                                'strerror@GLIBC_2.2.5' => 0,
+                                                                'strftime@GLIBC_2.2.5' => 0,
+                                                                'strlen@GLIBC_2.2.5' => 0,
+                                                                'strncasecmp@GLIBC_2.2.5' => 0,
+                                                                'strncmp@GLIBC_2.2.5' => 0,
+                                                                'strncpy@GLIBC_2.2.5' => 0,
+                                                                'strrchr@GLIBC_2.2.5' => 0,
+                                                                'strstr@GLIBC_2.2.5' => 0,
+                                                                'strtol@GLIBC_2.2.5' => 0,
+                                                                'time@GLIBC_2.2.5' => 0,
+                                                                'uncompress' => 0,
+                                                                'unlink@GLIBC_2.2.5' => 0,
+                                                                'usleep@GLIBC_2.2.5' => 0,
+                                                                'utime@GLIBC_2.2.5' => 0,
+                                                                'write@GLIBC_2.2.5' => 0
+                                                              }
+                                },
+          'WordSize' => '8'
+        };


### PR DESCRIPTION
Fixes: #181 

This PR adds a CI job to test ABI of client & server libraries. https://github.com/lvc/abi-dumper is used for dumping library ABI, and then https://github.com/lvc/abi-compliance-checker is used to check for any breakage. Both of these are available in Ubuntu repository.

**Job Overview**
- `vncclient` & `vncserver` targets are built with debug info (required by `abi-dumper` to properly parse the library).
- New ABI is checked against a reference ABI dump. Job will fail if ABIs are incompatible.
- HTML reports generated by the checker, along with new ABI dumps, are uploaded as GitHub artifacts.
- These reports can be consulted to know exactly what broke.

@bk138 I have included reference ABI dumps in `utils/abi` directory for now (just for testing). These are generated using this job itself. The two text files are ~950KB in total, and could be moved somewhere else.

I have temporarily disabled other CI jobs to reduce testing time. I will enable them when this PR is fully ready.