### PR TITLE
libvncclient: modify the judgment conditions of whether the screen is

### DIFF
--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -2124,7 +2124,7 @@ HandleRFBServerMessage(rfbClient* client)
           if (!ReadFromRFBServer(client, ((char *)&screen), sz_rfbExtDesktopScreen)) {
             return FALSE;
           }
-          if (screen.id != 0 && screen.width && screen.height) {
+          if (screen.width && screen.height) {
             client->screen = screen;
           } else {
             invalidScreen = TRUE;


### PR DESCRIPTION
This pull request modifies the screen validation logic in the libvncclient library when handling the ExtendedDesktopSize message. The previous implementation checked if screen.id was not equal to 0, along with validating screen.width and screen.height. However, this caused issues with certain VNC server implementations, such as TigerVNC, which may return a screen.id of 0.