### PR TITLE
Rename hash functions to prevent naming collisions

### DIFF
--- a/src/common/crypto.h
+++ b/src/common/crypto.h
@@ -8,11 +8,11 @@
 #define MD5_HASH_SIZE 16
 
 /* Generates an MD5 hash of 'in' and writes it to 'out', which must be 16 bytes in size. */
-int hash_md5(void *out, const void *in, const size_t in_len);
+int libvnc_hash_md5(void *out, const void *in, const size_t in_len);
 
 /* Generates an SHA1 hash of 'in' and writes it to 'out', which must be 20 bytes in size. */
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
-int hash_sha1(void *out, const void *in, const size_t in_len);
+int libvnc_hash_sha1(void *out, const void *in, const size_t in_len);
 #endif
 
 /* Fill 'out' with 'len' random bytes. */

--- a/src/common/crypto_included.c
+++ b/src/common/crypto_included.c
@@ -28,13 +28,13 @@
 #include "crypto.h"
 
 
-int hash_md5(void *out, const void *in, const size_t in_len)
+int libvnc_hash_md5(void *out, const void *in, const size_t in_len)
 {
     return 0;
 }
 
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
-int hash_sha1(void *out, const void *in, const size_t in_len)
+int libvnc_hash_sha1(void *out, const void *in, const size_t in_len)
 {
     SHA1Context sha1;
     if(SHA1Reset(&sha1) != shaSuccess)

--- a/src/common/crypto_libgcrypt.c
+++ b/src/common/crypto_libgcrypt.c
@@ -49,7 +49,7 @@ static unsigned char reverseByte(unsigned char b) {
    return b;
 }
 
-int hash_md5(void *out, const void *in, const size_t in_len)
+int libvnc_hash_md5(void *out, const void *in, const size_t in_len)
 {
     int result = 0;
     gcry_error_t error;
@@ -75,7 +75,7 @@ int hash_md5(void *out, const void *in, const size_t in_len)
 }
 
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
-int hash_sha1(void *out, const void *in, const size_t in_len)
+int libvnc_hash_sha1(void *out, const void *in, const size_t in_len)
 {
     int result = 0;
     gcry_error_t error;

--- a/src/common/crypto_openssl.c
+++ b/src/common/crypto_openssl.c
@@ -40,7 +40,7 @@ static unsigned char reverseByte(unsigned char b) {
    return b;
 }
 
-int hash_md5(void *out, const void *in, const size_t in_len)
+int libvnc_hash_md5(void *out, const void *in, const size_t in_len)
 {
     MD5_CTX md5;
     if(!MD5_Init(&md5))
@@ -53,7 +53,7 @@ int hash_md5(void *out, const void *in, const size_t in_len)
 }
 
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
-int hash_sha1(void *out, const void *in, const size_t in_len)
+int libvnc_hash_sha1(void *out, const void *in, const size_t in_len)
 {
     SHA_CTX sha1;
     if(!SHA1_Init(&sha1))

--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -864,7 +864,7 @@ HandleARDAuth(rfbClient *client)
   /* Step 4: Perform an MD5 hash of the shared secret.
      This 128-bit (16-byte) value will be used as the AES key. */
   shared = malloc(MD5_HASH_SIZE);
-  if(!hash_md5(shared, key, keylen)) {
+  if(!libvnc_hash_md5(shared, key, keylen)) {
       rfbClientErr("HandleARDAuth: hashing shared key failed\n");
       goto out;
   }

--- a/src/libvncserver/websockets.c
+++ b/src/libvncserver/websockets.c
@@ -104,7 +104,7 @@ static void webSocketsGenSha1Key(char *target, int size, char *key)
     char tmp[strlen(key) + sizeof(GUID) - 1];
     memcpy(tmp, key, strlen(key));
     memcpy(tmp + strlen(key), GUID, sizeof(GUID) - 1);
-    hash_sha1(hash, tmp, sizeof(tmp));
+    libvnc_hash_sha1(hash, tmp, sizeof(tmp));
     if (-1 == rfbBase64NtoP(hash, sizeof(hash), target, size))
 	rfbErr("rfbBase64NtoP failed\n");
 }


### PR DESCRIPTION
…s. This should help prevent issues when linking against multiple crypto libraries in the same project.
This pull request standardizes the naming of cryptographic hash functions across the codebase by renaming the `hash_md5` and `hash_sha1` functions to `libvnc_hash_md5` and `libvnc_hash_sha1`, respectively. This change affects their declarations, definitions, and all usages, improving clarity and avoiding potential naming conflicts.

**Function renaming for clarity and consistency:**

* Renamed `hash_md5` to `libvnc_hash_md5` and `hash_sha1` to `libvnc_hash_sha1` in the function declarations in `crypto.h` and all corresponding implementations in `crypto_included.c`, `crypto_libgcrypt.c`, and `crypto_openssl.c`. [[1]](diffhunk://#diff-67844f9e3afb4e118bf9d16b6d9ffd4d05973e4b5bd2ac39460f4667d6d668c6L11-R15) [[2]](diffhunk://#diff-7ce67cd45afc643cb2a59f5652cbeeb6169b46a0ac3966371af30543088353f2L31-R37) [[3]](diffhunk://#diff-b6c1070c8f92a4bc9d5d22a67d6f25fd5270ecf35c4b32456cd1a1034c939c62L52-R52) [[4]](diffhunk://#diff-b6c1070c8f92a4bc9d5d22a67d6f25fd5270ecf35c4b32456cd1a1034c939c62L78-R78) [[5]](diffhunk://#diff-0a4bc3338f5e5efa2e220b18521c7e43e733390ccd16bb1cddb2065a4aa60a3eL43-R43) [[6]](diffhunk://#diff-0a4bc3338f5e5efa2e220b18521c7e43e733390ccd16bb1cddb2065a4aa60a3eL56-R56)

**Codebase-wide updates to use new function names:**

* Updated all calls to the renamed functions in the codebase, including in `rfbclient.c` and `websockets.c`, to use `libvnc_hash_md5` and `libvnc_hash_sha1`. [[1]](diffhunk://#diff-ae4609c00155d5883414fc097deb936ab25ec90937b5fcead2c14fc7919259f2L867-R867) [[2]](diffhunk://#diff-45789544ad5a08e53a9127fd568bd5b49e8f670fbd32d9ffebfa62704320eb5dL107-R107)