### PR TITLE
Stop counting fds after enough free ones are encountered

### DIFF
--- a/include/rfb/rfb.h
+++ b/include/rfb/rfb.h
@@ -363,6 +363,9 @@ typedef struct _rfbScreenInfo
 	of file descriptors LibVNCServer uses before denying new client connections.
 	It is set to 0.5 per default. */
     float fdQuota;
+    /** The amount of free file descriptors after which checking for more file
+    descriptors is not necessary anymore. Set to 100_000 by default. */
+    int fdSufficientFreeCount;
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
     pthread_t listener_thread;
     int pipe_notify_listener_thread[2];

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -956,6 +956,7 @@ rfbScreenInfoPtr rfbGetScreen(int* argc,char** argv,
 #endif
 
    screen->fdQuota = 0.5;
+   screen->fdSufficientFreeCount = 100000;
 
    screen->httpInitDone=FALSE;
    screen->httpEnableProxyConnect=FALSE;


### PR DESCRIPTION
On systems with incredibly high `RLIMIT_NOFILE` (either intentionally or by accident) this can take quite a large amount of time.
Instead of checking them all, just stop after enough free ones have been encountered. 100k is a rather large number for that but the time needed to do this is quite low. My system does about about 7 million per second.

Closes #600

Disclaimer: I haven't properly tested this since I don't know how. I'd love some pointers on that.