### PR TITLE
libvncserver: Add thread protection for updateBuf

### DIFF
--- a/include/rfb/rfb.h
+++ b/include/rfb/rfb.h
@@ -707,6 +707,12 @@ typedef struct _rfbClientRec {
     int tightPngDstDataLen;
 #endif
 #endif
+
+    /** for thread safety for updateBuf in rfbSendFBUpdate() */
+#if defined(LIBVNCSERVER_HAVE_LIBPTHREAD) || defined(LIBVNCSERVER_HAVE_WIN32THREADS)
+    MUTEX(updateBufMutex);
+#endif
+
 } rfbClientRec, *rfbClientPtr;
 
 /**

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -1299,7 +1299,9 @@ rfbUpdateClient(rfbClientPtr cl)
         !sraRgnEmpty(cl->requestedRegion)) {
       result=TRUE;
       if(screen->deferUpdateTime == 0) {
+          LOCK(cl->updateBufMutex);
           rfbSendFramebufferUpdate(cl,cl->modifiedRegion);
+          UNLOCK(cl->updateBufMutex);
       } else if(cl->startDeferring.tv_usec == 0) {
         gettimeofday(&cl->startDeferring,NULL);
         if(cl->startDeferring.tv_usec == 0)
@@ -1311,7 +1313,9 @@ rfbUpdateClient(rfbClientPtr cl)
                +(tv.tv_usec-cl->startDeferring.tv_usec)/1000)
              > screen->deferUpdateTime) {
           cl->startDeferring.tv_usec = 0;
+          LOCK(cl->updateBufMutex);
           rfbSendFramebufferUpdate(cl,cl->modifiedRegion);
+          UNLOCK(cl->updateBufMutex);
         }
       }
     }

--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -378,6 +378,8 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
       INIT_MUTEX(cl->sendMutex);
       INIT_COND(cl->deleteCond);
 
+      INIT_MUTEX(cl->updateBufMutex);
+
       cl->state = RFB_PROTOCOL_VERSION;
 
       cl->reverseConnection = FALSE;
@@ -649,6 +651,11 @@ rfbClientConnectionGone(rfbClientPtr cl)
     LOCK(cl->sendMutex);
     UNLOCK(cl->sendMutex);
     TINI_MUTEX(cl->sendMutex);
+
+    /* make sure updateBufMutex is unlocked before destroying */
+    LOCK(cl->updateBufMutex);
+    UNLOCK(cl->updateBufMutex);
+    TINI_MUTEX(cl->updateBufMutex);
 
 #ifdef LIBVNCSERVER_HAVE_LIBPTHREAD
     if (cl->screen->backgroundLoop) {


### PR DESCRIPTION
Thread safety for updateBuf in rfbSendFramebufferUpdate. In multi-thread mode, different threads may modify cl->updateBuf and cl->ublen at same time. When this happends libvncserver may crash.