### PR TITLE
libvncserver: validate VNC auth response length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,7 @@ if(WITH_LIBVNCSERVER)
   list(APPEND SIMPLETESTS
     cargstest
     copyrecttest
+    password_list_test
   )
 endif(WITH_LIBVNCSERVER)
 
@@ -758,6 +759,7 @@ endif(LIBVNCSERVER_WITH_WEBSOCKETS AND WITH_LIBVNCSERVER)
 
 if(WITH_LIBVNCSERVER)
   add_test(NAME cargs COMMAND test_cargstest)
+  add_test(NAME password_list COMMAND test_password_list_test)
 endif(WITH_LIBVNCSERVER)
 if(UNIX)
   if(WITH_LIBVNCSERVER)

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -791,7 +791,15 @@ static rfbCursorPtr rfbDefaultGetCursorPtr(rfbClientPtr cl)
 static rfbBool rfbDefaultPasswordCheck(rfbClientPtr cl,const char* response,int len)
 {
   int i;
-  char *passwd=rfbDecryptPasswdFromFile(cl->screen->authPasswdData);
+  char *passwd;
+
+  if(response == NULL || len != CHALLENGESIZE) {
+    rfbErr("authProcessClientMessage: invalid response length from %s\n",
+	   cl->host);
+    return(FALSE);
+  }
+
+  passwd=rfbDecryptPasswdFromFile(cl->screen->authPasswdData);
 
   if(!passwd) {
     rfbErr("Couldn't read password file: %s\n",cl->screen->authPasswdData);
@@ -822,6 +830,12 @@ rfbBool rfbCheckPasswordByList(rfbClientPtr cl,const char* response,int len)
 {
   char **passwds;
   int i=0;
+
+  if(response == NULL || len != CHALLENGESIZE) {
+    rfbErr("authProcessClientMessage: invalid response length from %s\n",
+	   cl->host);
+    return(FALSE);
+  }
 
   for(passwds=(char**)cl->screen->authPasswdData;*passwds;passwds++,i++) {
     uint8_t auth_tmp[CHALLENGESIZE];

--- a/test/password_list_test.c
+++ b/test/password_list_test.c
@@ -1,0 +1,30 @@
+#include <rfb/rfb.h>
+
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    rfbScreenInfoPtr screen;
+    rfbClientRec cl;
+    char response[CHALLENGESIZE + 1];
+    char *passwords[] = { (char *)"password", NULL };
+
+    screen = rfbGetScreen(&argc, argv, 4, 4, 8, 1, 1);
+    if(!screen)
+	return 1;
+
+    memset(&cl, 0, sizeof(cl));
+    memset(response, 'A', sizeof(response));
+
+    cl.screen = screen;
+    cl.host = (char *)"test";
+    screen->authPasswdData = passwords;
+
+    if(rfbCheckPasswordByList(&cl, response, sizeof(response)) != FALSE) {
+	rfbScreenCleanup(screen);
+	return 1;
+    }
+
+    rfbScreenCleanup(screen);
+    return 0;
+}


### PR DESCRIPTION
Summary
-------
Reject invalid VNC auth response lengths before comparing them against the fixed-size authentication challenge buffer.

`rfbCheckPasswordByList()` builds a temporary encrypted challenge buffer of `CHALLENGESIZE` bytes, but compared it with the caller-provided length. Passing a length larger than `CHALLENGESIZE` could therefore make `memcmp()` read past the stack buffer.

The default password checker had the same implicit fixed-size response assumption, so this patch applies the same validation there as well.

Changes
-------
- Reject `NULL` authentication responses.
- Reject VNC authentication responses whose length is not exactly `CHALLENGESIZE`.
- Apply the validation to both built-in password checkers.
- Add a regression test for the overlong `rfbCheckPasswordByList()` response path.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-680-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-680-patch --parallel 1
ctest --test-dir build-680-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 6
```

Also ran the new regression test with AddressSanitizer enabled:

```sh
cmake -S . -B build-680-asan \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_C_FLAGS='-fsanitize=address -fno-omit-frame-pointer' \
  -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address'
cmake --build build-680-asan --target test_password_list_test --parallel 1
ASAN_OPTIONS=detect_leaks=0 ./build-680-asan/test/password_list_test
```

Closes #680.
