### PR TITLE
test: Fix comparison that is always false

### DIFF
--- a/test/tjbench.c
+++ b/test/tjbench.c
@@ -354,7 +354,8 @@ void dodecomptest(char *filename)
 {
 	FILE *file=NULL;  tjhandle handle=NULL;
 	unsigned char **jpegbuf=NULL, *srcbuf=NULL;
-	unsigned long *jpegsize=NULL, srcsize;
+	unsigned long *jpegsize=NULL;
+	long srcsize;
 	int w=0, h=0, subsamp=-1, _w, _h, _tilew, _tileh, _subsamp;
 	char *temp=NULL;
 	int i, tilew, tileh, ntilesw=1, ntilesh=1, retval=0;


### PR DESCRIPTION
If srcsize is an unsigned long, then the comparison (srcsize=ftell(file))<0 is always false.