### PR TITLE
libvncclient: avoid Tight JPEG for deep pixel formats

### DIFF
--- a/src/libvncclient/rfbclient.c
+++ b/src/libvncclient/rfbclient.c
@@ -197,6 +197,20 @@ SupportsServer2Client(rfbClient* client, int messageType)
     return (client->supportedMessages.server2client[((messageType & 0xFF)/8)] & (1<<(messageType % 8)) ? TRUE : FALSE);
 }
 
+static rfbBool
+CanUseTightJPEG(rfbClient* client)
+{
+  if (!client->appData.enableJPEG)
+    return FALSE;
+
+  if (!client->format.trueColour || client->format.bitsPerPixel <= 8)
+    return FALSE;
+
+  return client->format.redMax <= 0xFF &&
+         client->format.greenMax <= 0xFF &&
+         client->format.blueMax <= 0xFF;
+}
+
 void
 SetClient2Server(rfbClient* client, int messageType)
 {
@@ -1304,7 +1318,7 @@ SetFormatAndEncodings(rfbClient* client)
 	requestLastRectEncoding = TRUE;
 	if (client->appData.compressLevel >= 0 && client->appData.compressLevel <= 9)
 	  requestCompressLevel = TRUE;
-	if (client->appData.enableJPEG)
+	if (CanUseTightJPEG(client))
 	  requestQualityLevel = TRUE;
 #endif
 #endif
@@ -1397,7 +1411,7 @@ SetFormatAndEncodings(rfbClient* client)
       encs[se->nEncodings++] = rfbClientSwap32IfLE(rfbEncodingCompressLevel1);
     }
 
-    if (client->appData.enableJPEG) {
+    if (CanUseTightJPEG(client)) {
       if (client->appData.qualityLevel < 0 || client->appData.qualityLevel > 9)
 	client->appData.qualityLevel = 5;
       encs[se->nEncodings++] = rfbClientSwap32IfLE(client->appData.qualityLevel +


### PR DESCRIPTION
Summary
-------
Avoid requesting Tight JPEG when the client pixel format cannot safely consume 8-bit-per-channel JPEG samples.

Tight JPEG is an 8-bit RGB path. When the client format has more than 8 bits per RGB component, for example a 30-bit/10-bit-per-channel HDR format, requesting the Tight quality pseudo-encoding can make servers choose JPEG subencoding even though the negotiated client format cannot represent it losslessly and some servers cannot encode that source format as JPEG correctly.

Changes
-------
- Add a small helper that decides whether Tight JPEG should be requested for the current client pixel format.
- Keep requesting Tight JPEG for true-colour formats with more than 8 bpp and RGB component maxima up to 8 bits.
- Do not request Tight JPEG for 10-bit-per-channel/deep pixel formats.
- Reuse the helper for both explicit `tight` encoding requests and the default encoding list.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-695-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-695-patch --parallel 1
ctest --test-dir build-695-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
I could not run the original WayVNC HDR setup locally, so this should still be runtime-verified against the reported 10-bit framebuffer case.

Closes #695.
