### PR TITLE
CMake: Require at least CMake 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 set(PROJECT_LANGUAGES C)
 


### PR DESCRIPTION
CMake 4 dropped support for version requirements < 3.5.