### PR TITLE
libvncserver: serialize WebSocket SSL teardown

### DIFF
--- a/src/libvncserver/rfbssl_gnutls.c
+++ b/src/libvncserver/rfbssl_gnutls.c
@@ -265,8 +265,25 @@ int rfbssl_pending(rfbClientPtr cl)
 
 void rfbssl_destroy(rfbClientPtr cl)
 {
-    struct rfbssl_ctx *ctx = (struct rfbssl_ctx *)cl->sslctx;
-    gnutls_bye(ctx->session, GNUTLS_SHUT_WR);
-    gnutls_deinit(ctx->session);
-    gnutls_certificate_free_credentials(ctx->x509_cred);
+    struct rfbssl_ctx *ctx;
+
+    if (!cl || !cl->sslctx)
+	return;
+
+    ctx = (struct rfbssl_ctx *)cl->sslctx;
+    cl->sslctx = NULL;
+
+    if (ctx->session) {
+	gnutls_bye(ctx->session, GNUTLS_SHUT_WR);
+	gnutls_deinit(ctx->session);
+    }
+    if (ctx->x509_cred)
+	gnutls_certificate_free_credentials(ctx->x509_cred);
+    if (ctx->dh_params)
+	gnutls_dh_params_deinit(ctx->dh_params);
+#ifdef I_LIKE_RSA_PARAMS_THAT_MUCH
+    if (ctx->rsa_params)
+	gnutls_rsa_params_deinit(ctx->rsa_params);
+#endif
+    free(ctx);
 }

--- a/src/libvncserver/rfbssl_openssl.c
+++ b/src/libvncserver/rfbssl_openssl.c
@@ -127,9 +127,17 @@ int rfbssl_pending(rfbClientPtr cl)
 
 void rfbssl_destroy(rfbClientPtr cl)
 {
-    struct rfbssl_ctx *ctx = (struct rfbssl_ctx *)cl->sslctx;
+    struct rfbssl_ctx *ctx;
+
+    if (!cl || !cl->sslctx)
+	return;
+
+    ctx = (struct rfbssl_ctx *)cl->sslctx;
+    cl->sslctx = NULL;
+
     if (ctx->ssl)
 	SSL_free(ctx->ssl);
     if (ctx->ssl_ctx)
 	SSL_CTX_free(ctx->ssl_ctx);
+    free(ctx);
 }

--- a/src/libvncserver/sockets.c
+++ b/src/libvncserver/sockets.c
@@ -577,10 +577,14 @@ rfbCloseClient(rfbClientPtr cl)
 		&& !FD_ISSET(cl->screen->maxFd,&(cl->screen->allFds)))
 	    cl->screen->maxFd--;
 #ifdef LIBVNCSERVER_WITH_WEBSOCKETS
-	/* Has to happen before socket close as the SSL implementation might send a goodbye */
+	/* Has to happen before socket close as the SSL implementation might send a goodbye.
+	   Serialize SSL teardown with rfbWriteExact(), which may run in the output thread. */
+	LOCK(cl->outputMutex);
 	if (cl->sslctx)
 	    rfbssl_destroy(cl);
 	free(cl->wspath);
+	cl->wspath = NULL;
+	UNLOCK(cl->outputMutex);
 #endif
       }
     TSIGNAL(cl->updateCond);


### PR DESCRIPTION
Summary
-------
This is a conservative WSS disconnect race mitigation.

The issue reports intermittent crashes when a secure WebSocket client disconnects while the output thread is still sending framebuffer updates. The reported OpenSSL backtrace shows `SSL_write()` using SSL state that was already freed by `rfbCloseClient()` from the input thread. The GnuTLS backtrace shows the same class of issue around `rfbssl_destroy()` / credential teardown.

Changes
-------
- Serialize WebSocket SSL teardown with `rfbWriteExact()` by taking `cl->outputMutex` while destroying `cl->sslctx`.
- Make OpenSSL `rfbssl_destroy()` idempotent by returning early for NULL context and clearing `cl->sslctx` before freeing backend objects.
- Make GnuTLS `rfbssl_destroy()` idempotent in the same way.
- Free the backend SSL context wrapper after destroying its backend-specific resources.
- Clear `cl->wspath` after freeing it.

Validation
----------
Local build and tests without TLS:

```sh
cmake -S . -B build-665-patch \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=OFF \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-665-patch --parallel 1
ctest --test-dir build-665-patch --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

Local build and tests with OpenSSL enabled:

```sh
cmake -S . -B build-665-openssl \
  -DWITH_EXAMPLES=OFF \
  -DWITH_TESTS=ON \
  -DWITH_OPENSSL=ON \
  -DWITH_GNUTLS=OFF \
  -DWITH_GCRYPT=OFF \
  -DWITH_SDL=OFF \
  -DWITH_GTK=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF \
  -DWITH_XCB=OFF \
  -DWITH_LIBSSHTUNNEL=OFF \
  -DWITH_SYSTEMD=OFF \
  -DCMAKE_BUILD_TYPE=Debug
cmake --build build-665-openssl --parallel 1
ctest --test-dir build-665-openssl --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 5
```

WSS disconnect stress smoke
---------------------------
Validated with an OpenSSL-enabled AddressSanitizer build using
examples/server/camera with WSS enabled and a Python stress client that performs
TLS connect, WebSocket upgrade, RFB 3.8 handshake, SetEncodings, framebuffer
update requests, and abrupt disconnects in parallel.

Stress result:
- 8 client threads
- 75 loops per thread
- 600 total WSS connection attempts
- 587 completed client sessions
- server stayed alive
- no AddressSanitizer crash
- no SEGV/ABORTING
- no observed SSL teardown use-after-free

Notes
-----
Closes #665.