### PR TITLE
libvncclient: Add callback after client's screen size changed

### DIFF
--- a/include/rfb/rfbclient.h
+++ b/include/rfb/rfbclient.h
@@ -239,6 +239,9 @@ typedef char* (*GetUserProc)(struct _rfbClient* client);
 typedef char* (*GetSASLMechanismProc)(struct _rfbClient* client, char* mechlist);
 #endif /* LIBVNCSERVER_HAVE_SASL */
 
+/** Callback when the screen size of the client has changed. */
+typedef void (*ScreenSizeChangedProc)(struct _rfbClient* client, int width, int height);
+
 typedef struct _rfbClient {
 	uint8_t* frameBuffer;
 	int width, height;
@@ -452,6 +455,9 @@ typedef struct _rfbClient {
         GetUserProc GetUser;
 
 #endif /* LIBVNCSERVER_HAVE_SASL */
+
+	/** screen size changed nofication */
+	ScreenSizeChangedProc ScreenSizeChanged;
 
 #ifdef LIBVNCSERVER_HAVE_LIBZ
 #ifdef LIBVNCSERVER_HAVE_LIBJPEG

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -2174,6 +2174,7 @@ HandleRFBServerMessage(rfbClient* client)
             return FALSE;
           }
           rfbClientLog("Updated desktop size: %dx%d\n", rect.r.w, rect.r.h);
+          client->ScreenSizeChanged(client, rect.r.w, rect.r.h);
         }
         client->requestedResize = FALSE;
 


### PR DESCRIPTION
Add a callback function for display screen changed on server, i.e. the screen rotation occurs on mobile/tablet.

Log: Add callback after client's screen size changed.