### PR TITLE
Fix Extended Clipboard implementation issues

### DIFF
--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -1798,6 +1798,43 @@ sendExtClientCutTextNotify(rfbClient *client)
   return ret;
 }
 
+/**
+ * Due to bugs, many servers (including most versions of LibVNCServer) can't
+ * properly handle zlib streams created by compress() function of zlib library.
+ *
+ * Primary bug is that these servers don't expect inflate() to return Z_STREAM_END
+ * which is the case for (correct) streams created by compress().
+ *
+ * So this function creates a compatible stream, for which inflate() returns Z_OK.
+ * This is how some clients create zlib streams, unintentionally avoiding the bug.
+ */
+static int
+CompressClipData(Bytef *dest, uLongf *destLen, Bytef *source, uLong sourceLen)
+{
+  int ret;
+  z_stream *zs = (z_stream*)malloc(sizeof(z_stream));
+  memset(zs, 0, sizeof(z_stream));
+
+  zs->zfree = Z_NULL;
+  zs->zalloc = Z_NULL;
+  zs->opaque = Z_NULL;
+  ret = deflateInit(zs, Z_DEFAULT_COMPRESSION);
+  if (ret == Z_OK) {
+    zs->avail_in = sourceLen;
+    zs->next_in = source;
+    zs->avail_out = *destLen;
+    zs->next_out = dest;
+
+    do {
+      // Using Z_SYNC_FLUSH instead of Z_FINISH is the key here.
+      ret = deflate(zs, Z_SYNC_FLUSH);
+    } while (ret >= 0 && zs->avail_in > 0);
+
+    *destLen = zs->total_out;
+    deflateEnd(zs);
+  }
+  return ret;
+}
 
 /*
  * sendExtClientCutTextProvide
@@ -1831,7 +1868,7 @@ sendExtClientCutTextProvide(rfbClient *client, char* data, int len)
     return FALSE;
   }
   memcpy(cbuf, &be_flags, sizeof(be_flags));
-  if (compress(cbuf + sizeof(be_flags), &csz, buf, sz_to_compressed) != Z_OK) {
+  if (CompressClipData(cbuf + sizeof(be_flags), &csz, buf, sz_to_compressed) != Z_OK) {
     rfbClientLog("sendExtClientCutTextProvide: compress cbuf failed\n");
     free(buf);
     free(cbuf);

--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -2179,7 +2179,8 @@ rfbProcessExtendedServerCutTextData(rfbClientPtr cl, uint32_t flags, const char 
         }
         stream.avail_out = size;
         stream.next_out = (unsigned char *)buf;
-        if (inflate(&stream, Z_NO_FLUSH) != Z_OK) {
+        err = inflate(&stream, Z_NO_FLUSH);
+        if (err != Z_OK && err != Z_STREAM_END) {
             rfbLogPerror("rfbProcessExtendedServerCutTextData: zlib inflation error");
             free(buf);
             inflateEnd(&stream);


### PR DESCRIPTION
1. According to spec, clipboard text is null terminated and text length includes the null byte. This is how LibVNCServer  and other clients encode this. Fixed by 2nd commit https://github.com/LibVNC/libvncserver/commit/7ff0a53d565b6f03380b08b89d05757be82b9c34


2. This is a big one. Many servers (including LibVNCServer) can't  properly handle zlib streams created by `compress()` function of zlib library. When decompressing such streams, `inflate()` correctly returns `Z_STREAM_END`, but these servers are only expecting `Z_OK`. So they end up crashing, while LibVNCserver abruptly disconnects  from client.

   This is probably why the original PR #552 was not working. New PR simply suppressed it by adding extra byte, which made `inflate()` return `Z_OK`.

**Solution:**
- LibVNCServer is fixed by 1st commit https://github.com/LibVNC/libvncserver/commit/9593244708e52fb6320b2c0671b569aa18025e41
- TigerVNC is fixed since v1.11
- Submitted fix for UltraVNC (https://github.com/ultravnc/UltraVNC/pull/74)
- Because even after these fixes large number of servers will remain affected, I propose 3rd commit: https://github.com/LibVNC/libvncserver/commit/6adf8e20b72fac84c3a25424c803b79e268e9176. It creates slightly different zlib stream, which does not trigger the bug. It gives us compatibility with all affected servers.
  