### PR TITLE
Libvncclient fixes

### DIFF
--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -1964,7 +1964,7 @@ rfbClientProcessExtServerCutText(rfbClient* client, char *data, int len)
     return FALSE;
   }
   if (client->GotXCutTextUTF8)
-    client->GotXCutTextUTF8(client, buf, size);
+    client->GotXCutTextUTF8(client, (char *)buf, size);
   free(buf);
 
   inflateEnd(&stream);

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -1812,7 +1812,7 @@ sendExtClientCutTextProvide(rfbClient *client, char* data, int len)
                                                 | rfbExtendedClipboard_Text); /*text and provide*/
   const uint32_t be_size = rfbClientSwap32IfLE(len);
   const size_t sz_to_compressed = sizeof(be_size) + len; /*size, data*/
-  size_t csz = compressBound(sz_to_compressed + 1); /*tricky, some server need extar byte to flush data*/
+  uLong csz = compressBound(sz_to_compressed + 1); /*tricky, some server need extar byte to flush data*/
 
   unsigned char *buf = malloc(sz_to_compressed + 1); /*tricky, some server need extra byte to flush data*/
   if (!buf) {


### PR DESCRIPTION
Fix two minor type incompatibilities causing compiler errors when building with `-Werror`.