### PR TITLE
libvncserver: fix HTTP shutdown without httpDir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,7 @@ if(WITH_LIBVNCSERVER)
   list(APPEND SIMPLETESTS
     cargstest
     copyrecttest
+    http_no_dir_shutdown
   )
 endif(WITH_LIBVNCSERVER)
 
@@ -758,6 +759,7 @@ endif(LIBVNCSERVER_WITH_WEBSOCKETS AND WITH_LIBVNCSERVER)
 
 if(WITH_LIBVNCSERVER)
   add_test(NAME cargs COMMAND test_cargstest)
+  add_test(NAME http_no_dir_shutdown COMMAND test_http_no_dir_shutdown)
 endif(WITH_LIBVNCSERVER)
 if(UNIX)
   if(WITH_LIBVNCSERVER)

--- a/src/libvncserver/httpd.c
+++ b/src/libvncserver/httpd.c
@@ -97,6 +97,13 @@ rfbHttpInitSockets(rfbScreenInfoPtr rfbScreen)
     if (rfbScreen->httpInitDone)
 	return;
 
+    INIT_MUTEX(cl.outputMutex);
+    INIT_MUTEX(cl.refCountMutex);
+    INIT_MUTEX(cl.sendMutex);
+    cl.readFromSocket = rfbDefaultReadFromSocket;
+    cl.peekAtSocket = rfbDefaultPeekAtSocket;
+    cl.hasPendingOnSocket = rfbDefaultHasPendingOnSocket;
+    cl.writeToSocket = rfbDefaultWriteToSocket;
     rfbScreen->httpInitDone = TRUE;
 
     if (!rfbScreen->httpDir)
@@ -127,16 +134,14 @@ rfbHttpInitSockets(rfbScreenInfoPtr rfbScreen)
     rfbLog("Listening for HTTP connections on TCP6 port %d\n", rfbScreen->http6Port);
     rfbLog("  URL http://%s:%d\n",rfbScreen->thisHost,rfbScreen->http6Port);
 #endif
-    INIT_MUTEX(cl.outputMutex);
-    INIT_MUTEX(cl.refCountMutex);
-    INIT_MUTEX(cl.sendMutex);
-    cl.readFromSocket = rfbDefaultReadFromSocket;
-    cl.peekAtSocket = rfbDefaultPeekAtSocket;
-    cl.hasPendingOnSocket = rfbDefaultHasPendingOnSocket;
-    cl.writeToSocket = rfbDefaultWriteToSocket;
 }
 
 void rfbHttpShutdownSockets(rfbScreenInfoPtr rfbScreen) {
+    if (!rfbScreen->httpInitDone)
+       return;
+
+    rfbScreen->httpInitDone = FALSE;
+
     if(rfbScreen->httpSock>-1) {
 	FD_CLR(rfbScreen->httpSock,&rfbScreen->allFds);
 	rfbCloseSocket(rfbScreen->httpSock);

--- a/test/http_no_dir_shutdown.c
+++ b/test/http_no_dir_shutdown.c
@@ -1,0 +1,31 @@
+#include <rfb/rfb.h>
+
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    rfbScreenInfoPtr screen;
+    char *fb;
+
+    screen = rfbGetScreen(&argc, argv, 16, 16, 8, 3, 4);
+    if (!screen)
+	return 1;
+
+    fb = (char *)calloc(16 * 16 * 4, 1);
+    if (!fb) {
+	rfbScreenCleanup(screen);
+	return 1;
+    }
+
+    screen->frameBuffer = fb;
+    screen->port = 0;
+    screen->ipv6port = 0;
+    screen->httpDir = NULL;
+
+    rfbInitServer(screen);
+    rfbShutdownServer(screen, TRUE);
+    rfbScreenCleanup(screen);
+    free(fb);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes an HTTP shutdown crash when `rfbShutdownServer(screen, TRUE)` is called after server startup with `screen->httpDir == NULL` and no client has connected.

The HTTP init path marked `httpInitDone = TRUE` before returning early for a missing `httpDir`, but the HTTP client mutexes were initialized only later. Shutdown then tried to lock/destroy mutexes that had never been initialized, which is especially visible on Windows `CRITICAL_SECTION`.

## Changes

- Initialize the HTTP client mutexes immediately after HTTP init is marked done.
- Make `rfbHttpShutdownSockets()` return early when HTTP was never initialized.
- Reset `httpInitDone` during HTTP shutdown to avoid repeated shutdown work on already-destroyed HTTP mutexes.
- Add a regression test covering `rfbInitServer()` followed by `rfbShutdownServer()` with `httpDir == NULL` and no connected clients.

## Validation

```sh
cmake -S . -B build-704-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug

cmake --build build-704-patch --parallel 1
ctest --test-dir build-704-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 6
```

Notes
-----
Closes #704
