### PR TITLE
Fix memory leak on webclient disconnect

### DIFF
--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -607,6 +607,11 @@ rfbClientConnectionGone(rfbClientPtr cl)
 
     rfbLog("Client %s gone\n",cl->host);
     free(cl->host);
+	
+    if (cl->wsctx != NULL){
+        free(cl->wsctx);
+        cl->wsctx = NULL;
+    }
 
 #ifdef LIBVNCSERVER_HAVE_LIBZ
     /* Release the compression state structures if any. */


### PR DESCRIPTION
The webocket context was not free'd on client disconnect.