### PR TITLE
libvncserver: avoid colour map alignment issues

### DIFF
--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -3994,6 +3994,12 @@ rfbSendUpdateBuf(rfbClientPtr cl)
  * client, using values from the currently installed colormap.
  */
 
+static void
+rfbSetWireUint16(char *dst, uint16_t value)
+{
+    memcpy(dst, &value, sizeof(value));
+}
+
 rfbBool
 rfbSendSetColourMapEntries(rfbClientPtr cl,
                            int firstColour,
@@ -4001,36 +4007,36 @@ rfbSendSetColourMapEntries(rfbClientPtr cl,
 {
     char buf[sz_rfbSetColourMapEntriesMsg + 256 * 3 * 2];
     char *wbuf = buf;
-    rfbSetColourMapEntriesMsg *scme;
-    uint16_t *rgb;
+    char *rgb;
     rfbColourMap* cm = &cl->screen->colourMap;
     int i, len;
 
     if (nColours > 256) {
 	/* some rare hardware has, e.g., 4096 colors cells: PseudoColor:12 */
     	wbuf = (char *) malloc(sz_rfbSetColourMapEntriesMsg + nColours * 3 * 2);
+	if (wbuf == NULL)
+	    return FALSE;
     }
 
-    scme = (rfbSetColourMapEntriesMsg *)wbuf;
-    rgb = (uint16_t *)(&wbuf[sz_rfbSetColourMapEntriesMsg]);
+    rgb = &wbuf[sz_rfbSetColourMapEntriesMsg];
 
-    scme->type = rfbSetColourMapEntries;
-
-    scme->firstColour = Swap16IfLE(firstColour);
-    scme->nColours = Swap16IfLE(nColours);
+    wbuf[0] = rfbSetColourMapEntries;
+    wbuf[1] = 0;
+    rfbSetWireUint16(&wbuf[2], Swap16IfLE(firstColour));
+    rfbSetWireUint16(&wbuf[4], Swap16IfLE(nColours));
 
     len = sz_rfbSetColourMapEntriesMsg;
 
     for (i = 0; i < nColours; i++) {
       if(i<(int)cm->count) {
 	if(cm->is16) {
-	  rgb[i*3] = Swap16IfLE(cm->data.shorts[i*3]);
-	  rgb[i*3+1] = Swap16IfLE(cm->data.shorts[i*3+1]);
-	  rgb[i*3+2] = Swap16IfLE(cm->data.shorts[i*3+2]);
+	  rfbSetWireUint16(&rgb[i*6], Swap16IfLE(cm->data.shorts[i*3]));
+	  rfbSetWireUint16(&rgb[i*6+2], Swap16IfLE(cm->data.shorts[i*3+1]));
+	  rfbSetWireUint16(&rgb[i*6+4], Swap16IfLE(cm->data.shorts[i*3+2]));
 	} else {
-	  rgb[i*3] = Swap16IfLE((unsigned short)cm->data.bytes[i*3]);
-	  rgb[i*3+1] = Swap16IfLE((unsigned short)cm->data.bytes[i*3+1]);
-	  rgb[i*3+2] = Swap16IfLE((unsigned short)cm->data.bytes[i*3+2]);
+	  rfbSetWireUint16(&rgb[i*6], Swap16IfLE((unsigned short)cm->data.bytes[i*3]));
+	  rfbSetWireUint16(&rgb[i*6+2], Swap16IfLE((unsigned short)cm->data.bytes[i*3+1]));
+	  rfbSetWireUint16(&rgb[i*6+4], Swap16IfLE((unsigned short)cm->data.bytes[i*3+2]));
 	}
       }
     }


### PR DESCRIPTION
Summary
-------
Fixes the pointer aliasing/alignment issue in `rfbSendSetColourMapEntries()`.

The previous code built a wire buffer as `char[]`, then cast it to `rfbSetColourMapEntriesMsg *` and `uint16_t *`. That can create unaligned accesses on strict-alignment architectures and also relies on type-punning through incompatible pointer types.

Changes
-------
- Write the SetColourMapEntries header directly into the byte buffer.
- Write 16-bit wire values through a small `memcpy()` helper instead of casting the byte buffer to `uint16_t *`.
- Keep the existing wire layout and endian conversion behavior.
- Add a NULL check for the dynamic buffer allocation path used when `nColours > 256`.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-668-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-668-patch --parallel 1
ctest --test-dir build-668-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
Closes #668.
