### PR TITLE
Adding support for ARD AuthType 33/35/36

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,11 @@ if(SYSTEMD_FOUND)
 endif(SYSTEMD_FOUND)
 
 # common crypto used by both libvncserver and libvncclient
-if(WITH_GCRYPT AND LIBGCRYPT_LIBRARIES)
+if(APPLE AND OPENSSL_FOUND)
+  message(STATUS "Building crypto with OpenSSL")
+  set(CRYPTO_LIBRARIES ${OPENSSL_LIBRARIES})
+  set(CRYPTO_SOURCES ${COMMON_DIR}/crypto_openssl.c)
+elseif(WITH_GCRYPT AND LIBGCRYPT_LIBRARIES)
   message(STATUS "Building crypto with Libgcrypt")
   set(CRYPTO_LIBRARIES ${LIBGCRYPT_LIBRARIES})
   set(CRYPTO_SOURCES ${COMMON_DIR}/crypto_libgcrypt.c)
@@ -378,6 +382,7 @@ set(LIBVNCSERVER_SOURCES
 set(LIBVNCCLIENT_SOURCES
     ${LIBVNCCLIENT_DIR}/cursor.c
     ${LIBVNCCLIENT_DIR}/listen.c
+    ${LIBVNCCLIENT_DIR}/ardauth.c
     ${LIBVNCCLIENT_DIR}/rfbclient.c
     ${LIBVNCCLIENT_DIR}/sockets.c
     ${LIBVNCCLIENT_DIR}/vncviewer.c
@@ -516,6 +521,9 @@ if(WITH_LIBVNCCLIENT)
                         ${GNUTLS_LIBRARIES}
                         ${OPENSSL_LIBRARIES}
   )
+  if(APPLE)
+    target_link_libraries(vncclient "-framework CoreFoundation" "-framework GSS" "-framework Kerberos")
+  endif()
   set(LIBVNCSERVER_LIBRARIES vncclient)
 endif(WITH_LIBVNCCLIENT)
 if(WITH_LIBVNCSERVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,7 @@ endif(X11_xcb_FOUND AND X11_xcb_xtest_FOUND AND X11_xcb_keysyms_FOUND)
 
 set(LIBVNCCLIENT_EXAMPLES
     backchannel
+    ardauthprobe
     ppmtest
 )
 
@@ -652,7 +653,11 @@ if(WITH_EXAMPLES)
 
   if(WITH_LIBVNCCLIENT)
     foreach(e ${LIBVNCCLIENT_EXAMPLES})
-      add_executable(client_examples_${e} ${LIBVNCCLIEXAMPLE_DIR}/${e}.c ${LIBVNCCLIEXAMPLE_DIR}/${${e}_EXTRA_SOURCES} )
+      if(EXISTS ${TESTS_DIR}/${e}.c)
+        add_executable(client_examples_${e} ${TESTS_DIR}/${e}.c ${LIBVNCCLIEXAMPLE_DIR}/${${e}_EXTRA_SOURCES} )
+      else()
+        add_executable(client_examples_${e} ${LIBVNCCLIEXAMPLE_DIR}/${e}.c ${LIBVNCCLIEXAMPLE_DIR}/${${e}_EXTRA_SOURCES} )
+      endif()
       set_target_properties(client_examples_${e} PROPERTIES OUTPUT_NAME ${e})
       set_target_properties(client_examples_${e} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/examples/client)
       target_link_libraries(client_examples_${e} vncclient ${CMAKE_THREAD_LIBS_INIT} ${SDL2_LIBRARY} ${GTK2_LIBRARIES} ${FFMPEG_LIBRARIES} ${LIBSSHTUNNEL_LIBRARY})

--- a/include/rfb/rfbclient.h
+++ b/include/rfb/rfbclient.h
@@ -407,6 +407,11 @@ typedef struct _rfbClient {
 	 * Set by function SetClientAuthSchemes() */
 	uint32_t *clientAuthSchemes;
 
+	/** Optional configuration for ARD Kerberos auth. */
+	char *ardAuthRealm;
+	char *ardAuthClientPrincipal;
+	char *ardAuthServicePrincipal;
+
 	/** When the server is a repeater, this specifies the final destination */
 	char *destHost;
 	int destPort;
@@ -529,6 +534,9 @@ extern rfbClientLogProc rfbClientLog,rfbClientErr;
 extern rfbBool ConnectToRFBServer(rfbClient* client,const char *hostname, int port);
 extern rfbBool ConnectToRFBRepeater(rfbClient* client,const char *repeaterHost, int repeaterPort, const char *destHost, int destPort);
 extern void SetClientAuthSchemes(rfbClient* client,const uint32_t *authSchemes, int size);
+extern rfbBool rfbClientSetARDAuthRealm(rfbClient *client, const char *realm);
+extern rfbBool rfbClientSetARDAuthClientPrincipal(rfbClient *client, const char *principal);
+extern rfbBool rfbClientSetARDAuthServicePrincipal(rfbClient *client, const char *principal);
 extern rfbBool InitialiseRFBConnection(rfbClient* client);
 /**
  * Sends format and encoding parameters to the server. Your application can

--- a/include/rfb/rfbclient.h
+++ b/include/rfb/rfbclient.h
@@ -407,11 +407,6 @@ typedef struct _rfbClient {
 	 * Set by function SetClientAuthSchemes() */
 	uint32_t *clientAuthSchemes;
 
-	/** Optional configuration for ARD Kerberos auth. */
-	char *ardAuthRealm;
-	char *ardAuthClientPrincipal;
-	char *ardAuthServicePrincipal;
-
 	/** When the server is a repeater, this specifies the final destination */
 	char *destHost;
 	int destPort;
@@ -506,10 +501,16 @@ typedef struct _rfbClient {
 	 */
         GotXCutTextUTF8Proc GotXCutTextUTF8;
 
-        /* flag to indicate wheter updateRect is managed by lib or user */
-        rfbBool isUpdateRectManagedByLib;
+	        /* flag to indicate wheter updateRect is managed by lib or user */
+	        rfbBool isUpdateRectManagedByLib;
 
-        GetX509CertFingerprintMismatchDecisionProc GetX509CertFingerprintMismatchDecision;
+	        GetX509CertFingerprintMismatchDecisionProc GetX509CertFingerprintMismatchDecision;
+
+	/** Optional configuration for ARD Kerberos auth.
+	 * Appended here to preserve offsets of pre-existing public struct fields. */
+	char *ardAuthRealm;
+	char *ardAuthClientPrincipal;
+	char *ardAuthServicePrincipal;
 } rfbClient;
 
 /* cursor.c */

--- a/include/rfb/rfbproto.h
+++ b/include/rfb/rfbproto.h
@@ -300,7 +300,10 @@ typedef char rfbProtocolVersionMsg[13];	/* allow extra byte for null */
 #define rfbTLS 18
 #define rfbVeNCrypt 19
 #define rfbSASL 20
-#define rfbARD 30
+#define rfbARDAuthDH 30
+#define rfbARDAuthRSASRP 33
+#define rfbARDAuthKerberosGSSAPI 35
+#define rfbARDAuthDirectSRP 36
 #define rfbUltraMSLogonI 0x70	/* UNIMPLEMENTED */
 #define rfbUltraMSLogonII 0x71
 #define rfbMSLogon 0xfffffffa

--- a/src/common/crypto.h
+++ b/src/common/crypto.h
@@ -5,6 +5,7 @@
 #include "rfb/rfbconfig.h"
 
 #define SHA1_HASH_SIZE 20
+#define SHA512_HASH_SIZE 64
 #define MD5_HASH_SIZE 16
 
 /* Generates an MD5 hash of 'in' and writes it to 'out', which must be 16 bytes in size. */
@@ -12,6 +13,9 @@ int hash_md5(void *out, const void *in, const size_t in_len);
 
 /* Generates an SHA1 hash of 'in' and writes it to 'out', which must be 20 bytes in size. */
 int hash_sha1(void *out, const void *in, const size_t in_len);
+
+/* Generates an SHA512 hash of 'in' and writes it to 'out', which must be 64 bytes in size. */
+int hash_sha512(void *out, const void *in, const size_t in_len);
 
 /* Fill 'out' with 'len' random bytes. */
 void random_bytes(void *out, size_t len);

--- a/src/common/crypto.h
+++ b/src/common/crypto.h
@@ -35,6 +35,9 @@ int decrypt_rfbdes(void *out, int *out_len, const unsigned char key[8], const vo
 /* Encrypts 'in' with the the 16-byte key in 'key' using AES-128-ECB and writes the result to 'out'. */
 int encrypt_aes128ecb(void *out, int *out_len, const unsigned char key[16], const void *in, const size_t in_len);
 
+/* Derives key material with PBKDF2-HMAC-SHA512. */
+int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len, const uint8_t *salt, size_t salt_len, uint32_t rounds, uint8_t *out, size_t out_len);
+
 /*
    Generates a Diffie-Hellman public-private keypair using the generator value 'gen' and prime modulo
    'prime', writing the result to 'pub_out' and 'priv_out', which must be 'keylen' in size.

--- a/src/common/crypto.h
+++ b/src/common/crypto.h
@@ -39,6 +39,12 @@ int encrypt_aes128ecb(void *out, int *out_len, const unsigned char key[16], cons
 int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len, const uint8_t *salt, size_t salt_len, uint32_t rounds, uint8_t *out, size_t out_len);
 
 /*
+  Imports an RSA public key from SubjectPublicKeyInfo DER and encrypts 'in'
+  with PKCS#1 v1.5 padding, writing the ciphertext to 'out'.
+ */
+int encrypt_rsa_pkcs1_spki_der(uint8_t *out, size_t *out_len, const uint8_t *der, size_t der_len, const void *in, size_t in_len);
+
+/*
    Generates a Diffie-Hellman public-private keypair using the generator value 'gen' and prime modulo
    'prime', writing the result to 'pub_out' and 'priv_out', which must be 'keylen' in size.
  */

--- a/src/common/crypto_included.c
+++ b/src/common/crypto_included.c
@@ -90,6 +90,18 @@ int encrypt_aes128ecb(void *out, int *out_len, const unsigned char key[16], cons
     return 0;
 }
 
+int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len, const uint8_t *salt, size_t salt_len, uint32_t rounds, uint8_t *out, size_t out_len)
+{
+    (void)password;
+    (void)password_len;
+    (void)salt;
+    (void)salt_len;
+    (void)rounds;
+    (void)out;
+    (void)out_len;
+    return 0;
+}
+
 int dh_generate_keypair(uint8_t *priv_out, uint8_t *pub_out, const uint8_t *gen, const size_t gen_len, const uint8_t *prime, const size_t keylen)
 {
     return 0;

--- a/src/common/crypto_included.c
+++ b/src/common/crypto_included.c
@@ -102,6 +102,17 @@ int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len, const uint8
     return 0;
 }
 
+int encrypt_rsa_pkcs1_spki_der(uint8_t *out, size_t *out_len, const uint8_t *der, size_t der_len, const void *in, size_t in_len)
+{
+    (void)out;
+    (void)out_len;
+    (void)der;
+    (void)der_len;
+    (void)in;
+    (void)in_len;
+    return 0;
+}
+
 int dh_generate_keypair(uint8_t *priv_out, uint8_t *pub_out, const uint8_t *gen, const size_t gen_len, const uint8_t *prime, const size_t keylen)
 {
     return 0;

--- a/src/common/crypto_included.c
+++ b/src/common/crypto_included.c
@@ -46,6 +46,14 @@ int hash_sha1(void *out, const void *in, const size_t in_len)
     return 1;
 }
 
+int hash_sha512(void *out, const void *in, const size_t in_len)
+{
+    (void)out;
+    (void)in;
+    (void)in_len;
+    return 0;
+}
+
 void random_bytes(void *out, size_t len)
 {
 

--- a/src/common/crypto_libgcrypt.c
+++ b/src/common/crypto_libgcrypt.c
@@ -220,6 +220,20 @@ int encrypt_aes128ecb(void *out, int *out_len, const unsigned char key[16], cons
     return result;
 }
 
+int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len,
+		       const uint8_t *salt, size_t salt_len, uint32_t rounds,
+		       uint8_t *out, size_t out_len)
+{
+    gcry_error_t error;
+
+    if (!password || !salt || !out || out_len == 0)
+	return 0;
+
+    error = gcry_kdf_derive(password, password_len, GCRY_KDF_PBKDF2, GCRY_MD_SHA512,
+			    salt, salt_len, rounds ? rounds : 1, out_len, out);
+    return gcry_err_code(error) == GPG_ERR_NO_ERROR;
+}
+
 int dh_generate_keypair(uint8_t *priv_out, uint8_t *pub_out, const uint8_t *gen, const size_t gen_len, const uint8_t *prime, const size_t keylen)
 {
     int result = 0;

--- a/src/common/crypto_libgcrypt.c
+++ b/src/common/crypto_libgcrypt.c
@@ -99,6 +99,31 @@ int hash_sha1(void *out, const void *in, const size_t in_len)
     return result;
 }
 
+int hash_sha512(void *out, const void *in, const size_t in_len)
+{
+    int result = 0;
+    gcry_error_t error;
+    gcry_md_hd_t sha512 = NULL;
+    void *digest;
+
+    error = gcry_md_open(&sha512, GCRY_MD_SHA512, 0);
+    if (gcry_err_code(error) != GPG_ERR_NO_ERROR)
+	goto out;
+
+    gcry_md_write(sha512, in, in_len);
+
+    if(!(digest = gcry_md_read(sha512, GCRY_MD_SHA512)))
+       goto out;
+
+    memcpy(out, digest, gcry_md_get_algo_dlen(GCRY_MD_SHA512));
+
+    result = 1;
+
+ out:
+    gcry_md_close(sha512);
+    return result;
+}
+
 void random_bytes(void *out, size_t len)
 {
     gcry_randomize(out, len, GCRY_STRONG_RANDOM);

--- a/src/common/crypto_libgcrypt.c
+++ b/src/common/crypto_libgcrypt.c
@@ -234,6 +234,19 @@ int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len,
     return gcry_err_code(error) == GPG_ERR_NO_ERROR;
 }
 
+int encrypt_rsa_pkcs1_spki_der(uint8_t *out, size_t *out_len,
+			       const uint8_t *der, size_t der_len,
+			       const void *in, size_t in_len)
+{
+    (void)out;
+    (void)out_len;
+    (void)der;
+    (void)der_len;
+    (void)in;
+    (void)in_len;
+    return 0;
+}
+
 int dh_generate_keypair(uint8_t *priv_out, uint8_t *pub_out, const uint8_t *gen, const size_t gen_len, const uint8_t *prime, const size_t keylen)
 {
     int result = 0;

--- a/src/common/crypto_openssl.c
+++ b/src/common/crypto_openssl.c
@@ -28,6 +28,8 @@
 #include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
+#include <openssl/rsa.h>
+#include <openssl/x509.h>
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #include <openssl/provider.h>
 #endif
@@ -208,6 +210,46 @@ int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len,
     return PKCS5_PBKDF2_HMAC((const char *)password, (int)password_len, salt,
 			     (int)salt_len, rounds ? (int)rounds : 1,
 			     EVP_sha512(), (int)out_len, out) == 1;
+}
+
+int encrypt_rsa_pkcs1_spki_der(uint8_t *out, size_t *out_len,
+			       const uint8_t *der, size_t der_len,
+			       const void *in, size_t in_len)
+{
+    int result = 0;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    const unsigned char *derp = der;
+    size_t required_len = 0;
+
+    if (!out || !out_len || !der || !in)
+	goto out;
+
+    pkey = d2i_PUBKEY(NULL, &derp, (long)der_len);
+    if (!pkey || EVP_PKEY_base_id(pkey) != EVP_PKEY_RSA)
+	goto out;
+
+    ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    if (!ctx)
+	goto out;
+    if (EVP_PKEY_encrypt_init(ctx) <= 0)
+	goto out;
+    if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PADDING) <= 0)
+	goto out;
+    if (EVP_PKEY_encrypt(ctx, NULL, &required_len, in, in_len) <= 0)
+	goto out;
+    if (required_len > *out_len)
+	goto out;
+    if (EVP_PKEY_encrypt(ctx, out, &required_len, in, in_len) <= 0)
+	goto out;
+
+    *out_len = required_len;
+    result = 1;
+
+ out:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return result;
 }
 
 static void pad_leading_zeros(uint8_t *out, const size_t current_len, const size_t expected_len) {

--- a/src/common/crypto_openssl.c
+++ b/src/common/crypto_openssl.c
@@ -199,6 +199,17 @@ int encrypt_aes128ecb(void *out, int *out_len, const unsigned char key[16], cons
     return result;
 }
 
+int pbkdf2_hmac_sha512(const uint8_t *password, size_t password_len,
+		       const uint8_t *salt, size_t salt_len, uint32_t rounds,
+		       uint8_t *out, size_t out_len)
+{
+    if (!password || !salt || !out || out_len == 0)
+	return 0;
+    return PKCS5_PBKDF2_HMAC((const char *)password, (int)password_len, salt,
+			     (int)salt_len, rounds ? (int)rounds : 1,
+			     EVP_sha512(), (int)out_len, out) == 1;
+}
+
 static void pad_leading_zeros(uint8_t *out, const size_t current_len, const size_t expected_len) {
     if (current_len >= expected_len || expected_len < 1)
         return;

--- a/src/common/crypto_openssl.c
+++ b/src/common/crypto_openssl.c
@@ -64,6 +64,28 @@ int hash_sha1(void *out, const void *in, const size_t in_len)
     return 1;
 }
 
+int hash_sha512(void *out, const void *in, const size_t in_len)
+{
+    EVP_MD_CTX *ctx = NULL;
+    int result = 0;
+    unsigned int digest_len = 0;
+
+    if (!(ctx = EVP_MD_CTX_new()))
+	goto out;
+    if (!EVP_DigestInit_ex(ctx, EVP_sha512(), NULL))
+	goto out;
+    if (!EVP_DigestUpdate(ctx, in, in_len))
+	goto out;
+    if (!EVP_DigestFinal_ex(ctx, out, &digest_len))
+	goto out;
+
+    result = digest_len == SHA512_HASH_SIZE;
+
+ out:
+    EVP_MD_CTX_free(ctx);
+    return result;
+}
+
 void random_bytes(void *out, size_t len)
 {
     RAND_bytes(out, len);

--- a/src/libvncclient/ardauth.c
+++ b/src/libvncclient/ardauth.c
@@ -10,7 +10,7 @@
 #include <GSS/GSS.h>
 #endif
 
-#if defined(__has_include)
+#if defined(__APPLE__) && defined(LIBVNCSERVER_HAVE_LIBSSL) && defined(__has_include)
 #if __has_include(<openssl/bn.h>)
 #include <openssl/bn.h>
 #define LIBVNCCLIENT_APPLE_HAS_OPENSSL_BN 1
@@ -148,11 +148,19 @@ static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
     int wm = WaitForMessage(client, 1500000);
     ssize_t r;
 
-    if (wm <= 0)
+    if (wm < 0)
+        return FALSE;
+    if (wm == 0)
         return TRUE;
-    r = recv(client->sock, (char *)hdr, sizeof(hdr), MSG_PEEK);
-    if (r < 4)
-        return TRUE;
+    if (client->buffered >= sizeof(hdr)) {
+        memcpy(hdr, client->bufoutptr, sizeof(hdr));
+    } else {
+        if (client->buffered > 0 || client->tlsSession || client->saslconn)
+            return TRUE;
+        r = recv(client->sock, (char *)hdr, sizeof(hdr), MSG_PEEK);
+        if (r < (ssize_t)sizeof(hdr))
+            return TRUE;
+    }
     n = ReadBEU32(hdr);
     if (n < 16 || n > 4096)
         return TRUE;
@@ -1059,15 +1067,9 @@ done:
     return ok;
 }
 
+#if defined(__APPLE__)
 static rfbBool ImportKerberosName(const char *value, gss_const_OID oid,
                                   gss_name_t *out_name, const char *what) {
-#if !defined(__APPLE__)
-    (void)value;
-    (void)oid;
-    (void)out_name;
-    (void)what;
-    return FALSE;
-#else
     OM_uint32 major = 0;
     OM_uint32 minor = 0;
     gss_buffer_desc buf = GSS_C_EMPTY_BUFFER;
@@ -1086,8 +1088,8 @@ static rfbBool ImportKerberosName(const char *value, gss_const_OID oid,
         return FALSE;
     }
     return TRUE;
-#endif
 }
+#endif
 
 static rfbBool WriteLengthPrefixedBlob(rfbClient *client, const uint8_t *buf,
                                        size_t len, const char *what) {

--- a/src/libvncclient/ardauth.c
+++ b/src/libvncclient/ardauth.c
@@ -1,0 +1,1343 @@
+#include <rfb/rfbclient.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "crypto.h"
+
+#if defined(__APPLE__)
+#include <CoreFoundation/CoreFoundation.h>
+#include <GSS/GSS.h>
+#endif
+
+#if defined(__has_include)
+#if __has_include(<openssl/bn.h>)
+#include <openssl/bn.h>
+#define LIBVNCCLIENT_APPLE_HAS_OPENSSL_BN 1
+#endif
+#endif
+
+#include "ardauth.h"
+
+static void WriteBEU16(uint8_t *out, uint16_t value) {
+    out[0] = (uint8_t)((value >> 8) & 0xff);
+    out[1] = (uint8_t)(value & 0xff);
+}
+
+static void WriteBEU32(uint8_t *out, uint32_t value) {
+    out[0] = (uint8_t)((value >> 24) & 0xff);
+    out[1] = (uint8_t)((value >> 16) & 0xff);
+    out[2] = (uint8_t)((value >> 8) & 0xff);
+    out[3] = (uint8_t)(value & 0xff);
+}
+
+static uint16_t ReadBEU16(const uint8_t *p) {
+    return (uint16_t)(((uint16_t)p[0] << 8) | (uint16_t)p[1]);
+}
+
+static uint32_t ReadBEU32(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+static uint64_t ReadBEU64(const uint8_t *p) {
+    return ((uint64_t)p[0] << 56) | ((uint64_t)p[1] << 48) |
+           ((uint64_t)p[2] << 40) | ((uint64_t)p[3] << 32) |
+           ((uint64_t)p[4] << 24) | ((uint64_t)p[5] << 16) |
+           ((uint64_t)p[6] << 8) | (uint64_t)p[7];
+}
+
+static void FreeARDUserCredential(rfbCredential *cred) {
+    if (!cred)
+        return;
+    free(cred->userCredential.username);
+    free(cred->userCredential.password);
+    free(cred);
+}
+
+static const char *GetARDSRPMethodName(uint32_t auth_type) {
+    switch (auth_type) {
+    case rfbARDAuthRSASRP:
+        return "rsa-srp";
+    case rfbARDAuthDirectSRP:
+        return "direct-srp";
+    default:
+        return "srp";
+    }
+}
+
+static int HashSHA512Parts(uint8_t out[SHA512_HASH_SIZE], const void **parts,
+                           const size_t *part_lens, size_t part_count) {
+    size_t i;
+    size_t total_len = 0;
+    uint8_t *buf = NULL;
+    uint8_t *p = NULL;
+    int ok;
+
+    if (!out)
+        return 0;
+    for (i = 0; i < part_count; ++i) {
+        if (parts[i] && part_lens[i] != 0)
+            total_len += part_lens[i];
+    }
+
+    if (total_len == 0)
+        return hash_sha512(out, "", 0);
+
+    buf = (uint8_t *)malloc(total_len);
+    if (!buf)
+        return 0;
+    p = buf;
+    for (i = 0; i < part_count; ++i) {
+        if (parts[i] && part_lens[i] != 0) {
+            memcpy(p, parts[i], part_lens[i]);
+            p += part_lens[i];
+        }
+    }
+    ok = hash_sha512(out, buf, total_len);
+    free(buf);
+    return ok;
+}
+
+static int HashSHA512TwoParts(uint8_t out[SHA512_HASH_SIZE], const void *a,
+                              size_t a_len, const void *b, size_t b_len) {
+    const void *parts[2] = {a, b};
+    const size_t lens[2] = {a_len, b_len};
+
+    return HashSHA512Parts(out, parts, lens, 2);
+}
+
+static rfbBool ReadLengthPrefixedBlob(rfbClient *client, uint8_t **outbuf,
+                                      uint32_t *outlen, const char *what) {
+    uint8_t inhdr[4];
+    uint8_t *buf = NULL;
+    uint32_t n = 0;
+
+    if (!outbuf || !outlen)
+        return FALSE;
+    *outbuf = NULL;
+    *outlen = 0;
+    if (!ReadFromRFBServer(client, (char *)inhdr, 4)) {
+        rfbClientErr("ard auth: failed reading %s length\n", what);
+        return FALSE;
+    }
+    n = ReadBEU32(inhdr);
+    if (n == 0 || n > (1u << 20)) {
+        rfbClientErr("ard auth: suspicious %s length=%u\n", what, (unsigned)n);
+        return FALSE;
+    }
+    buf = (uint8_t *)malloc(n);
+    if (!buf)
+        return FALSE;
+    if (!ReadFromRFBServer(client, (char *)buf, n)) {
+        free(buf);
+        return FALSE;
+    }
+    *outbuf = buf;
+    *outlen = n;
+    return TRUE;
+}
+
+static rfbBool WriteLengthPrefixedBlob(rfbClient *client, const uint8_t *buf,
+                                       size_t len, const char *what);
+
+static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
+    uint8_t hdr[4];
+    uint32_t n = 0;
+    uint8_t *buf = NULL;
+    int wm = WaitForMessage(client, 1500000);
+    ssize_t r;
+
+    if (wm <= 0)
+        return TRUE;
+    r = recv(client->sock, (char *)hdr, sizeof(hdr), MSG_PEEK);
+    if (r < 4)
+        return TRUE;
+    n = ReadBEU32(hdr);
+    if (n < 16 || n > 4096)
+        return TRUE;
+    if (!ReadFromRFBServer(client, (char *)hdr, 4))
+        return FALSE;
+    buf = (uint8_t *)malloc(n);
+    if (!buf)
+        return FALSE;
+    if (!ReadFromRFBServer(client, (char *)buf, n)) {
+        free(buf);
+        return FALSE;
+    }
+    free(buf);
+    return TRUE;
+}
+
+static rfbBool HandleARDAuthDH(rfbClient *client) {
+    uint8_t gen[2], len[2];
+    size_t keylen;
+    uint8_t *mod = NULL, *resp = NULL, *priv = NULL, *pub = NULL, *key = NULL,
+            *shared = NULL;
+    uint8_t userpass[128], ciphertext[128];
+    int ciphertext_len;
+    int passwordLen, usernameLen;
+    rfbCredential *cred = NULL;
+    rfbBool result = FALSE;
+
+    if (!ReadFromRFBServer(client, (char *)gen, 2)) {
+        rfbClientErr("HandleARDAuthDH: reading generator value failed\n");
+        goto out;
+    }
+    if (!ReadFromRFBServer(client, (char *)len, 2)) {
+        rfbClientErr("HandleARDAuthDH: reading key length failed\n");
+        goto out;
+    }
+    keylen = 256 * len[0] + len[1];
+
+    mod = (uint8_t *)malloc(keylen * 5);
+    if (!mod)
+        goto out;
+
+    resp = mod + keylen;
+    pub = resp + keylen;
+    priv = pub + keylen;
+    key = priv + keylen;
+
+    if (!ReadFromRFBServer(client, (char *)mod, keylen)) {
+        rfbClientErr("HandleARDAuthDH: reading prime modulus failed\n");
+        goto out;
+    }
+    if (!ReadFromRFBServer(client, (char *)resp, keylen)) {
+        rfbClientErr(
+            "HandleARDAuthDH: reading peer's generated public key failed\n");
+        goto out;
+    }
+
+    if (!dh_generate_keypair(priv, pub, gen, 2, mod, keylen)) {
+        rfbClientErr("HandleARDAuthDH: generating keypair failed\n");
+        goto out;
+    }
+
+    if (!dh_compute_shared_key(key, priv, resp, mod, keylen)) {
+        rfbClientErr("HandleARDAuthDH: creating shared key failed\n");
+        goto out;
+    }
+
+    shared = malloc(MD5_HASH_SIZE);
+    if (!hash_md5(shared, key, keylen)) {
+        rfbClientErr("HandleARDAuthDH: hashing shared key failed\n");
+        goto out;
+    }
+
+    if (!client->GetCredential) {
+        rfbClientErr("HandleARDAuthDH: GetCredential callback is not set\n");
+        goto out;
+    }
+    cred = client->GetCredential(client, rfbCredentialTypeUser);
+    if (!cred) {
+        rfbClientErr("HandleARDAuthDH: reading credential failed\n");
+        goto out;
+    }
+    passwordLen = strlen(cred->userCredential.password) + 1;
+    usernameLen = strlen(cred->userCredential.username) + 1;
+    if (passwordLen > sizeof(userpass) / 2)
+        passwordLen = sizeof(userpass) / 2;
+    if (usernameLen > sizeof(userpass) / 2)
+        usernameLen = sizeof(userpass) / 2;
+    random_bytes(userpass, sizeof(userpass));
+    memcpy(userpass, cred->userCredential.username, usernameLen);
+    memcpy(userpass + sizeof(userpass) / 2, cred->userCredential.password,
+           passwordLen);
+
+    if (!encrypt_aes128ecb(ciphertext, &ciphertext_len, shared, userpass,
+                           sizeof(userpass))) {
+        rfbClientErr("HandleARDAuthDH: encrypting credentials failed\n");
+        goto out;
+    }
+
+    if (!WriteToRFBServer(client, (char *)ciphertext, sizeof(ciphertext)))
+        goto out;
+    if (!WriteToRFBServer(client, (char *)pub, keylen))
+        goto out;
+
+    result = TRUE;
+
+out:
+    if (cred)
+        FreeARDUserCredential(cred);
+
+    free(mod);
+    free(shared);
+
+    return result;
+}
+
+struct ardsrp_challenge_fields {
+    uint8_t cflag;
+    const uint8_t *N;
+    size_t N_len;
+    const uint8_t *g;
+    size_t g_len;
+    const uint8_t *salt;
+    size_t salt_len;
+    const uint8_t *B;
+    size_t B_len;
+    uint64_t iterations;
+    const uint8_t *options;
+    size_t options_len;
+};
+
+struct ardsrp_step2 {
+    uint8_t *A;
+    size_t A_len;
+    uint8_t *m1;
+    size_t m1_len;
+    const uint8_t *options;
+    size_t options_len;
+};
+
+static int ComputeSRPStep2(const char *password, uint32_t auth_type,
+                           const struct ardsrp_challenge_fields *parsed,
+                           struct ardsrp_step2 *step2);
+static int BuildSRPStep2Response(const struct ardsrp_step2 *step2,
+                                 uint8_t *outbuf, size_t outcap,
+                                 size_t *outlen);
+
+static int ParseARDSRPChallengeFieldsAt(const uint8_t *buf, size_t n,
+                                        size_t off,
+                                        struct ardsrp_challenge_fields *out) {
+    uint16_t field_len;
+
+    if (!buf || !out || n < 11)
+        return 0;
+    memset(out, 0, sizeof(*out));
+    if (off + 1 > n)
+        return 0;
+    out->cflag = buf[off++];
+    if (off + 2 > n)
+        return 0;
+    field_len = ReadBEU16(buf + off);
+    off += 2;
+    if (off + field_len > n)
+        return 0;
+    out->N = buf + off;
+    out->N_len = field_len;
+    off += field_len;
+    if (off + 2 > n)
+        return 0;
+    field_len = ReadBEU16(buf + off);
+    off += 2;
+    if (off + field_len > n)
+        return 0;
+    out->g = buf + off;
+    out->g_len = field_len;
+    off += field_len;
+    if (off + 1 > n)
+        return 0;
+    field_len = buf[off++];
+    if (off + field_len > n)
+        return 0;
+    out->salt = buf + off;
+    out->salt_len = field_len;
+    off += field_len;
+    if (off + 2 > n)
+        return 0;
+    field_len = ReadBEU16(buf + off);
+    off += 2;
+    if (off + field_len > n)
+        return 0;
+    out->B = buf + off;
+    out->B_len = field_len;
+    off += field_len;
+    if (off + 8 > n)
+        return 0;
+    out->iterations = ReadBEU64(buf + off);
+    off += 8;
+    if (off + 2 > n)
+        return 0;
+    field_len = ReadBEU16(buf + off);
+    off += 2;
+    if (off + field_len > n)
+        return 0;
+    out->options = buf + off;
+    out->options_len = field_len;
+    off += field_len;
+    return off == n;
+}
+
+static int ParseARDSRPChallengeFields(const uint8_t *buf, size_t n,
+                                      uint32_t auth_type,
+                                      struct ardsrp_challenge_fields *out) {
+    size_t off = 0;
+
+    if (!buf || !out)
+        return 0;
+    if (auth_type == rfbARDAuthRSASRP) {
+        if (n >= 10 && memcmp(buf + 2, "RSA1", 4) == 0) {
+            off = 10;
+        } else if (n >= 6 && ReadBEU32(buf) == 2 &&
+                   ReadBEU16(buf + 4) == n - 6) {
+            off = 10;
+        } else {
+            rfbClientErr(
+                "ard %s: RSA1 challenge header missing or short (len=%lu)\n",
+                GetARDSRPMethodName(auth_type), (unsigned long)n);
+            return 0;
+        }
+    } else if (auth_type == rfbARDAuthDirectSRP) {
+        if (n < 4 || ReadBEU32(buf) != n - 4) {
+            rfbClientErr("ard %s: direct SRP challenge inner length mismatch "
+                         "(len=%lu, inner=%u)\n",
+                         GetARDSRPMethodName(auth_type), (unsigned long)n,
+                         n >= 4 ? ReadBEU32(buf) : 0);
+            return 0;
+        }
+        off = 4;
+    }
+    if (!ParseARDSRPChallengeFieldsAt(buf, n, off, out)) {
+        rfbClientErr(
+            "ard %s: failed to parse SRP challenge fields (len=%lu, off=%lu)\n",
+            GetARDSRPMethodName(auth_type), (unsigned long)n,
+            (unsigned long)off);
+        return 0;
+    }
+    return 1;
+}
+
+#if defined(__APPLE__)
+static void ReleaseCFRef(CFTypeRef ref) {
+    if (ref)
+        CFRelease(ref);
+}
+
+static void LogGSSStatus1(const char *prefix, OM_uint32 code, int status_type) {
+    OM_uint32 msg_ctx = 0;
+    OM_uint32 minor = 0;
+    gss_buffer_desc msg = GSS_C_EMPTY_BUFFER;
+
+    do {
+        if (gss_display_status(&minor, code, status_type, GSS_C_NO_OID,
+                               &msg_ctx, &msg) != GSS_S_COMPLETE)
+            break;
+        rfbClientErr("%s%s\n", prefix,
+                     msg.value ? (const char *)msg.value : "<empty>");
+        gss_release_buffer(&minor, &msg);
+    } while (msg_ctx != 0);
+}
+
+static void LogGSSError(const char *prefix, OM_uint32 major, OM_uint32 minor) {
+    char line[256];
+
+    snprintf(line, sizeof(line), "%smajor: ", prefix);
+    LogGSSStatus1(line, major, GSS_C_GSS_CODE);
+    snprintf(line, sizeof(line), "%sminor: ", prefix);
+    LogGSSStatus1(line, minor, GSS_C_MECH_CODE);
+}
+
+static void LogCFError(const char *prefix, CFErrorRef error) {
+    CFStringRef desc = NULL;
+    char buf[256];
+
+    if (!error)
+        return;
+    desc = CFErrorCopyDescription(error);
+    if (!desc)
+        return;
+    if (CFStringGetCString(desc, buf, sizeof(buf), kCFStringEncodingUTF8))
+        rfbClientErr("%s%s\n", prefix, buf);
+    CFRelease(desc);
+}
+#endif
+
+#if defined(__APPLE__) && defined(LIBVNCCLIENT_APPLE_HAS_OPENSSL_BN)
+static int BNToPad(const BIGNUM *bn, uint8_t *out, size_t out_len) {
+    if (!bn || !out || out_len == 0)
+        return 0;
+    return BN_bn2binpad(bn, out, (int)out_len) == (int)out_len;
+}
+
+static int RandomBigInt(BIGNUM *out, int bits) {
+    int byte_len;
+    uint8_t *buf;
+
+    if (!out)
+        return 0;
+    if (bits < 64)
+        bits = 64;
+    byte_len = (bits + 7) / 8;
+    buf = (uint8_t *)malloc((size_t)byte_len);
+    if (!buf)
+        return 0;
+    random_bytes(buf, (size_t)byte_len);
+    if (bits % 8)
+        buf[0] &= (uint8_t)((1u << (bits % 8)) - 1u);
+    if (BN_bin2bn(buf, byte_len, out) == NULL) {
+        free(buf);
+        return 0;
+    }
+    free(buf);
+    return 1;
+}
+#endif
+
+static int BuildRSASRPKeyRequestPacket(uint8_t *out, size_t out_len,
+                                       uint16_t packet_version) {
+    if (!out || out_len < 14)
+        return 0;
+    memset(out, 0, 14);
+    WriteBEU32(out, 10);
+    WriteBEU16(out + 4, packet_version);
+    memcpy(out + 6, "RSA1", 4);
+    return 1;
+}
+
+static int BuildRSASRPInitPacket(uint8_t *out, size_t out_len,
+                                 uint16_t packet_version, uint16_t auth_type,
+                                 uint16_t aux_type, const uint8_t *key_material,
+                                 size_t key_material_len) {
+    if (!out || !key_material || out_len < 654 || key_material_len != 256)
+        return 0;
+    memset(out, 0, 654);
+    WriteBEU32(out, 650);
+    WriteBEU16(out + 4, packet_version);
+    memcpy(out + 6, "RSA1", 4);
+    WriteBEU16(out + 10, auth_type);
+    WriteBEU16(out + 12, aux_type);
+    memcpy(out + 14, key_material, key_material_len);
+    return 1;
+}
+
+static int BuildSRPInitPlaintext(const char *username, uint8_t *out,
+                                 size_t out_len, size_t *plaintext_len) {
+    size_t user_len;
+    size_t total_plain_len;
+    uint8_t *p;
+
+    if (!username || !out || !plaintext_len)
+        return 0;
+    user_len = strlen(username);
+    if (user_len > 0xffffu)
+        return 0;
+    total_plain_len = 11 + user_len;
+    if (out_len < total_plain_len)
+        return 0;
+    memset(out, 0, out_len);
+    WriteBEU32(out, (uint32_t)(total_plain_len - 4));
+    WriteBEU16(out + 4, 0);
+    WriteBEU16(out + 6, (uint16_t)user_len);
+    memcpy(out + 8, username, user_len);
+    p = out + 8 + user_len;
+    WriteBEU16(p, 0);
+    p += 2;
+    *p = 0;
+    *plaintext_len = total_plain_len;
+    return 1;
+}
+
+static int BuildDirectSRPBranchEntryPacket(const char *username, uint8_t *out,
+                                           size_t out_len, size_t *packet_len) {
+    uint8_t plaintext[512];
+    size_t plaintext_len = 0;
+
+    if (!username || !out || !packet_len)
+        return 0;
+    if (!BuildSRPInitPlaintext(username, plaintext, sizeof(plaintext),
+                               &plaintext_len))
+        return 0;
+    if (out_len < 1 + 4 + plaintext_len)
+        return 0;
+
+    out[0] = (uint8_t)rfbARDAuthDirectSRP;
+    WriteBEU32(out + 1, (uint32_t)plaintext_len);
+    memcpy(out + 5, plaintext, plaintext_len);
+    *packet_len = 1 + 4 + plaintext_len;
+    return 1;
+}
+
+static void FreeARDSRPStep2(struct ardsrp_step2 *step2) {
+    if (!step2)
+        return;
+    free(step2->A);
+    free(step2->m1);
+    memset(step2, 0, sizeof(*step2));
+}
+
+#if defined(__APPLE__)
+static rfbBool BuildRSASRPInitKeyMaterial(const char *username,
+                                          const uint8_t *type0_reply,
+                                          uint32_t type0_reply_len,
+                                          uint8_t *outbuf, size_t outcap,
+                                          size_t *outlen) {
+    uint32_t der_len;
+    uint8_t plaintext[512];
+    size_t plaintext_len = 0;
+    const uint8_t *der;
+
+    if (!username || !type0_reply || type0_reply_len < 6 || !outbuf || !outlen)
+        return FALSE;
+    der_len = ReadBEU32(type0_reply + 2);
+    if (6u + der_len > type0_reply_len)
+        return FALSE;
+    der = type0_reply + 6;
+    if (!BuildSRPInitPlaintext(username, plaintext, sizeof(plaintext),
+                               &plaintext_len))
+        return FALSE;
+    *outlen = outcap;
+    if (!encrypt_rsa_pkcs1_spki_der(outbuf, outlen, der, der_len, plaintext,
+                                    plaintext_len))
+        return FALSE;
+    return *outlen == 256;
+}
+#else
+static rfbBool BuildRSASRPInitKeyMaterial(const char *username,
+                                          const uint8_t *type0_reply,
+                                          uint32_t type0_reply_len,
+                                          uint8_t *outbuf, size_t outcap,
+                                          size_t *outlen) {
+    (void)username;
+    (void)type0_reply;
+    (void)type0_reply_len;
+    (void)outbuf;
+    (void)outcap;
+    (void)outlen;
+    return FALSE;
+}
+#endif
+
+static int BuildSRPStep2Inner(rfbClient *client, uint32_t auth_type,
+                              const char *password, const uint8_t *challenge,
+                              uint32_t challenge_len, uint8_t *outbuf,
+                              size_t outcap, size_t *outlen) {
+    struct ardsrp_challenge_fields parsed;
+    struct ardsrp_step2 step2;
+    int ok = FALSE;
+
+    if (!client || !password || !*password || !challenge || !challenge_len ||
+        !outbuf || !outlen)
+        return FALSE;
+    if (!ParseARDSRPChallengeFields(challenge, challenge_len, auth_type,
+                                    &parsed))
+        return FALSE;
+    if (!ComputeSRPStep2(password, auth_type, &parsed, &step2))
+        return FALSE;
+    ok = BuildSRPStep2Response(&step2, outbuf, outcap, outlen);
+    if (!ok) {
+        rfbClientErr("ard %s: output buffer too small for response\n",
+                     GetARDSRPMethodName(auth_type));
+    }
+    FreeARDSRPStep2(&step2);
+    return ok;
+}
+
+static int ComputeSRPStep2(const char *password, uint32_t auth_type,
+                           const struct ardsrp_challenge_fields *parsed,
+                           struct ardsrp_step2 *step2) {
+#if !defined(__APPLE__) || !defined(LIBVNCCLIENT_APPLE_HAS_OPENSSL_BN)
+    (void)password;
+    (void)auth_type;
+    (void)parsed;
+    (void)step2;
+    return FALSE;
+#else
+    static const uint8_t empty_user_hash[SHA512_HASH_SIZE] = {
+        0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd, 0xf1, 0x54, 0x28,
+        0x50, 0xd6, 0x6d, 0x80, 0x07, 0xd6, 0x20, 0xe4, 0x05, 0x0b, 0x57,
+        0x15, 0xdc, 0x83, 0xf4, 0xa9, 0x21, 0xd3, 0x6c, 0xe9, 0xce, 0x47,
+        0xd0, 0xd1, 0x3c, 0x5d, 0x85, 0xf2, 0xb0, 0xff, 0x83, 0x18, 0xd2,
+        0x87, 0x7e, 0xec, 0x2f, 0x63, 0xb9, 0x31, 0xbd, 0x47, 0x41, 0x7a,
+        0x81, 0xa5, 0x38, 0x32, 0x7a, 0xf9, 0x27, 0xda, 0x3e};
+    BIGNUM *N = NULL;
+    BIGNUM *g = NULL;
+    BIGNUM *B = NULL;
+    BIGNUM *a = NULL;
+    BIGNUM *A = NULL;
+    BIGNUM *x = NULL;
+    BIGNUM *v = NULL;
+    BIGNUM *k = NULL;
+    BIGNUM *u = NULL;
+    BIGNUM *ux = NULL;
+    BIGNUM *exp = NULL;
+    BIGNUM *tmp = NULL;
+    BIGNUM *base = NULL;
+    BIGNUM *S = NULL;
+    BN_CTX *bn_ctx = NULL;
+    uint8_t *Np = NULL;
+    uint8_t *gp = NULL;
+    uint8_t *Ap = NULL;
+    uint8_t *Bp = NULL;
+    uint8_t *K = NULL;
+    uint8_t *pbkdf2_pass = NULL;
+    uint8_t *x_bytes = NULL;
+    uint8_t *Sp = NULL;
+    uint8_t hN[SHA512_HASH_SIZE];
+    uint8_t hg[SHA512_HASH_SIZE];
+    uint8_t hu[SHA512_HASH_SIZE];
+    uint8_t xor_ng[SHA512_HASH_SIZE];
+    uint8_t digest[SHA512_HASH_SIZE];
+    uint8_t digest2[SHA512_HASH_SIZE];
+    size_t pad_len;
+    size_t password_len;
+    size_t x_len;
+    size_t k_len;
+    size_t i;
+    int ok = FALSE;
+
+    if (!password || !*password || !parsed || !step2)
+        return FALSE;
+    memset(step2, 0, sizeof(*step2));
+
+    password_len = strlen(password);
+    pad_len = parsed->N_len;
+    N = BN_bin2bn(parsed->N, (int)parsed->N_len, NULL);
+    g = BN_bin2bn(parsed->g, (int)parsed->g_len, NULL);
+    B = BN_bin2bn(parsed->B, (int)parsed->B_len, NULL);
+    a = BN_new();
+    A = BN_new();
+    x = BN_new();
+    v = BN_new();
+    k = BN_new();
+    u = BN_new();
+    ux = BN_new();
+    exp = BN_new();
+    tmp = BN_new();
+    base = BN_new();
+    S = BN_new();
+    bn_ctx = BN_CTX_new();
+    Np = (uint8_t *)malloc(pad_len);
+    gp = (uint8_t *)malloc(pad_len);
+    Ap = (uint8_t *)malloc(pad_len);
+    Bp = (uint8_t *)malloc(pad_len);
+    step2->m1 = (uint8_t *)malloc(SHA512_HASH_SIZE);
+    if (!N || !g || !B || !a || !A || !x || !v || !k || !u || !ux || !exp ||
+        !tmp || !base || !S || !bn_ctx || !Np || !gp || !Ap || !Bp ||
+        !step2->m1) {
+        rfbClientErr("ard %s: BN allocation failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    if (!RandomBigInt(a, 512) || !BN_mod_exp(A, g, a, N, bn_ctx) ||
+        !BNToPad(N, Np, pad_len) || !BNToPad(g, gp, pad_len) ||
+        !BNToPad(B, Bp, pad_len) || !BNToPad(A, Ap, pad_len)) {
+        rfbClientErr("ard %s: failed generating or padding SRP public values\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+
+    pbkdf2_pass = (uint8_t *)malloc(128);
+    if (!pbkdf2_pass) {
+        rfbClientErr("ard %s: PBKDF buffer allocation failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    if (!pbkdf2_hmac_sha512((const uint8_t *)password, password_len,
+                            parsed->salt, parsed->salt_len,
+                            (uint32_t)parsed->iterations, pbkdf2_pass, 128)) {
+        rfbClientErr("ard %s: PBKDF2-SHA512 failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    {
+        const void *parts[2] = {":", pbkdf2_pass};
+        const size_t lens[2] = {1, 128};
+        HashSHA512Parts(digest, parts, lens, 2);
+    }
+    {
+        const void *parts[2] = {parsed->salt, digest};
+        const size_t lens[2] = {parsed->salt_len, sizeof(digest)};
+        HashSHA512Parts(digest2, parts, lens, 2);
+    }
+    x_len = sizeof(digest2);
+    x_bytes = (uint8_t *)malloc(x_len);
+    if (!x_bytes) {
+        rfbClientErr("ard %s: x buffer allocation failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    memcpy(x_bytes, digest2, x_len);
+    if (!BN_bin2bn(x_bytes, (int)x_len, x)) {
+        rfbClientErr("ard %s: BN_bin2bn(x) failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+
+    HashSHA512TwoParts(digest, Np, pad_len, gp, pad_len);
+    if (!BN_bin2bn(digest, sizeof(digest), k)) {
+        rfbClientErr("ard %s: BN_bin2bn(k) failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+
+    HashSHA512TwoParts(digest, Ap, pad_len, Bp, pad_len);
+    if (!BN_bin2bn(digest, sizeof(digest), u)) {
+        rfbClientErr("ard %s: BN_bin2bn(u) failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    if (!BN_mod_exp(v, g, x, N, bn_ctx) || !BN_mod_mul(tmp, k, v, N, bn_ctx) ||
+        !BN_mod_sub(base, B, tmp, N, bn_ctx) || !BN_mul(ux, u, x, bn_ctx) ||
+        !BN_add(exp, a, ux) || !BN_mod_exp(S, base, exp, N, bn_ctx)) {
+        rfbClientErr("ard %s: SRP shared secret computation failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+
+    Sp = (uint8_t *)malloc(pad_len);
+    if (!Sp || !BNToPad(S, Sp, pad_len)) {
+        rfbClientErr("ard %s: failed serializing shared secret\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    HashSHA512TwoParts(digest, Sp, pad_len, NULL, 0);
+    K = (uint8_t *)malloc(sizeof(digest));
+    if (!K) {
+        rfbClientErr("ard %s: session hash buffer allocation failed\n",
+                     GetARDSRPMethodName(auth_type));
+        goto done;
+    }
+    memcpy(K, digest, sizeof(digest));
+    k_len = sizeof(digest);
+    HashSHA512TwoParts(hN, Np, pad_len, NULL, 0);
+    HashSHA512TwoParts(hg, gp, pad_len, NULL, 0);
+    memcpy(hu, empty_user_hash, sizeof(hu));
+    for (i = 0; i < sizeof(xor_ng); ++i)
+        xor_ng[i] = hN[i] ^ hg[i];
+    {
+        const void *parts[6] = {xor_ng, hu, parsed->salt, Ap, Bp, K};
+        const size_t lens[6] = {sizeof(xor_ng), sizeof(hu), parsed->salt_len,
+                                pad_len,        pad_len,    k_len};
+        HashSHA512Parts(step2->m1, parts, lens, 6);
+    }
+
+    step2->A = Ap;
+    step2->A_len = pad_len;
+    Ap = NULL;
+    step2->m1_len = SHA512_HASH_SIZE;
+    step2->options = parsed->options;
+    step2->options_len = parsed->options_len;
+    ok = TRUE;
+
+done:
+    if (!ok)
+        FreeARDSRPStep2(step2);
+    BN_free(N);
+    BN_free(g);
+    BN_free(B);
+    BN_free(a);
+    BN_free(A);
+    BN_free(x);
+    BN_free(v);
+    BN_free(k);
+    BN_free(u);
+    BN_free(ux);
+    BN_free(exp);
+    BN_free(tmp);
+    BN_free(base);
+    BN_free(S);
+    BN_CTX_free(bn_ctx);
+    free(Np);
+    free(gp);
+    free(Ap);
+    free(Bp);
+    free(K);
+    free(pbkdf2_pass);
+    free(x_bytes);
+    free(Sp);
+    return ok;
+#endif
+}
+
+static int BuildSRPStep2Response(const struct ardsrp_step2 *step2,
+                                 uint8_t *outbuf, size_t outcap,
+                                 size_t *outlen) {
+    uint8_t nonce16[16];
+    size_t inner_len;
+    size_t off = 0;
+
+    if (!step2 || !step2->A || !step2->m1 || !outbuf || !outlen)
+        return FALSE;
+
+    inner_len = 2 + step2->A_len + 1 + step2->m1_len + 2 + step2->options_len +
+                1 + sizeof(nonce16);
+    if (outcap < inner_len)
+        return FALSE;
+
+    random_bytes(nonce16, sizeof(nonce16));
+    WriteBEU16(outbuf + off, (uint16_t)step2->A_len);
+    off += 2;
+    memcpy(outbuf + off, step2->A, step2->A_len);
+    off += step2->A_len;
+    outbuf[off++] = (uint8_t)step2->m1_len;
+    memcpy(outbuf + off, step2->m1, step2->m1_len);
+    off += step2->m1_len;
+    WriteBEU16(outbuf + off, (uint16_t)step2->options_len);
+    off += 2;
+    memcpy(outbuf + off, step2->options, step2->options_len);
+    off += step2->options_len;
+    outbuf[off++] = (uint8_t)sizeof(nonce16);
+    memcpy(outbuf + off, nonce16, sizeof(nonce16));
+    off += sizeof(nonce16);
+    *outlen = off;
+    return TRUE;
+}
+
+static int BuildRSASRPPacket2Candidate(rfbClient *client, const char *password,
+                                       const uint8_t *challenge,
+                                       uint32_t challenge_len, uint8_t *outbuf,
+                                       size_t outcap, size_t *outlen) {
+#if !defined(__APPLE__) || !defined(LIBVNCCLIENT_APPLE_HAS_OPENSSL_BN)
+    (void)client;
+    (void)password;
+    (void)challenge;
+    (void)challenge_len;
+    (void)outbuf;
+    (void)outcap;
+    (void)outlen;
+    return FALSE;
+#else
+    uint8_t inner[4096];
+    size_t inner_len = 0;
+    size_t wrapped_body_len;
+    size_t wrapped_len;
+
+    if (!BuildSRPStep2Inner(client, rfbARDAuthRSASRP, password, challenge,
+                            challenge_len, inner, sizeof(inner), &inner_len)) {
+        return FALSE;
+    }
+
+    wrapped_body_len = 4 + inner_len;
+    wrapped_len = wrapped_body_len + 384;
+    if (!outbuf || !outlen || outcap < 14 + wrapped_len)
+        return FALSE;
+    memset(outbuf, 0, 14 + wrapped_len);
+    WriteBEU16(outbuf + 14 + 0, 0);
+    WriteBEU16(outbuf + 14 + 2, (uint16_t)inner_len);
+    memcpy(outbuf + 14 + 4, inner, inner_len);
+    WriteBEU32(outbuf, (uint32_t)(10 + wrapped_len));
+    WriteBEU16(outbuf + 4, 0x0100);
+    memcpy(outbuf + 6, "RSA1", 4);
+    WriteBEU16(outbuf + 10, 0x0002);
+    WriteBEU16(outbuf + 12, (uint16_t)wrapped_body_len);
+    *outlen = 14 + wrapped_len;
+    return TRUE;
+#endif
+}
+
+static rfbBool HandleARDAuthRSASRP(rfbClient *client) {
+    uint8_t outbuf[8192];
+    uint8_t keyreq[14];
+    uint8_t init_key_material[256];
+    uint8_t *type0_reply = NULL;
+    uint8_t *inbuf = NULL;
+    size_t outlen = 654;
+    uint32_t type0_reply_len = 0;
+    uint32_t inlen = 0;
+    uint16_t packet_version = 0x0100;
+    uint16_t auth_type = 0x0002;
+    uint16_t aux_type = 0x0100;
+    rfbCredential *cred = NULL;
+    rfbBool ok = FALSE;
+
+    if (!client->GetCredential) {
+        rfbClientErr("ard rsa-srp: GetCredential callback is not set\n");
+        return FALSE;
+    }
+    cred = client->GetCredential(client, rfbCredentialTypeUser);
+    if (!cred || !cred->userCredential.username ||
+        !cred->userCredential.password) {
+        rfbClientErr("ard rsa-srp: reading credential failed\n");
+        FreeARDUserCredential(cred);
+        return FALSE;
+    }
+
+    memset(outbuf, 0, sizeof(outbuf));
+
+    if (!BuildRSASRPKeyRequestPacket(keyreq, sizeof(keyreq), packet_version))
+        goto done;
+    if (!WriteToRFBServer(client, (const char *)keyreq, sizeof(keyreq)))
+        goto done;
+    if (!ReadLengthPrefixedBlob(client, &type0_reply, &type0_reply_len,
+                                "rsa-srp type0 reply"))
+        goto done;
+
+    if (!BuildRSASRPInitKeyMaterial(cred->userCredential.username, type0_reply,
+                                    type0_reply_len, init_key_material,
+                                    sizeof(init_key_material), &outlen)) {
+        goto done;
+    }
+    free(type0_reply);
+    type0_reply = NULL;
+
+    outlen = 654;
+    if (!BuildRSASRPInitPacket(outbuf, sizeof(outbuf), packet_version,
+                               auth_type, aux_type, init_key_material,
+                               sizeof(init_key_material))) {
+        goto done;
+    }
+    if (!WriteToRFBServer(client, (const char *)outbuf, (unsigned int)outlen))
+        goto done;
+
+    if (!ReadLengthPrefixedBlob(client, &inbuf, &inlen, "rsa-srp challenge"))
+        goto done;
+    if (!BuildRSASRPPacket2Candidate(client, cred->userCredential.password,
+                                     inbuf, inlen, outbuf, sizeof(outbuf),
+                                     &outlen)) {
+        goto done;
+    }
+    free(inbuf);
+    inbuf = NULL;
+    if (!WriteToRFBServer(client, (const char *)outbuf, (unsigned int)outlen))
+        goto done;
+    if (!ConsumeRSASRPServerFinalIfPresent(client))
+        goto done;
+
+    ok = TRUE;
+
+done:
+    FreeARDUserCredential(cred);
+    free(type0_reply);
+    free(inbuf);
+    return ok;
+}
+
+static rfbBool HandleARDAuthDirectSRP(rfbClient *client) {
+    uint8_t entry[1024];
+    uint8_t response_inner[4096];
+    uint8_t response[4100];
+    uint8_t *challenge = NULL;
+    uint8_t *final_token = NULL;
+    uint32_t challenge_len = 0;
+    uint32_t final_token_len = 0;
+    size_t entry_len = 0;
+    size_t response_inner_len = 0;
+    size_t response_len = 0;
+    rfbCredential *cred = NULL;
+    rfbBool ok = FALSE;
+
+    if (!client->GetCredential) {
+        rfbClientErr("ard direct-srp: GetCredential callback is not set\n");
+        return FALSE;
+    }
+    cred = client->GetCredential(client, rfbCredentialTypeUser);
+    if (!cred || !cred->userCredential.username ||
+        !cred->userCredential.password) {
+        rfbClientErr("ard direct-srp: reading credential failed\n");
+        FreeARDUserCredential(cred);
+        return FALSE;
+    }
+
+    if (!BuildDirectSRPBranchEntryPacket(cred->userCredential.username, entry,
+                                         sizeof(entry), &entry_len)) {
+        goto done;
+    }
+    if (!WriteToRFBServer(client, (const char *)entry, (unsigned int)entry_len))
+        goto done;
+
+    if (!ReadLengthPrefixedBlob(client, &challenge, &challenge_len,
+                                "direct-srp challenge"))
+        goto done;
+    if (!BuildSRPStep2Inner(client, rfbARDAuthDirectSRP,
+                            cred->userCredential.password, challenge,
+                            challenge_len, response_inner,
+                            sizeof(response_inner), &response_inner_len)) {
+        goto done;
+    }
+    if (response_inner_len > 0xffffffffu ||
+        response_inner_len + 4 > sizeof(response))
+        goto done;
+    WriteBEU32(response, (uint32_t)response_inner_len);
+    memcpy(response + 4, response_inner, response_inner_len);
+    response_len = response_inner_len + 4;
+    if (!WriteLengthPrefixedBlob(client, response, response_len,
+                                 "direct-srp response"))
+        goto done;
+    if (!ReadLengthPrefixedBlob(client, &final_token, &final_token_len,
+                                "direct-srp final token"))
+        goto done;
+
+    ok = TRUE;
+
+done:
+    FreeARDUserCredential(cred);
+    free(challenge);
+    free(final_token);
+    return ok;
+}
+
+static rfbBool ImportKerberosName(const char *value, gss_const_OID oid,
+                                  gss_name_t *out_name, const char *what) {
+#if !defined(__APPLE__)
+    (void)value;
+    (void)oid;
+    (void)out_name;
+    (void)what;
+    return FALSE;
+#else
+    OM_uint32 major = 0;
+    OM_uint32 minor = 0;
+    gss_buffer_desc buf = GSS_C_EMPTY_BUFFER;
+
+    if (!value || !out_name)
+        return FALSE;
+    *out_name = GSS_C_NO_NAME;
+    buf.value = (void *)value;
+    buf.length = strlen(value);
+    major = gss_import_name(&minor, &buf, oid, out_name);
+    if (major != GSS_S_COMPLETE) {
+        char prefix[128];
+        snprintf(prefix, sizeof(prefix),
+                 "ard kerberos: gss_import_name(%s) failed: ", what);
+        LogGSSError(prefix, major, minor);
+        return FALSE;
+    }
+    return TRUE;
+#endif
+}
+
+static rfbBool WriteLengthPrefixedBlob(rfbClient *client, const uint8_t *buf,
+                                       size_t len, const char *what) {
+    uint8_t hdr[4];
+
+    if (!client || !buf || len == 0 || len > 0xffffffffu)
+        return FALSE;
+    WriteBEU32(hdr, (uint32_t)len);
+    if (!WriteToRFBServer(client, (const char *)hdr, sizeof(hdr))) {
+        rfbClientErr("ard kerberos: failed writing %s length\n", what);
+        return FALSE;
+    }
+    if (!WriteToRFBServer(client, (const char *)buf, (unsigned int)len)) {
+        rfbClientErr("ard kerberos: failed writing %s body\n", what);
+        return FALSE;
+    }
+    return TRUE;
+}
+
+#if defined(__APPLE__)
+static char *BuildKerberosClientPrincipal(rfbClient *client,
+                                          const char *username) {
+    const char *override = client ? client->ardAuthClientPrincipal : NULL;
+    const char *realm = client ? client->ardAuthRealm : NULL;
+    size_t need = 0;
+    char *out = NULL;
+
+    if (override)
+        return strdup(override);
+    if (!username || !*username)
+        return NULL;
+    if (strchr(username, '@'))
+        return strdup(username);
+    if (!realm || !*realm)
+        return NULL;
+    need = strlen(username) + 1 + strlen(realm) + 1;
+    out = (char *)malloc(need);
+    if (!out)
+        return NULL;
+    snprintf(out, need, "%s@%s", username, realm);
+    return out;
+}
+
+static char *BuildKerberosServicePrincipal(rfbClient *client) {
+    const char *override = client ? client->ardAuthServicePrincipal : NULL;
+    const char *realm = client ? client->ardAuthRealm : NULL;
+    const char *serverHost = client ? client->serverHost : NULL;
+    size_t need = 0;
+    char *out = NULL;
+
+    if (override)
+        return strdup(override);
+    if (!serverHost || !*serverHost || !realm || !*realm)
+        return NULL;
+    need = 4 + strlen(serverHost) + 1 + strlen(realm) + 1;
+    out = (char *)malloc(need);
+    if (!out)
+        return NULL;
+    snprintf(out, need, "vnc/%s@%s", serverHost, realm);
+    return out;
+}
+
+static rfbBool HandleARDAuthKerberosGSSAPI(rfbClient *client) {
+    static const uint8_t preface[4] = {0x00, 0x00, 0x00, 0x00};
+    uint8_t zero_word[4];
+    uint8_t *aprep = NULL;
+    uint8_t *wrap = NULL;
+    uint32_t aprep_len = 0;
+    uint32_t wrap_len = 0;
+    rfbCredential *cred = NULL;
+    gss_name_t user_name = GSS_C_NO_NAME;
+    gss_name_t target_name = GSS_C_NO_NAME;
+    gss_cred_id_t gss_cred = GSS_C_NO_CREDENTIAL;
+    gss_ctx_id_t gss_ctx = GSS_C_NO_CONTEXT;
+    gss_buffer_desc input = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc output = GSS_C_EMPTY_BUFFER;
+    OM_uint32 major = 0;
+    OM_uint32 minor = 0;
+    OM_uint32 ret_flags = 0;
+    int conf_state = 0;
+    CFStringRef password = NULL;
+    CFStringRef lkdc_host = NULL;
+    CFMutableDictionaryRef attrs = NULL;
+    CFErrorRef cferr = NULL;
+    char *client_principal = NULL;
+    char *service_principal = NULL;
+    rfbBool ok = FALSE;
+
+    if (!client->GetCredential) {
+        rfbClientErr("ard kerberos: GetCredential callback is not set\n");
+        return FALSE;
+    }
+    cred = client->GetCredential(client, rfbCredentialTypeUser);
+    if (!cred || !cred->userCredential.username ||
+        !cred->userCredential.password || !client->serverHost ||
+        !*client->serverHost) {
+        rfbClientErr("ard kerberos: reading credential or hostname failed\n");
+        goto done;
+    }
+
+    if (!WriteToRFBServer(client, (const char *)preface, sizeof(preface)))
+        goto done;
+    if (!ReadFromRFBServer(client, (char *)zero_word, sizeof(zero_word)))
+        goto done;
+    if (ReadBEU32(zero_word) != 0)
+        rfbClientLog("ard kerberos: server preface word was 0x%08x\n",
+                     ReadBEU32(zero_word));
+
+    client_principal =
+        BuildKerberosClientPrincipal(client, cred->userCredential.username);
+    service_principal = BuildKerberosServicePrincipal(client);
+    if (!client_principal || !service_principal) {
+        rfbClientErr(
+            "ard kerberos: missing Kerberos configuration. Set ARD auth "
+            "realm/service overrides on the client or pass a "
+            "fully-qualified Kerberos principal in VNC_USER.\n");
+        goto done;
+    }
+    if (!ImportKerberosName(client_principal, GSS_KRB5_NT_PRINCIPAL_NAME,
+                            &user_name, "client principal"))
+        goto done;
+
+    password = CFStringCreateWithCString(kCFAllocatorDefault,
+                                         cred->userCredential.password,
+                                         kCFStringEncodingUTF8);
+    lkdc_host = CFStringCreateWithCString(
+        kCFAllocatorDefault, client->serverHost, kCFStringEncodingUTF8);
+    attrs = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                                      &kCFTypeDictionaryKeyCallBacks,
+                                      &kCFTypeDictionaryValueCallBacks);
+    if (!password || !lkdc_host || !attrs)
+        goto done;
+    CFDictionarySetValue(attrs, kGSSICPassword, password);
+    CFDictionarySetValue(attrs, kGSSCredentialUsage, kGSS_C_INITIATE);
+    CFDictionarySetValue(attrs, kGSSICLKDCHostname, lkdc_host);
+
+    major = gss_aapl_initial_cred(user_name, gss_mech_krb5, attrs, &gss_cred,
+                                  &cferr);
+    if (major != GSS_S_COMPLETE || gss_cred == GSS_C_NO_CREDENTIAL) {
+        LogCFError("ard kerberos: gss_aapl_initial_cred failed: ", cferr);
+        LogGSSError("ard kerberos: gss_aapl_initial_cred failed: ", major, 0);
+        goto done;
+    }
+
+    if (!ImportKerberosName(service_principal, GSS_KRB5_NT_PRINCIPAL_NAME,
+                            &target_name, "service principal"))
+        goto done;
+
+    major = gss_init_sec_context(
+        &minor, gss_cred, &gss_ctx, target_name, (gss_OID)gss_mech_krb5,
+        GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG, 0, GSS_C_NO_CHANNEL_BINDINGS,
+        GSS_C_NO_BUFFER, NULL, &output, &ret_flags, NULL);
+    if ((major != GSS_S_COMPLETE && major != GSS_S_CONTINUE_NEEDED) ||
+        output.length == 0) {
+        LogGSSError("ard kerberos: initial gss_init_sec_context failed: ",
+                    major, minor);
+        goto done;
+    }
+    if (!WriteLengthPrefixedBlob(client, (const uint8_t *)output.value,
+                                 output.length, "AP-REQ")) {
+        gss_release_buffer(&minor, &output);
+        goto done;
+    }
+    gss_release_buffer(&minor, &output);
+
+    if (!ReadLengthPrefixedBlob(client, &aprep, &aprep_len, "kerberos AP-REP"))
+        goto done;
+    input.value = aprep;
+    input.length = aprep_len;
+    major = gss_init_sec_context(
+        &minor, gss_cred, &gss_ctx, target_name, (gss_OID)gss_mech_krb5,
+        GSS_C_MUTUAL_FLAG | GSS_C_SEQUENCE_FLAG, 0, GSS_C_NO_CHANNEL_BINDINGS,
+        &input, NULL, &output, &ret_flags, NULL);
+    if (major != GSS_S_COMPLETE) {
+        LogGSSError("ard kerberos: AP-REP processing failed: ", major, minor);
+        goto done;
+    }
+    if (output.length != 0) {
+        rfbClientErr(
+            "ard kerberos: unexpected AP-REP output token length=%lu\n",
+            (unsigned long)output.length);
+        gss_release_buffer(&minor, &output);
+        goto done;
+    }
+    gss_release_buffer(&minor, &output);
+
+    if (!ReadLengthPrefixedBlob(client, &wrap, &wrap_len,
+                                "kerberos wrap token"))
+        goto done;
+    input.value = wrap;
+    input.length = wrap_len;
+    major = gss_unwrap(&minor, gss_ctx, &input, &output, &conf_state, NULL);
+    if (major != GSS_S_COMPLETE) {
+        LogGSSError("ard kerberos: gss_unwrap failed: ", major, minor);
+        goto done;
+    }
+    if (!conf_state) {
+        rfbClientErr(
+            "ard kerberos: wrap token did not provide confidentiality\n");
+        gss_release_buffer(&minor, &output);
+        goto done;
+    }
+    gss_release_buffer(&minor, &output);
+    ok = TRUE;
+
+done:
+    if (gss_ctx != GSS_C_NO_CONTEXT)
+        gss_delete_sec_context(&minor, &gss_ctx, GSS_C_NO_BUFFER);
+    if (gss_cred != GSS_C_NO_CREDENTIAL)
+        gss_release_cred(&minor, &gss_cred);
+    if (user_name != GSS_C_NO_NAME)
+        gss_release_name(&minor, &user_name);
+    if (target_name != GSS_C_NO_NAME)
+        gss_release_name(&minor, &target_name);
+    if (output.length != 0)
+        gss_release_buffer(&minor, &output);
+    ReleaseCFRef(cferr);
+    ReleaseCFRef(attrs);
+    ReleaseCFRef(password);
+    ReleaseCFRef(lkdc_host);
+    FreeARDUserCredential(cred);
+    free(client_principal);
+    free(service_principal);
+    free(aprep);
+    free(wrap);
+    return ok;
+}
+#else
+static rfbBool HandleARDAuthKerberosGSSAPI(rfbClient *client) {
+    (void)client;
+    rfbClientErr(
+        "ARD Kerberos GSS-API auth requires macOS GSS/Kerberos support\n");
+    return FALSE;
+}
+#endif
+
+rfbBool rfbClientHandleARDAuth(rfbClient *client, uint32_t authScheme) {
+    if (!client)
+        return FALSE;
+
+    switch (authScheme) {
+    case rfbARDAuthDH:
+        return HandleARDAuthDH(client);
+    case rfbARDAuthRSASRP:
+        return HandleARDAuthRSASRP(client);
+    case rfbARDAuthKerberosGSSAPI:
+        return HandleARDAuthKerberosGSSAPI(client);
+    case rfbARDAuthDirectSRP:
+        return HandleARDAuthDirectSRP(client);
+    default:
+        return FALSE;
+    }
+}

--- a/src/libvncclient/ardauth.c
+++ b/src/libvncclient/ardauth.c
@@ -152,7 +152,7 @@ static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
     uint32_t n = 0;
     uint8_t *buf = NULL;
     int wm = WaitForMessage(client, 1500000);
-    ssize_t r;
+    int r;
 
     if (wm < 0)
         return FALSE;
@@ -164,7 +164,7 @@ static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
         if (client->buffered > 0 || client->tlsSession || ARD_CLIENT_HAS_SASL_STATE(client))
             return TRUE;
         r = recv(client->sock, (char *)hdr, sizeof(hdr), MSG_PEEK);
-        if (r < (ssize_t)sizeof(hdr))
+        if (r < (int)sizeof(hdr))
             return TRUE;
     }
     n = ReadBEU32(hdr);

--- a/src/libvncclient/ardauth.c
+++ b/src/libvncclient/ardauth.c
@@ -141,6 +141,12 @@ static rfbBool ReadLengthPrefixedBlob(rfbClient *client, uint8_t **outbuf,
 static rfbBool WriteLengthPrefixedBlob(rfbClient *client, const uint8_t *buf,
                                        size_t len, const char *what);
 
+#ifdef LIBVNCSERVER_HAVE_SASL
+#define ARD_CLIENT_HAS_SASL_STATE(client) ((client)->saslconn != NULL)
+#else
+#define ARD_CLIENT_HAS_SASL_STATE(client) FALSE
+#endif
+
 static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
     uint8_t hdr[4];
     uint32_t n = 0;
@@ -155,7 +161,7 @@ static rfbBool ConsumeRSASRPServerFinalIfPresent(rfbClient *client) {
     if (client->buffered >= sizeof(hdr)) {
         memcpy(hdr, client->bufoutptr, sizeof(hdr));
     } else {
-        if (client->buffered > 0 || client->tlsSession || client->saslconn)
+        if (client->buffered > 0 || client->tlsSession || ARD_CLIENT_HAS_SASL_STATE(client))
             return TRUE;
         r = recv(client->sock, (char *)hdr, sizeof(hdr), MSG_PEEK);
         if (r < (ssize_t)sizeof(hdr))

--- a/src/libvncclient/ardauth.h
+++ b/src/libvncclient/ardauth.h
@@ -1,0 +1,8 @@
+#ifndef LIBVNCSERVER_SRC_LIBVNCCLIENT_ARDAUTH_H
+#define LIBVNCSERVER_SRC_LIBVNCCLIENT_ARDAUTH_H
+
+#include <rfb/rfbclient.h>
+
+rfbBool rfbClientHandleARDAuth(rfbClient *client, uint32_t authScheme);
+
+#endif

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -131,12 +131,10 @@ SupportsARDAuthScheme(uint8_t authScheme)
 #if defined(__APPLE__)
 	case rfbARDAuthKerberosGSSAPI:
 		return TRUE;
-#if defined(__has_include)
-#if __has_include(<openssl/bn.h>)
+#if defined(LIBVNCSERVER_HAVE_LIBSSL)
 	case rfbARDAuthRSASRP:
 	case rfbARDAuthDirectSRP:
 		return TRUE;
-#endif
 #endif
 #endif
 	default:

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -102,6 +102,28 @@ rfbClientLogProc rfbClientErr=rfbDefaultClientLog;
 
 rfbClientProtocolExtension* rfbClientExtensions = NULL;
 
+static rfbBool
+SupportsARDAuthScheme(uint8_t authScheme)
+{
+	switch (authScheme) {
+	case rfbARDAuthDH:
+		return TRUE;
+#if defined(__APPLE__)
+	case rfbARDAuthKerberosGSSAPI:
+		return TRUE;
+#if defined(__has_include)
+#if __has_include(<openssl/bn.h>)
+	case rfbARDAuthRSASRP:
+	case rfbARDAuthDirectSRP:
+		return TRUE;
+#endif
+#endif
+#endif
+	default:
+		return FALSE;
+	}
+}
+
 void rfbClientRegisterExtension(rfbClientProtocolExtension* e)
 {
 	e->next = rfbClientExtensions;
@@ -465,12 +487,14 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
 {
     uint8_t count=0;
     uint8_t loop=0;
-    uint8_t flag=0;
+    uint8_t selectedLoop=0;
     rfbBool extAuthHandler;
     uint8_t tAuth[256];
     char buf1[500],buf2[10];
     uint32_t authScheme;
     rfbClientProtocolExtension* e;
+    rfbBool selected=FALSE;
+    int selectedPriority=-1;
 
     if (!ReadFromRFBServer(client, (char *)&count, 1)) return FALSE;
 
@@ -500,7 +524,6 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
 			break;
 		}
 
-        if (flag) continue;
         extAuthHandler=FALSE;
         for (e = rfbClientExtensions; e; e = e->next) {
             if (!e->handleAuthentication) continue;
@@ -519,7 +542,8 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
 #ifdef LIBVNCSERVER_HAVE_SASL
             tAuth[loop]==rfbSASL ||
 #endif /* LIBVNCSERVER_HAVE_SASL */
-            ((tAuth[loop]==rfbARD || tAuth[loop]==rfbUltraMSLogonII) && client->GetCredential))
+            (((SupportsARDAuthScheme(tAuth[loop])) ||
+              tAuth[loop]==rfbUltraMSLogonII) && client->GetCredential))
         {
             if (!subAuth && client->clientAuthSchemes)
             {
@@ -528,22 +552,23 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
                 {
                     if (client->clientAuthSchemes[i]==(uint32_t)tAuth[loop])
                     {
-                        flag++;
-                        authScheme=tAuth[loop];
+                        if (!selected || selectedPriority < 0 || i < selectedPriority) {
+                            selected=TRUE;
+                            selectedPriority=i;
+                            selectedLoop=loop;
+                            authScheme=tAuth[loop];
+                        }
                         break;
                     }
                 }
             }
             else
             {
-                flag++;
-                authScheme=tAuth[loop];
-            }
-            if (flag)
-            {
-                rfbClientLog("Selecting security type %d (%d/%d in the list)\n", authScheme, loop, count);
-                /* send back a single byte indicating which security type to use */
-                if (!WriteToRFBServer(client, (char *)&tAuth[loop], 1)) return FALSE;
+                if (!selected) {
+                    selected=TRUE;
+                    selectedLoop=loop;
+                    authScheme=tAuth[loop];
+                }
             }
         }
     }
@@ -560,9 +585,15 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
                buf1);
         return FALSE;
     }
+    rfbClientLog("Selecting security type %d (%d/%d in the list)\n", authScheme, selectedLoop, count);
+    if (authScheme != rfbARDAuthDirectSRP) {
+        uint8_t selectedType = (uint8_t)authScheme;
+        if (!WriteToRFBServer(client, (char *)&selectedType, 1)) return FALSE;
+    }
     *result = authScheme;
     return TRUE;
 }
+
 
 static rfbBool
 HandleVncAuth(rfbClient *client)

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -103,6 +103,25 @@ rfbClientLogProc rfbClientErr=rfbDefaultClientLog;
 rfbClientProtocolExtension* rfbClientExtensions = NULL;
 
 static rfbBool
+SetOptionalClientString(char **dst, const char *value)
+{
+	char *copy = NULL;
+
+	if (!dst)
+		return FALSE;
+
+	if (value) {
+		copy = strdup(value);
+		if (!copy)
+			return FALSE;
+	}
+
+	free(*dst);
+	*dst = copy;
+	return TRUE;
+}
+
+static rfbBool
 SupportsARDAuthScheme(uint8_t authScheme)
 {
 	switch (authScheme) {
@@ -985,6 +1004,30 @@ SetClientAuthSchemes(rfbClient* client,const uint32_t *authSchemes, int size)
       client->clientAuthSchemes[size] = 0;
     }
   }
+}
+
+rfbBool
+rfbClientSetARDAuthRealm(rfbClient *client, const char *realm)
+{
+  if (!client)
+    return FALSE;
+  return SetOptionalClientString(&client->ardAuthRealm, realm);
+}
+
+rfbBool
+rfbClientSetARDAuthClientPrincipal(rfbClient *client, const char *principal)
+{
+  if (!client)
+    return FALSE;
+  return SetOptionalClientString(&client->ardAuthClientPrincipal, principal);
+}
+
+rfbBool
+rfbClientSetARDAuthServicePrincipal(rfbClient *client, const char *principal)
+{
+  if (!client)
+    return FALSE;
+  return SetOptionalClientString(&client->ardAuthServicePrincipal, principal);
 }
 
 /*

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -64,6 +64,7 @@
 #include "minilzo.h"
 #endif
 #include "tls.h"
+#include "ardauth.h"
 
 #define MAX_TEXTCHAT_SIZE 10485760 /* 10MB */
 
@@ -613,7 +614,6 @@ ReadSupportedSecurityType(rfbClient* client, uint32_t *result, rfbBool subAuth)
     return TRUE;
 }
 
-
 static rfbBool
 HandleVncAuth(rfbClient *client)
 {
@@ -852,129 +852,6 @@ HandleMSLogonAuth(rfbClient *client)
   return TRUE;
 }
 
-
-static rfbBool
-HandleARDAuth(rfbClient *client)
-{
-  uint8_t gen[2], len[2];
-  size_t keylen;
-  uint8_t *mod = NULL, *resp = NULL, *priv = NULL, *pub = NULL, *key = NULL, *shared = NULL;
-  uint8_t userpass[128], ciphertext[128];
-  int ciphertext_len;
-  int passwordLen, usernameLen;
-  rfbCredential *cred = NULL;
-  rfbBool result = FALSE;
-
-  /* Step 1: Read the authentication material from the socket.
-     A two-byte generator value, a two-byte key length value. */
-  if (!ReadFromRFBServer(client, (char *)gen, 2)) {
-      rfbClientErr("HandleARDAuth: reading generator value failed\n");
-      goto out;
-  }
-  if (!ReadFromRFBServer(client, (char *)len, 2)) {
-      rfbClientErr("HandleARDAuth: reading key length failed\n");
-      goto out;
-  }
-  keylen = 256*len[0]+len[1]; /* convert from char[] to int */
-
-  mod = (uint8_t*)malloc(keylen*5); /* the block actually contains mod, resp, pub, priv and key */
-  if (!mod)
-      goto out;
-
-  resp = mod+keylen;
-  pub = resp+keylen;
-  priv = pub+keylen;
-  key = priv+keylen;
-
-  /* Step 1: Read the authentication material from the socket.
-     The prime modulus (keylen bytes) and the peer's generated public key (keylen bytes). */
-  if (!ReadFromRFBServer(client, (char *)mod, keylen)) {
-      rfbClientErr("HandleARDAuth: reading prime modulus failed\n");
-      goto out;
-  }
-  if (!ReadFromRFBServer(client, (char *)resp, keylen)) {
-      rfbClientErr("HandleARDAuth: reading peer's generated public key failed\n");
-      goto out;
-  }
-
-  /* Step 2: Generate own Diffie-Hellman public-private key pair. */
-  if(!dh_generate_keypair(priv, pub, gen, 2, mod, keylen)) {
-      rfbClientErr("HandleARDAuth: generating keypair failed\n");
-      goto out;
-  }
-
-  /* Step 3: Perform Diffie-Hellman key agreement, using the generator (gen),
-     prime (mod), and the peer's public key. The output will be a shared
-     secret known to both us and the peer. */
-  if(!dh_compute_shared_key(key, priv, resp, mod, keylen)) {
-      rfbClientErr("HandleARDAuth: creating shared key failed\n");
-      goto out;
-  }
-
-  /* Step 4: Perform an MD5 hash of the shared secret.
-     This 128-bit (16-byte) value will be used as the AES key. */
-  shared = malloc(MD5_HASH_SIZE);
-  if(!hash_md5(shared, key, keylen)) {
-      rfbClientErr("HandleARDAuth: hashing shared key failed\n");
-      goto out;
-  }
-
-  /* Step 5: Pack the username and password into a 128-byte
-     plaintext "userpass" structure: { username[64], password[64] }.
-     Null-terminate each. Fill the unused bytes with random characters
-     so that the encryption output is less predictable. */
-  if(!client->GetCredential) {
-      rfbClientErr("HandleARDAuth: GetCredential callback is not set\n");
-      goto out;
-  }
-  cred = client->GetCredential(client, rfbCredentialTypeUser);
-  if(!cred) {
-      rfbClientErr("HandleARDAuth: reading credential failed\n");
-      goto out;
-  }
-  passwordLen = strlen(cred->userCredential.password)+1;
-  usernameLen = strlen(cred->userCredential.username)+1;
-  if (passwordLen > sizeof(userpass)/2)
-      passwordLen = sizeof(userpass)/2;
-  if (usernameLen > sizeof(userpass)/2)
-      usernameLen = sizeof(userpass)/2;
-  random_bytes(userpass, sizeof(userpass));
-  memcpy(userpass, cred->userCredential.username, usernameLen);
-  memcpy(userpass+sizeof(userpass)/2, cred->userCredential.password, passwordLen);
-
-  /* Step 6: Encrypt the plaintext credentials with the 128-bit MD5 hash
-     from step 4, using the AES 128-bit symmetric cipher in electronic
-     codebook (ECB) mode. Use no further padding for this block cipher. */
-  if(!encrypt_aes128ecb(ciphertext, &ciphertext_len, shared, userpass, sizeof(userpass))) {
-      rfbClientErr("HandleARDAuth: encrypting credentials failed\n");
-      goto out;
-  }
-
-  /* Step 7: Write the ciphertext from step 6 to the stream.
-     Write the generated DH public key to the stream. */
-  if (!WriteToRFBServer(client, (char *)ciphertext, sizeof(ciphertext)))
-      goto out;
-  if (!WriteToRFBServer(client, (char *)pub, keylen))
-      goto out;
-
-  /* Handle the SecurityResult message */
-  if (!rfbHandleAuthResult(client))
-      goto out;
-
-  result = TRUE;
-
- out:
-  if (cred)
-    FreeUserCredential(cred);
-
-  free(mod);
-  free(shared);
-
-  return result;
-}
-
-
-
 /*
  * SetClientAuthSchemes.
  */
@@ -1154,8 +1031,12 @@ InitialiseRFBConnection(rfbClient* client)
     if (!HandleMSLogonAuth(client)) return FALSE;
     break;
 
-  case rfbARD:
-    if (!HandleARDAuth(client)) return FALSE;
+  case rfbARDAuthDH:
+  case rfbARDAuthRSASRP:
+  case rfbARDAuthKerberosGSSAPI:
+  case rfbARDAuthDirectSRP:
+    if (!rfbClientHandleARDAuth(client, authScheme)) return FALSE;
+    if (!rfbHandleAuthResult(client)) return FALSE;
     break;
 
   case rfbTLS:

--- a/src/libvncclient/vncviewer.c
+++ b/src/libvncclient/vncviewer.c
@@ -396,6 +396,9 @@ rfbClient* rfbGetClient(int bitsPerSample,int samplesPerPixel,
   client->listen6Sock = RFB_INVALID_SOCKET;
   client->listen6Address = NULL;
   client->clientAuthSchemes = NULL;
+  client->ardAuthRealm = NULL;
+  client->ardAuthClientPrincipal = NULL;
+  client->ardAuthServicePrincipal = NULL;
 
 #ifdef LIBVNCSERVER_HAVE_SASL
   client->GetSASLMechanism = NULL;
@@ -588,6 +591,9 @@ void rfbClientCleanup(rfbClient* client) {
   free(client->serverHost);
   free(client->destHost);
   free(client->clientAuthSchemes);
+  free(client->ardAuthRealm);
+  free(client->ardAuthClientPrincipal);
+  free(client->ardAuthServicePrincipal);
   free(client->rcSource);
   free(client->rcMask);
 

--- a/test/ardauthprobe.c
+++ b/test/ardauthprobe.c
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
     int init_argc = 2;
     char *init_argv[3] = {NULL, NULL, NULL};
 
-    if (argc < 3 || strcmp(argv[1], "-auth") != 0 ||
+    if (argc < 4 || strcmp(argv[1], "-auth") != 0 ||
         !ParseAuthType(argv[2], &auth_types[0])) {
         fprintf(stderr, "usage: %s -auth <security-type> <host[:port]>\n",
                 argv[0]);

--- a/test/ardauthprobe.c
+++ b/test/ardauthprobe.c
@@ -1,0 +1,152 @@
+/**
+ * @example ardauthprobe.c
+ *
+ * Headless ARD auth probe client for testing one forced security type at a
+ * time against a remote Screen Sharing / ARD server.
+ *
+ * Usage:
+ *   VNC_USER=<username> VNC_PASS=<password> \
+ *   ./ardauthprobe -auth <security-type> <host[:port]>
+ *
+ * Optional Kerberos overrides for auth type 35:
+ *   VNC_ARD_REALM=<realm>
+ *   VNC_ARD_CLIENT_PRINCIPAL=<client-principal>
+ *   VNC_ARD_SERVICE_PRINCIPAL=<service-principal>
+ *
+ * Example:
+ *   VNC_USER=alex VNC_PASS=secret \
+ *   ./ardauthprobe -auth 33 Alexs-Mac-mini.local:5900
+ *
+ * ARD auth type samples:
+ *   -auth 30   ARD DH
+ *   -auth 33   ARD RSA-SRP
+ *   -auth 35   ARD Kerberos GSS-API
+ *   -auth 36   ARD Direct SRP
+ *
+ * Kerberos sample:
+ *   VNC_USER=alex VNC_PASS=secret \
+ *   VNC_ARD_REALM='LKDC:SHA1.XXXXXX' \
+ *   VNC_ARD_SERVICE_PRINCIPAL='vnc/LKDC:SHA1.XXXXXX@LKDC:SHA1.XXXXXX' \
+ *   ./ardauthprobe -auth 35 Alexs-Mac-mini.local:5900
+ *
+ * On success the probe prints one AUTH_OK line with the requested and selected
+ * auth schemes plus the negotiated desktop name and size, then exits.
+ */
+
+#include <rfb/rfbclient.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void HandleRect(rfbClient *client, int x, int y, int w, int h) {
+    (void)client;
+    (void)x;
+    (void)y;
+    (void)w;
+    (void)h;
+}
+
+static rfbCredential *GetCredential(rfbClient *client, int credentialType) {
+    const char *user = getenv("VNC_USER");
+    const char *pass = getenv("VNC_PASS");
+    rfbCredential *cred = NULL;
+
+    (void)client;
+    if (credentialType != rfbCredentialTypeUser)
+        return NULL;
+    if (!user || !pass) {
+        rfbClientErr("Set VNC_USER and VNC_PASS in the environment.\n");
+        return NULL;
+    }
+
+    cred = (rfbCredential *)calloc(1, sizeof(*cred));
+    if (!cred)
+        return NULL;
+    cred->userCredential.username = strdup(user);
+    cred->userCredential.password = strdup(pass);
+    if (!cred->userCredential.username || !cred->userCredential.password) {
+        free(cred->userCredential.username);
+        free(cred->userCredential.password);
+        free(cred);
+        return NULL;
+    }
+    return cred;
+}
+
+/*
+ * Kerberos-based ARD auth needs more than a username/password pair. These
+ * environment variables let the probe supply the same realm/principal data we
+ * discover externally from Keychain or prior captures without hardcoding it.
+ */
+static void ApplyOptionalKerberosConfig(rfbClient *client) {
+    const char *realm = getenv("VNC_ARD_REALM");
+    const char *client_principal = getenv("VNC_ARD_CLIENT_PRINCIPAL");
+    const char *service_principal = getenv("VNC_ARD_SERVICE_PRINCIPAL");
+
+    if (realm && *realm)
+        rfbClientSetARDAuthRealm(client, realm);
+    if (client_principal && *client_principal)
+        rfbClientSetARDAuthClientPrincipal(client, client_principal);
+    if (service_principal && *service_principal)
+        rfbClientSetARDAuthServicePrincipal(client, service_principal);
+}
+
+static int ParseAuthType(const char *value, uint32_t *out) {
+    char *end = NULL;
+    unsigned long parsed = 0;
+
+    if (!value || !out)
+        return 0;
+    parsed = strtoul(value, &end, 0);
+    if (!end || *end != '\0' || parsed > 255)
+        return 0;
+    *out = (uint32_t)parsed;
+    return 1;
+}
+
+int main(int argc, char **argv) {
+    rfbClient *client = NULL;
+    uint32_t auth_types[2] = {0, 0};
+    int init_argc = 2;
+    char *init_argv[3] = {NULL, NULL, NULL};
+
+    if (argc < 3 || strcmp(argv[1], "-auth") != 0 ||
+        !ParseAuthType(argv[2], &auth_types[0])) {
+        fprintf(stderr, "usage: %s -auth <security-type> <host[:port]>\n",
+                argv[0]);
+        return 2;
+    }
+
+    client = rfbGetClient(8, 3, 4);
+    if (!client) {
+        fprintf(stderr, "failed to create VNC client\n");
+        return 1;
+    }
+
+    client->GotFrameBufferUpdate = HandleRect;
+    client->GetCredential = GetCredential;
+    ApplyOptionalKerberosConfig(client);
+
+    /* Restrict negotiation to the requested auth type so each probe run
+     * answers one concrete question about server compatibility. */
+    SetClientAuthSchemes(client, auth_types, -1);
+
+    init_argv[0] = argv[0];
+    init_argv[1] = argv[3];
+
+    if (!rfbInitClient(client, &init_argc, init_argv)) {
+        rfbClientCleanup(client);
+        return 1;
+    }
+
+    fprintf(stderr,
+            "AUTH_OK requested=%u selected=%u subauth=%u desktop=\"%s\" "
+            "size=%dx%d\n",
+            auth_types[0], client->authScheme, client->subAuthScheme,
+            client->desktopName ? client->desktopName : "",
+            client->width, client->height);
+
+    rfbClientCleanup(client);
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces support for Apple Remote Desktop (ARD) authentication schemes and adds new cryptographic functionality to the codebase (to support this PR). The changes include updates to the build system for OpenSSL support on macOS, new ARD auth configuration options in the client, and implementations for key cryptographic primitives such as SHA-512, PBKDF2-HMAC-SHA512, and RSA encryption. The client authentication selection logic has been refactored to support multiple ARD schemes and prioritize user preferences.

### ARD Authentication Support

* Added new ARD authentication schemes (`rfbARDAuthDH`, `rfbARDAuthRSASRP`, `rfbARDAuthKerberosGSSAPI`, `rfbARDAuthDirectSRP`) and logic to select and handle them in the client, including `ardauth.h` and integration in `rfbclient.c`. [[1]](diffhunk://#diff-22c6a3346c33fca0b43c5064783b237803d60ad11fed361b19e9e5932ea95212L303-R306) [[2]](diffhunk://#diff-e86c325dbc54b6d33e75896d820d3adc55be0d30b3e6708d10dd618c80165828R1-R8) [[3]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2R67) [[4]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2R106-R146) [[5]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2L468-R517) [[6]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2L503) [[7]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2L522-R566) [[8]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2L531-L546) [[9]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2R608-R612)
* Extended the `rfbClient` struct with optional ARD Kerberos authentication configuration fields and added setter functions for these fields. [[1]](diffhunk://#diff-764191075de76d419365d48a3bd7deec9cf2dd37372b405f9d7f141739b6e294R410-R414) [[2]](diffhunk://#diff-764191075de76d419365d48a3bd7deec9cf2dd37372b405f9d7f141739b6e294R537-R539)

### Cryptography Enhancements

* Added SHA-512 hash, PBKDF2-HMAC-SHA512 key derivation, and RSA PKCS#1 encryption primitives to the cryptographic API, with implementations for OpenSSL and Libgcrypt. [[1]](diffhunk://#diff-67844f9e3afb4e118bf9d16b6d9ffd4d05973e4b5bd2ac39460f4667d6d668c6R8) [[2]](diffhunk://#diff-67844f9e3afb4e118bf9d16b6d9ffd4d05973e4b5bd2ac39460f4667d6d668c6R17-R19) [[3]](diffhunk://#diff-67844f9e3afb4e118bf9d16b6d9ffd4d05973e4b5bd2ac39460f4667d6d668c6R38-R46) [[4]](diffhunk://#diff-7ce67cd45afc643cb2a59f5652cbeeb6169b46a0ac3966371af30543088353f2R49-R56) [[5]](diffhunk://#diff-7ce67cd45afc643cb2a59f5652cbeeb6169b46a0ac3966371af30543088353f2R93-R115) [[6]](diffhunk://#diff-b6c1070c8f92a4bc9d5d22a67d6f25fd5270ecf35c4b32456cd1a1034c939c62R102-R126) [[7]](diffhunk://#diff-b6c1070c8f92a4bc9d5d22a67d6f25fd5270ecf35c4b32456cd1a1034c939c62R223-R249) [[8]](diffhunk://#diff-0a4bc3338f5e5efa2e220b18521c7e43e733390ccd16bb1cddb2065a4aa60a3eR31-R32) [[9]](diffhunk://#diff-0a4bc3338f5e5efa2e220b18521c7e43e733390ccd16bb1cddb2065a4aa60a3eR69-R90) [[10]](diffhunk://#diff-0a4bc3338f5e5efa2e220b18521c7e43e733390ccd16bb1cddb2065a4aa60a3eR204-R254)

### Build System and Platform Support

* Updated `CMakeLists.txt` to build crypto with OpenSSL on macOS, link ARD authentication sources, and add macOS-specific frameworks for the VNC client. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL251-R255) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR385) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR524-R526)
* Added new example and test targets for ARD authentication probing in the build system. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR607) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR656-R660)

These changes collectively enable ARD authentication in the VNC client, provide the necessary cryptographic primitives, and ensure proper build and linking, especially for macOS platforms.