### PR TITLE
cmake: Fix the include guards in rfbconfig.h

### DIFF
--- a/include/rfb/rfbconfig.h.cmakein
+++ b/include/rfb/rfbconfig.h.cmakein
@@ -1,5 +1,5 @@
 #ifndef _RFB_RFBCONFIG_H
-#cmakedefine _RFB_RFBCONFIG_H 1
+#define _RFB_RFBCONFIG_H
  
 /* rfb/rfbconfig.h. Generated automatically by cmake. */
 


### PR DESCRIPTION
The include guard shouldn't be a cmakedefine - this is not a 0/1 define that we expect cmake to configure, it should always be defined here.

This avoids warnings like this (when building with Clang, targeting Windows), due to rfbconfig.h being included multiple times, when building with CMake:

    libvncserver/build/include/rfb/rfbconfig.h:197:13: warning: redefinition of typedef 'socklen_t' is a C11 feature [-Wtypedef-redefinition]
      197 | typedef int socklen_t;
          |             ^
    libvncserver/include/rfb/rfbproto.h:70:10: note: 'libvncserver/build/include/rfb/rfbconfig.h' included multiple times, additional include site here
       70 | #include <rfb/rfbconfig.h>
          |          ^
    libvncserver/include/rfb/threading.h:25:10: note: 'libvncserver/build/include/rfb/rfbconfig.h' included multiple times, additional include site here
       25 | #include <rfb/rfbconfig.h>
          |          ^