### PR TITLE
libvncserver: read HTTP files in aligned chunks

### DIFF
--- a/src/libvncserver/httpd.c
+++ b/src/libvncserver/httpd.c
@@ -295,6 +295,7 @@ httpProcessInput(rfbScreenInfoPtr rfbScreen)
     unsigned int maxFnameLen;
     FILE* fd;
     rfbBool performSubstitutions = FALSE;
+    size_t bytesToRead;
     char str[256+32];
 #ifndef WIN32
     char* user=getenv("USER");
@@ -484,8 +485,12 @@ if(rfbScreen->httpEnableProxyConnect) {
     /* end the header */
     rfbWriteExact(&cl, "\r\n", 2);
 
+    /* .vnc substitutions need one byte for NUL termination. Other
+       HTTP files can use the full, aligned buffer. */
+    bytesToRead = performSubstitutions ? BUF_SIZE - 1 : BUF_SIZE;
+
     while (1) {
-	int n = fread(buf, 1, BUF_SIZE-1, fd);
+	int n = fread(buf, 1, bytesToRead, fd);
 	if (n < 0) {
 	    rfbLogPerror("httpProcessInput: read");
 	    fclose(fd);


### PR DESCRIPTION
Summary
-------
Fixes the HTTP file transfer chunk size described in #199.

The HTTP server used `BUF_SIZE - 1` for every file read so that `.vnc` files could be NUL-terminated before variable substitution. For non-`.vnc` assets this produced 32767-byte chunks even though the static HTTP buffer is 32768 bytes.

On strict-alignment ARM targets this can make the HTTP/WebSocket write path hit unaligned buffer handling when large files are sent in repeated chunks.

Changes
-------
- Keep `BUF_SIZE - 1` only for `.vnc` files that need NUL termination before substitutions.
- Use the full `BUF_SIZE` for all other HTTP files, preserving the aligned 32768-byte chunk size.
- Leave `.vnc` substitution behavior unchanged.

Validation
----------
Tested with a minimal local CMake configuration:

```sh
cmake -S . -B build-199-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-199-patch --parallel 1
ctest --test-dir build-199-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
I do not have access to an ARM strict-alignment target for runtime validation, so this follows the issue's proposed fix while keeping the `.vnc` substitution path unchanged.

Closes #199.
