### PR TITLE
httpd: fix crash in rfbHttpShutdownSockets when httpDir is NULL

### DIFF
--- a/src/libvncserver/httpd.c
+++ b/src/libvncserver/httpd.c
@@ -90,6 +90,7 @@ static size_t buf_filled=0;
  */
 
 static rfbClientRec cl;
+static rfbBool httpMutexesInit = FALSE;
 
 void
 rfbHttpInitSockets(rfbScreenInfoPtr rfbScreen)
@@ -130,6 +131,7 @@ rfbHttpInitSockets(rfbScreenInfoPtr rfbScreen)
     INIT_MUTEX(cl.outputMutex);
     INIT_MUTEX(cl.refCountMutex);
     INIT_MUTEX(cl.sendMutex);
+    httpMutexesInit = TRUE;
 }
 
 void rfbHttpShutdownSockets(rfbScreenInfoPtr rfbScreen) {
@@ -150,17 +152,21 @@ void rfbHttpShutdownSockets(rfbScreenInfoPtr rfbScreen) {
 	rfbCloseSocket(rfbScreen->httpListen6Sock);
 	rfbScreen->httpListen6Sock=RFB_INVALID_SOCKET;
     }
-    LOCK(cl.outputMutex);
-    UNLOCK(cl.outputMutex);
-    TINI_MUTEX(cl.outputMutex);
+    if (httpMutexesInit) {
+        LOCK(cl.outputMutex);
+        UNLOCK(cl.outputMutex);
+        TINI_MUTEX(cl.outputMutex);
 
-    LOCK(cl.sendMutex);
-    UNLOCK(cl.sendMutex);
-    TINI_MUTEX(cl.sendMutex);
+        LOCK(cl.sendMutex);
+        UNLOCK(cl.sendMutex);
+        TINI_MUTEX(cl.sendMutex);
 
-    LOCK(cl.refCountMutex);
-    UNLOCK(cl.refCountMutex);
-    TINI_MUTEX(cl.refCountMutex);
+        LOCK(cl.refCountMutex);
+        UNLOCK(cl.refCountMutex);
+        TINI_MUTEX(cl.refCountMutex);
+
+        httpMutexesInit = FALSE;
+    }
 
     memset(&cl, 0, sizeof(rfbClientRec));
 }


### PR DESCRIPTION
### Summary
This Pull Request resolves a crash (segmentation fault / access violation) that occurs in  if no HTTP directory is configured () and no client has connected during the server's lifecycle (fixes #704).

### Cause
In , the HTTP socket initialization returns early if  is . Because of this, the mutexes of the file-static structure  (, , ) are never initialized via . 
However, during shutdown in , these mutexes are unconditionally locked, unlocked, and destroyed, leading to an immediate segmentation fault.

### Fix
We introduced a file-static boolean flag  in  to track whether these client-related mutexes have been successfully initialized. The shutdown operations are now safely wrapped in a conditional check:



### Verification & Testing
The fix has been compiled and verified inside a secure  sandbox container on a Debian Bookworm VPS, utilizing the following minimal reproduction program:


* **Pre-patch:** Program terminates with a Segmentation Fault (Access Violation).
* **Post-patch:** Program runs and shuts down cleanly with Exit Code 0.
