### PR TITLE
Fix issue accessing uninitialized memory in zrle.c

### DIFF
--- a/src/libvncclient/zrle.c
+++ b/src/libvncclient/zrle.c
@@ -225,12 +225,12 @@ return TRUE;
 
 #if REALBPP!=BPP && defined(UNCOMP) && UNCOMP!=0
 #if UNCOMP>0
-#define UncompressCPixel(pointer) ((*(CARDBPP*)pointer)>>UNCOMP)
+#define UncompressCPixel(pointer) ({CARDBPP pixel=0;memcpy(&pixel,pointer,REALBPP/8);pixel>>UNCOMP;})
 #else
-#define UncompressCPixel(pointer) ((*(CARDBPP*)pointer)<<(-(UNCOMP)))
+#define UncompressCPixel(pointer) ({CARDBPP pixel=0;memcpy(&pixel,pointer,REALBPP/8);pixel<<(-UNCOMP);})
 #endif
 #else
-#define UncompressCPixel(pointer) (*(CARDBPP*)pointer)
+#define UncompressCPixel(pointer) ({CARDBPP pixel=0;memcpy(&pixel,pointer,REALBPP/8);pixel;})
 #endif
 
 static int HandleZRLETile(rfbClient* client,


### PR DESCRIPTION
This replaces pointer casting in UncompressCPixel with memcpy to prevent reading uninitialized memory when REALBPP/8 is smaller than sizeof(CARDBPP). For example, this is important if REALBPP/8 was 3 bytes but sizeof(CARDBPP) was 4 bytes.

I detected this issue and verified this fix with the help of https://github.com/google/sanitizers/wiki/memorysanitizer.