### PR TITLE
The UltraVNC support has been fixed. If the authScheme of rfbUltra(17…

### DIFF
--- a/include/rfb/rfbproto.h
+++ b/include/rfb/rfbproto.h
@@ -340,6 +340,7 @@ typedef char rfbProtocolVersionMsg[13];	/* allow extra byte for null */
 #define rfbVncAuthOK 0
 #define rfbVncAuthFailed 1
 #define rfbVncAuthTooMany 2
+#define rfbVncAuthContinue 0xFFFFFFFF
 
 
 /*-----------------------------------------------------------------------------


### PR DESCRIPTION
…) is not processed, the UltraServer will not recognize the client as an UltraViewer, resulting in the TextChat function being unusable