### PR TITLE
sockets.c: Destinct pointers for restrict parameters

### DIFF
--- a/src/libvncserver/sockets.c
+++ b/src/libvncserver/sockets.c
@@ -669,6 +669,7 @@ rfbReadExactTimeout(rfbClientPtr cl, char* buf, int len, int timeout)
     rfbSocket sock = cl->sock;
     int n;
     fd_set fds;
+    fd_set exceptfds;
     struct timeval tv;
 
     while (len > 0) {
@@ -715,9 +716,10 @@ rfbReadExactTimeout(rfbClientPtr cl, char* buf, int len, int timeout)
 #endif
             FD_ZERO(&fds);
             FD_SET(sock, &fds);
+	    exceptfds = fds;
             tv.tv_sec = timeout / 1000;
             tv.tv_usec = (timeout % 1000) * 1000;
-            n = select(sock+1, &fds, NULL, &fds, &tv);
+            n = select(sock+1, &fds, NULL, &exceptfds, &tv);
             if (n < 0) {
                 rfbLogPerror("ReadExact: select");
                 return n;


### PR DESCRIPTION
Avoid passing the same pointer twice for `restrict` parameters for `select`. Rather copy the object for the second argument.