### PR TITLE
libvncclient: improve compatibility with GnuTLS 3.8

### DIFF
--- a/src/libvncclient/tls_gnutls.c
+++ b/src/libvncclient/tls_gnutls.c
@@ -25,7 +25,7 @@
 #include "tls.h"
 
 
-static const char *rfbTLSPriority = "NORMAL:+DHE-DSS:+RSA:+DHE-RSA:+SRP";
+static const char *rfbTLSPriority = "NORMAL:+DHE-DSS:+RSA:+DHE-RSA";
 static const char *rfbAnonTLSPriority = "NORMAL:+ANON-ECDH:+ANON-DH";
 
 #define DH_BITS 1024


### PR DESCRIPTION
Since GnuTLS 3.8, TTLS-SRP is disabled by default at compile time [1]. As a result, connecting to a server via TLS fails with:

> Warning: Failed to set TLS priority: The request is invalid. (+SRP).

> TLS handshake failed: No or insufficient priorities were set.

On the other hand, TLS-SRP is apparently unused in libvncclient. It seems TLS-SRP requires providing serveral parameters, including a username and a password, via specific GnuTLS API [2], which I didn't find in the codebase.

[1] https://gitlab.com/gnutls/gnutls/-/merge_requests/1681
[2] https://www.gnutls.org/manual/html_node/Authentication-using-SRP.html