### PR TITLE
LibVNCClient: bound Tight Gradient width

### DIFF
--- a/include/rfb/rfbclient.h
+++ b/include/rfb/rfbclient.h
@@ -328,10 +328,11 @@ typedef struct _rfbClient {
 	rfbBool zlibStreamActive[4];
 
 	/* Filter stuff. Should be initialized by filter initialization code. */
+#define TIGHT_GRADIENT_MAX_WIDTH 2048
 	rfbBool cutZeros;
 	int rectWidth, rectColors;
 	char tightPalette[256*4];
-	uint8_t tightPrevRow[2048*3*sizeof(uint16_t)];
+	uint8_t tightPrevRow[TIGHT_GRADIENT_MAX_WIDTH*3*sizeof(uint16_t)];
 
 #ifdef LIBVNCSERVER_HAVE_LIBJPEG
 	/** JPEG decoder state (obsolete-- do not use). */

--- a/src/libvncclient/tight.c
+++ b/src/libvncclient/tight.c
@@ -229,6 +229,11 @@ HandleTightBPP (rfbClient* client, int rx, int ry, int rw, int rh)
       bitsPixel = InitFilterPaletteBPP(client, rw, rh);
       break;
     case rfbTightFilterGradient:
+      if (rw > TIGHT_GRADIENT_MAX_WIDTH) {
+	rfbClientLog("Tight Gradient rectangle width %d exceeds maximum %d.\n",
+		     rw, TIGHT_GRADIENT_MAX_WIDTH);
+	return FALSE;
+      }
       filterFn = FilterGradientBPP;
       bitsPixel = InitFilterGradientBPP(client, rw, rh);
       break;
@@ -430,7 +435,7 @@ FilterGradient24 (rfbClient* client, int srcx, int srcy, int numRows)
   CARDBPP *dst =
     (CARDBPP *)&client->frameBuffer[(srcy * client->width + srcx) * BPP / 8];
   int x, y, c;
-  uint8_t thisRow[2048*3];
+  uint8_t thisRow[TIGHT_GRADIENT_MAX_WIDTH*3];
   uint8_t pix[3];
   int est[3];
 
@@ -473,7 +478,7 @@ FilterGradientBPP (rfbClient* client, int srcx, int srcy, int numRows)
   int x, y, c;
   CARDBPP *src = (CARDBPP *)client->buffer;
   uint16_t *thatRow = (uint16_t *)client->tightPrevRow;
-  uint16_t thisRow[2048*3];
+  uint16_t thisRow[TIGHT_GRADIENT_MAX_WIDTH*3];
   uint16_t pix[3];
   uint16_t max[3];
   int shift[3];
@@ -705,4 +710,3 @@ ReadCompactLen (rfbClient* client)
 /* LIBVNCSERVER_HAVE_LIBZ and LIBVNCSERVER_HAVE_LIBJPEG */
 #endif
 #endif
-


### PR DESCRIPTION
This bounds Tight Gradient rectangles to the fixed Gradient row-buffer width used by LibVNCClient.

The Tight Gradient decoder uses fixed-width row state buffers sized for 2048 pixels. This change ties the limit to `TIGHT_GRADIENT_MAX_WIDTH` and rejects wider Gradient-filtered Tight rectangles before the Gradient filter initialization and row copy paths run.

The same define is used for:

- `rfbClient::tightPrevRow`
- `FilterGradient24()` local row buffer
- `FilterGradientBPP()` local row buffer
- the Tight Gradient width check before `InitFilterGradientBPP()`

I verified locally that oversized Gradient rectangles are rejected, while width 2048 remains accepted.