### PR TITLE
remove unnecessary NULL checks before free()

### DIFF
--- a/src/libvncclient/cursor.c
+++ b/src/libvncclient/cursor.c
@@ -60,8 +60,7 @@ rfbBool HandleCursorShape(rfbClient* client,int xhot, int yhot, int width, int h
     return FALSE;
 
   /* Allocate memory for pixel data and temporary mask data. */
-  if(client->rcSource)
-    free(client->rcSource);
+  free(client->rcSource);
 
   client->rcSource = malloc((size_t)width * height * bytesPerPixel);
   if (client->rcSource == NULL)
@@ -146,8 +145,7 @@ rfbBool HandleCursorShape(rfbClient* client,int xhot, int yhot, int width, int h
     return FALSE;
   }
 
-  if(client->rcMask)
-    free(client->rcMask);
+  free(client->rcMask);
 
   client->rcMask = malloc((size_t)width * height);
   if (client->rcMask == NULL) {

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -605,8 +605,8 @@ HandleVncAuth(rfbClient *client)
 static void
 FreeUserCredential(rfbCredential *cred)
 {
-  if (cred->userCredential.username) free(cred->userCredential.username);
-  if (cred->userCredential.password) free(cred->userCredential.password);
+  free(cred->userCredential.username);
+  free(cred->userCredential.password);
   free(cred);
 }
 

--- a/src/libvncclient/tls_openssl.c
+++ b/src/libvncclient/tls_openssl.c
@@ -527,10 +527,10 @@ HandleAnonTLSAuth(rfbClient* client)
 static void
 FreeX509Credential(rfbCredential *cred)
 {
-  if (cred->x509Credential.x509CACertFile) free(cred->x509Credential.x509CACertFile);
-  if (cred->x509Credential.x509CACrlFile) free(cred->x509Credential.x509CACrlFile);
-  if (cred->x509Credential.x509ClientCertFile) free(cred->x509Credential.x509ClientCertFile);
-  if (cred->x509Credential.x509ClientKeyFile) free(cred->x509Credential.x509ClientKeyFile);
+  free(cred->x509Credential.x509CACertFile);
+  free(cred->x509Credential.x509CACrlFile);
+  free(cred->x509Credential.x509ClientCertFile);
+  free(cred->x509Credential.x509ClientKeyFile);
   free(cred);
 }
 

--- a/src/libvncclient/vncviewer.c
+++ b/src/libvncclient/vncviewer.c
@@ -466,9 +466,8 @@ rfbBool rfbInitClient(rfbClient* client,int* argc,char** argv) {
       } else if (i+1<*argc && strcmp(argv[i], "-repeaterdest") == 0) {
 	char* colon=strchr(argv[i+1],':');
 
-	if(client->destHost)
-	  free(client->destHost);
-        client->destPort = 5900;
+	free(client->destHost);
+	client->destPort = 5900;
 
 	client->destHost = strdup(argv[i+1]);
 	if(client->destHost && colon) {
@@ -479,8 +478,7 @@ rfbBool rfbInitClient(rfbClient* client,int* argc,char** argv) {
       } else {
 	char* colon=strrchr(argv[i],':');
 
-	if(client->serverHost)
-	  free(client->serverHost);
+	free(client->serverHost);
 
 	if(colon) {
 	  client->serverHost = strdup(argv[i]);
@@ -537,11 +535,8 @@ void rfbClientCleanup(rfbClient* client) {
 #endif /* LIBVNCSERVER_HAVE_LIBJPEG */
 #endif
 
-  if (client->ultra_buffer)
-    free(client->ultra_buffer);
-
-  if (client->raw_buffer)
-    free(client->raw_buffer);
+  free(client->ultra_buffer);
+  free(client->raw_buffer);
 
   FreeTLS(client);
 
@@ -551,8 +546,7 @@ void rfbClientCleanup(rfbClient* client) {
     client->clientData = next;
   }
 
-  if(client->vncRec)
-	  free(client->vncRec);
+  free(client->vncRec);
 
   if (client->sock != RFB_INVALID_SOCKET)
     rfbCloseSocket(client->sock);
@@ -562,18 +556,13 @@ void rfbClientCleanup(rfbClient* client) {
     rfbCloseSocket(client->listen6Sock);
   free(client->desktopName);
   free(client->serverHost);
-  if (client->destHost)
-    free(client->destHost);
-  if (client->clientAuthSchemes)
-    free(client->clientAuthSchemes);
-  if(client->rcSource)
-    free(client->rcSource);
-  if(client->rcMask)
-    free(client->rcMask);
+  free(client->destHost);
+  free(client->clientAuthSchemes);
+  free(client->rcSource);
+  free(client->rcMask);
 
 #ifdef LIBVNCSERVER_HAVE_SASL
-  if (client->saslSecret)
-    free(client->saslSecret);
+  free(client->saslSecret);
   if (client->saslconn)
     sasl_dispose(&client->saslconn);
 #endif /* LIBVNCSERVER_HAVE_SASL */

--- a/src/libvncserver/cursor.c
+++ b/src/libvncserver/cursor.c
@@ -291,7 +291,7 @@ rfbCursorPtr rfbMakeXCursor(int width,int height,char* cursorString,char* maskSt
      cursor->mask = (unsigned char*)rfbMakeMaskForXCursor(width,height,(char*)cursor->source);
    cursor->cleanupMask = TRUE;
 
-   return(cursor);
+   return cursor;
 }
 
 char* rfbMakeMaskForXCursor(int width,int height,char* source)
@@ -367,16 +367,17 @@ char* rfbMakeMaskFromAlphaSource(int width,int height,unsigned char* alphaSource
 void rfbFreeCursor(rfbCursorPtr cursor)
 {
    if(cursor) {
-       if(cursor->cleanupRichSource && cursor->richSource)
-	   free(cursor->richSource);
-       if(cursor->cleanupRichSource && cursor->alphaSource)
-	   free(cursor->alphaSource);
-       if(cursor->cleanupSource && cursor->source)
-	   free(cursor->source);
-       if(cursor->cleanupMask && cursor->mask)
-	   free(cursor->mask);
+       if(cursor->cleanupRichSource)
+       {
+         free(cursor->richSource);
+         free(cursor->alphaSource);
+       }
+       if(cursor->cleanupSource)
+        free(cursor->source);
+       if(cursor->cleanupMask)
+        free(cursor->mask);
        if(cursor->cleanup)
-	   free(cursor);
+        free(cursor);
        else {
 	   cursor->cleanup=cursor->cleanupSource=cursor->cleanupMask
 	       =cursor->cleanupRichSource=FALSE;
@@ -398,7 +399,7 @@ void rfbMakeXCursorFromRichCursor(rfbScreenInfoPtr rfbScreen,rfbCursorPtr cursor
    unsigned char bit;
    int interp = 0;
 
-   if(cursor->source && cursor->cleanupSource)
+   if(cursor->cleanupSource)
        free(cursor->source);
    cursor->source=(unsigned char*)calloc(w,cursor->height);
    if(!cursor->source)
@@ -475,7 +476,7 @@ void rfbMakeRichCursorFromXCursor(rfbScreenInfoPtr rfbScreen,rfbCursorPtr cursor
    unsigned char *cp;
    unsigned char bit;
 
-   if(cursor->richSource && cursor->cleanupRichSource)
+   if(cursor->cleanupRichSource)
        free(cursor->richSource);
    cp=cursor->richSource=(unsigned char*)calloc((size_t)cursor->width*bpp,cursor->height);
    if(!cp)

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -1163,9 +1163,9 @@ void rfbScreenCleanup(rfbScreenInfoPtr screen)
   }
   rfbReleaseClientIterator(i);
     
-#define FREE_IF(x) if(screen->x) free(screen->x)
-  FREE_IF(colourMap.data.bytes);
-  FREE_IF(underCursorBuffer);
+#define FREE_SCREEN_MEMBER(member) free(screen->member)
+  FREE_SCREEN_MEMBER(colourMap.data.bytes);
+  FREE_SCREEN_MEMBER(underCursorBuffer);
   TINI_MUTEX(screen->cursorMutex);
 
   if(screen->cursor != &myCursor)

--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -636,7 +636,7 @@ rfbClientConnectionGone(rfbClientPtr cl)
     sraRgnDestroy(cl->requestedRegion);
     sraRgnDestroy(cl->copyRegion);
 
-    if (cl->translateLookupTable) free(cl->translateLookupTable);
+    free(cl->translateLookupTable);
 
     TINI_COND(cl->updateCond);
     TINI_MUTEX(cl->updateMutex);
@@ -1115,7 +1115,7 @@ rfbSetServerVersionIdentity(rfbScreenInfoPtr screen, char *fmt, ...)
     vsnprintf(buffer, sizeof(buffer)-1, fmt, ap);
     va_end(ap);
     
-    if (screen->versionString!=NULL) free(screen->versionString);
+    free(screen->versionString);
     screen->versionString = strdup(buffer);
 }
 

--- a/src/libvncserver/zrleoutstream.c
+++ b/src/libvncserver/zrleoutstream.c
@@ -40,8 +40,7 @@ static rfbBool zrleBufferAlloc(zrleBuffer *buffer, int size)
 
 static void zrleBufferFree(zrleBuffer *buffer)
 {
-  if (buffer->start)
-    free(buffer->start);
+  free(buffer->start);
   buffer->start = buffer->ptr = buffer->end = NULL;
 }
 

--- a/test/bmp.c
+++ b/test/bmp.c
@@ -168,7 +168,7 @@ int loadppm(int *fd, unsigned char **buf, int *w, int *h,
 
 	finally:
 	if(fs) {fclose(fs);  *fd=-1;}
-	if(tempbuf) free(tempbuf);
+	free(tempbuf);
 	return retcode;
 }
 
@@ -262,7 +262,7 @@ int loadbmp(char *filename, unsigned char **buf, int *w, int *h,
 		srcbottomup!=dstbottomup);
 
 	finally:
-	if(tempbuf) free(tempbuf);
+	free(tempbuf);
 	if(fd!=-1) close(fd);
 	return retcode;
 }
@@ -291,7 +291,7 @@ int saveppm(char *filename, unsigned char *buf, int w, int h,
 	if((fwrite(tempbuf, w*h*3, 1, fs))!=1) _throw("Write error");
 
 	finally:
-	if(tempbuf) free(tempbuf);
+	free(tempbuf);
 	if(fs) fclose(fs);
 	return retcode;
 }
@@ -379,7 +379,7 @@ int savebmp(char *filename, unsigned char *buf, int w, int h,
 		_throw(strerror(errno));
 
 	finally:
-	if(tempbuf) free(tempbuf);
+	free(tempbuf);
 	if(fd!=-1) close(fd);
 	return retcode;
 }

--- a/test/tjbench.c
+++ b/test/tjbench.c
@@ -658,6 +658,6 @@ int main(int argc, char *argv[])
 	printf("\n");
 
 	bailout:
-	if(srcbuf) free(srcbuf);
+	free(srcbuf);
 	return retval;
 }

--- a/test/tjunittest.c
+++ b/test/tjunittest.c
@@ -265,7 +265,7 @@ void compTest(tjhandle handle, unsigned char **dstBuf,
 	printf("  %f ms\n  Result in %s\n", t*1000., tempStr);
 
 	bailout:
-	if(srcBuf) free(srcBuf);
+	free(srcBuf);
 }
 
 
@@ -306,7 +306,7 @@ void _decompTest(tjhandle handle, unsigned char *jpegBuf,
 	printf("  %f ms\n", t*1000.);
 
 	bailout:
-	if(dstBuf) free(dstBuf);
+	free(dstBuf);
 }
 
 
@@ -370,7 +370,7 @@ void doTest(int w, int h, const int *formats, int nformats, int subsamp,
 	if(chandle) tjDestroy(chandle);
 	if(dhandle) tjDestroy(dhandle);
 
-	if(dstBuf) free(dstBuf);
+	free(dstBuf);
 }
 
 
@@ -433,8 +433,8 @@ void bufSizeTest(void)
 	printf("Done.      \n");
 
 	bailout:
-	if(srcBuf) free(srcBuf);
-	if(jpegBuf) free(jpegBuf);
+	free(srcBuf);
+	free(jpegBuf);
 	if(handle) tjDestroy(handle);
 }
 


### PR DESCRIPTION
I found several unnecessary checks for NULL before call of free().

I removed them.

I **don't** remove the check in code that sets the pointer to NULL after the free:
```
if(p)
{
    free(p);
    p = NULL;
}
```

Additionally I found a questionable macro FREE_IF in `main.c` which seems to be a shortcut to free (with unnecessary NULL check) a member of `struct screen`.  I renamed it to FREE_SCREEN_MEMBER to reflect its purpose better, but it is used only twice, so I'd favor to remove this macro completely.