### PR TITLE
Update SendExtDesktopSize to include expected screen data in resize message

### DIFF
--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -1715,6 +1715,14 @@ SendExtDesktopSize(rfbClient* client, uint16_t width, uint16_t height)
     sdm.width = rfbClientSwap16IfLE(width);
     sdm.height = rfbClientSwap16IfLE(height);
     sdm.numberOfScreens = 1;
+
+    /* Copy existing screen information to send with update. */
+    screen.id = client->screen.id;
+    screen.x = client->screen.x;
+    screen.y = client->screen.y;
+    screen.flags = client->screen.flags;
+
+    /* Get updated width and height for the resize. */
     screen.width = rfbClientSwap16IfLE(width);
     screen.height = rfbClientSwap16IfLE(height);
 


### PR DESCRIPTION
This pull request adds a few data points to the screen data structure that is used to send the desktop resize request to the server. In using this library with the Guacamole project, I encountered some issues getting the resize to work correctly when pointed at a TigerVNC server. A post to that mailing list and some digging in the code led to the conclusion that, while TigerVNC is expecting the screen ID, offset, and flags to contain valid data, libvncclient currently only sends the width and height, and the remaining data in the screen data structure is uninitialized.

This change copies the screen id, x and y offset, and flags, from the values in `client->screen`, which, at least for a TigerVNC server, appears to work as expected, allowing the resize to take place.