### PR TITLE
libvncserver: close resources on error paths

### DIFF
--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -423,6 +423,10 @@ rfbNewTCPOrUDPClient(rfbScreenInfoPtr rfbScreen,
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
       if(!rfbSetNonBlocking(sock)) {
 	rfbCloseSocket(sock);
+	free(cl->host);
+	if (cl->scaledScreen != NULL)
+	  cl->scaledScreen->scaledScreenRefCount--;
+	free(cl);
 	return NULL;
       }
 
@@ -1482,7 +1486,14 @@ rfbBool rfbSendDirContent(rfbClientPtr cl, int length, char *buffer)
         return rfbSendFileTransferMessage(cl, rfbDirPacket, rfbADirectory, 0, 0, NULL);
 
     /* send back the path name (necessary for links) */
-    if (rfbSendFileTransferMessage(cl, rfbDirPacket, rfbADirectory, 0, length, buffer)==FALSE) return FALSE;
+    if (rfbSendFileTransferMessage(cl, rfbDirPacket, rfbADirectory, 0, length, buffer)==FALSE) {
+#ifdef WIN32
+        FindClose(findHandle);
+#else
+        closedir(dirp);
+#endif
+        return FALSE;
+    }
 
 #ifdef WIN32
     while (findHandle != INVALID_HANDLE_VALUE)

--- a/src/libvncserver/sockets.c
+++ b/src/libvncserver/sockets.c
@@ -1208,8 +1208,10 @@ rfbConnectToTcpAddr(char *host,
         sock = RFB_INVALID_SOCKET; /* set return value */
     } else {
 	/* one succeeded, re-set to blocking */
-	if (!sock_set_nonblocking(sock, FALSE, rfbErr))
+	if (!sock_set_nonblocking(sock, FALSE, rfbErr)) {
 	    rfbCloseSocket(sock);
+	    sock = RFB_INVALID_SOCKET;
+	}
     }
 
     /* all done with this structure now */


### PR DESCRIPTION
Summary
-------
Fixes the three resource cleanup paths reported by static analysis in #660.

Changes
-------
- Close the directory/search handle when sending the initial file-transfer directory response fails.
- Return `RFB_INVALID_SOCKET` if restoring a successfully connected socket to blocking mode fails after the socket has been closed.
- Release the partially initialized client allocation, peer host string, and scaled-screen reference when `rfbSetNonBlocking()` fails while accepting a new TCP client.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-660-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-660-patch --parallel 1
ctest --test-dir build-660-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
No new regression test is included because the three paths require forcing low-level OS/API failures (`opendir`/file-transfer send failure, `sock_set_nonblocking()` failure after connect, and accepted-client nonblocking setup failure). The patch keeps the changes surgical and directly closes the resources reported by static analysis.

Closes #660.
