### PR TITLE
libvncserver: fix of listening for incoming connections

### DIFF
--- a/src/libvncclient/listen.c
+++ b/src/libvncclient/listen.c
@@ -103,9 +103,9 @@ listenForIncomingConnections(rfbClient* client)
 
     if (r > 0) {
       if (listenSocket != RFB_INVALID_SOCKET && FD_ISSET(listenSocket, &fds))
-	client->sock = AcceptTcpConnection(client->listenSock); 
+	client->sock = AcceptTcpConnection(listenSocket);
       else if (listen6Socket != RFB_INVALID_SOCKET && FD_ISSET(listen6Socket, &fds))
-	client->sock = AcceptTcpConnection(client->listen6Sock);
+	client->sock = AcceptTcpConnection(listen6Socket);
 
       if (client->sock == RFB_INVALID_SOCKET)
 	return;


### PR DESCRIPTION
Listening uses a socket declared as a local variable, whereas accepting used an uninitialized client member variable. Note that the use of a local variable is necessary because the pointer to the client is invalid in the child process.

The problem was highlighted with x11vnc when running a VNC repeater (x11vnc -reflect listen:5500) waiting for an incoming connection from a VNC server (x11vnc -connect IP.ADDRESS.OF.REPEATER). When an incoming connection request was submitted, the repeater did not accept it and returned an error.