### PR TITLE
libvncserver: use zlib stream for Tight level zero

### DIFF
--- a/src/libvncserver/tight.c
+++ b/src/libvncserver/tight.c
@@ -820,12 +820,7 @@ SendMonoRect(rfbClientPtr cl,
     dataLen = (w + 7) / 8;
     dataLen *= h;
 
-    if (tightConf[cl->tightCompressLevel].monoZlibLevel == 0 &&
-        cl->tightEncoding != rfbEncodingTightPng)
-        cl->updateBuf[cl->ublen++] =
-            (char)((rfbTightNoZlib | rfbTightExplicitFilter) << 4);
-    else
-        cl->updateBuf[cl->ublen++] = (streamId | rfbTightExplicitFilter) << 4;
+    cl->updateBuf[cl->ublen++] = (streamId | rfbTightExplicitFilter) << 4;
     cl->updateBuf[cl->ublen++] = rfbTightFilterPalette;
     cl->updateBuf[cl->ublen++] = 1;
 
@@ -897,12 +892,7 @@ SendIndexedRect(palettePtr palette,
     }
 
     /* Prepare tight encoding header. */
-    if (tightConf[cl->tightCompressLevel].idxZlibLevel == 0 &&
-        cl->tightEncoding != rfbEncodingTightPng)
-        cl->updateBuf[cl->ublen++] =
-            (char)((rfbTightNoZlib | rfbTightExplicitFilter) << 4);
-    else
-        cl->updateBuf[cl->ublen++] = (streamId | rfbTightExplicitFilter) << 4;
+    cl->updateBuf[cl->ublen++] = (streamId | rfbTightExplicitFilter) << 4;
     cl->updateBuf[cl->ublen++] = rfbTightFilterPalette;
     cl->updateBuf[cl->ublen++] = (char)(palette->numColors - 1);
 
@@ -973,11 +963,7 @@ SendFullColorRect(rfbClientPtr cl,
             return FALSE;
     }
 
-    if (tightConf[cl->tightCompressLevel].rawZlibLevel == 0 &&
-        cl->tightEncoding != rfbEncodingTightPng)
-        cl->updateBuf[cl->ublen++] = (char)(rfbTightNoZlib << 4);
-    else
-        cl->updateBuf[cl->ublen++] = 0x00;  /* stream id = 0, no flushing, no filter */
+    cl->updateBuf[cl->ublen++] = 0x00;  /* stream id = 0, no flushing, no filter */
     rfbStatRecordEncodingSentAdd(cl, cl->tightEncoding, 1);
 
     if (cl->tightUsePixelFormat24) {
@@ -1007,9 +993,6 @@ CompressData(rfbClientPtr cl,
         rfbStatRecordEncodingSentAdd(cl, cl->tightEncoding, dataLen);
         return TRUE;
     }
-
-    if (zlibLevel == 0)
-        return rfbSendCompressedDataTight(cl, cl->beforeEncBuf, dataLen);
 
     pz = &cl->zsStruct[streamId];
 


### PR DESCRIPTION
Summary
-------
Fixes Tight encoding with zlib compression level 0.

With compression level 0, Tight rectangles were sent using the `rfbTightNoZlib` path or by bypassing zlib in `CompressData()`. That means clients received raw uncompressed bytes without a zlib wrapper. Some clients, including the ones reported in #370, expect a valid zlib stream even when the selected zlib level is 0.

Changes
-------
- Stop emitting `rfbTightNoZlib` for mono rectangles when the configured zlib level is 0.
- Stop emitting `rfbTightNoZlib` for indexed rectangles when the configured zlib level is 0.
- Stop emitting `rfbTightNoZlib` for full-color rectangles when the configured zlib level is 0.
- Remove the `zlibLevel == 0` fast-path in `CompressData()` so level 0 still goes through `deflateInit2()` / `deflate()` and produces a valid zlib stream.

Validation
----------
```sh
cmake -S . -B build-370 \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-370 --parallel 1
ctest --test-dir build-370 --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Notes
-----
I did not run an interoperability smoke test with UltraVNCViewer/TightVNC. The change follows the issue report exactly and keeps level-0 zlib as uncompressed data inside a valid zlib stream.

Closes #370.