### PR TITLE
libvncserver: explicit cast before shift

### DIFF
--- a/libvncserver/tableinittctemplate.c
+++ b/libvncserver/tableinittctemplate.c
@@ -126,7 +126,7 @@ rfbInitOneRGBTableOUT (OUT_T *table, int inMax, int outMax, int outShift,
     int nEntries = inMax + 1;
 
     for (i = 0; i < nEntries; i++) {
-        table[i] = ((i * outMax + inMax / 2) / inMax) << outShift;
+        table[i] = ((OUT_T)((i * outMax + inMax / 2) / inMax)) << outShift;
 #if (OUT != 8)
         if (swap) {
             table[i] = SwapOUT(table[i]);


### PR DESCRIPTION
Shifting a signed integer can result in undefined behavior.

Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=55190 cc @bk138 