### PR TITLE
libvncserver: avoid deferUpdateTime overflow

### DIFF
--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -19,6 +19,7 @@
 
 #include <stdarg.h>
 #include <errno.h>
+#include <limits.h>
 
 #ifndef false
 #define false 0
@@ -1263,6 +1264,18 @@ static void gettimeofday(struct timeval* tv,char* dummy)
 }
 #endif
 
+static long
+rfbDeferUpdateTimeToUsec(rfbScreenInfoPtr screen)
+{
+  if(screen->deferUpdateTime <= 0)
+    return 0;
+
+  if(screen->deferUpdateTime > LONG_MAX / 1000L)
+    return LONG_MAX;
+
+  return (long)screen->deferUpdateTime * 1000L;
+}
+
 rfbBool
 rfbProcessEvents(rfbScreenInfoPtr screen,long usec)
 {
@@ -1273,7 +1286,7 @@ rfbProcessEvents(rfbScreenInfoPtr screen,long usec)
     rfbGetClientIteratorWithClosed(rfbScreenInfoPtr rfbScreen);
 
   if(usec<0)
-    usec=screen->deferUpdateTime*1000;
+    usec=rfbDeferUpdateTimeToUsec(screen);
 
   rfbCheckFds(screen,usec);
   rfbHttpCheckFds(screen);
@@ -1353,7 +1366,7 @@ rfbBool rfbIsActive(rfbScreenInfoPtr screenInfo) {
 void rfbRunEventLoop(rfbScreenInfoPtr screen, long usec, rfbBool runInBackground)
 {
   if(usec<0)
-    usec=screen->deferUpdateTime*1000;
+    usec=rfbDeferUpdateTimeToUsec(screen);
 
   screen->select_timeout_usec = usec;
 


### PR DESCRIPTION
Summary
-------
Fixes a potential integer overflow in the deferred update timeout calculation.

The server stores `deferUpdateTime` as milliseconds, but the event loop converts it to microseconds with an `int * int` expression before passing it to `select()`. Large values, for example from `-deferupdate`, can overflow before the value is widened.

Changes
-------
- Add a small helper to convert `deferUpdateTime` from milliseconds to microseconds safely.
- Treat non-positive values as a zero timeout, preserving the existing immediate-processing behavior.
- Clamp excessively large values to avoid overflow before passing the timeout to the socket wait helper.
- Reuse the helper in both `rfbProcessEvents()` and `rfbRunEventLoop()`.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-701-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-701-patch --parallel 1
ctest --test-dir build-701-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
Closes #701.
