### PR TITLE
Libvncserver: Enable ExtendedClipboard encoding only when app signals support for UTF-8 cut-text

### DIFF
--- a/include/rfb/rfb.h
+++ b/include/rfb/rfb.h
@@ -370,6 +370,8 @@ typedef struct _rfbScreenInfo
     uintptr_t listener_thread;
 #endif
 #ifdef LIBVNCSERVER_HAVE_LIBZ
+    /** This is called when UTF-8 cut-text is received from a client.
+     *  Set this callback to enable ExtendedClipboard support. */
     rfbSetXCutTextUTF8ProcPtr setXCutTextUTF8;
 #endif
     /* Timeout value for select() calls, mainly used for multithreaded servers. */

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -1041,7 +1041,7 @@ rfbScreenInfoPtr rfbGetScreen(int* argc,char** argv,
    screen->ptrAddEvent = rfbDefaultPtrAddEvent;
    screen->setXCutText = rfbDefaultSetXCutText;
 #ifdef LIBVNCSERVER_HAVE_LIBZ
-   screen->setXCutTextUTF8 = rfbDefaultSetXCutText;
+   screen->setXCutTextUTF8 = NULL;
 #endif
    screen->getCursorPtr = rfbDefaultGetCursorPtr;
    screen->setTranslateFunction = rfbSetTranslateFunction;

--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -2193,7 +2193,7 @@ rfbProcessExtendedServerCutTextData(rfbClientPtr cl, uint32_t flags, const char 
         }
         if (i == 0) {
             /* text */
-            if (!cl->viewOnly) {
+            if (!cl->viewOnly && cl->screen->setXCutTextUTF8) {
                 cl->screen->setXCutTextUTF8(buf, size, cl);
             }
         }
@@ -2465,14 +2465,16 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
                 break;
 #ifdef LIBVNCSERVER_HAVE_LIBZ
             case rfbEncodingExtendedClipboard:
-                if (!cl->enableExtendedClipboard) {
-                    rfbLog("Enabling ExtendedClipboard extension for client "
-                           "%s\n", cl->host);
-                    cl->enableExtendedClipboard = TRUE;
-                }
-                /* send the capabilities we support, currently only text */
-                if (!rfbSendExtendedClipboardCapability(cl)) {
-                    return;
+                if (cl->screen->setXCutTextUTF8) {
+                    if (!cl->enableExtendedClipboard) {
+                        rfbLog("Enabling ExtendedClipboard extension for client "
+                               "%s\n", cl->host);
+                        cl->enableExtendedClipboard = TRUE;
+                    }
+                    /* send the capabilities we support, currently only text */
+                    if (!rfbSendExtendedClipboardCapability(cl)) {
+                        return;
+                    }
                 }
                 break;
 #endif


### PR DESCRIPTION
A UTF-8 capable client will usually prefer to send cut-text via ExtendedClipboard encoding once libvncserver declares support for it. If app doesn't assign a setXCutTextUTF8() callback, the default handler is used which is no-op. So client-to-server clipboard transfer will not work.

Re: #638