### PR TITLE
Fix Svacer iterator leak warning

### DIFF
--- a/src/libvncserver/cursor.c
+++ b/src/libvncserver/cursor.c
@@ -364,28 +364,39 @@ char* rfbMakeMaskFromAlphaSource(int width,int height,unsigned char* alphaSource
 	return (char *) result;
 }
 
+static void rfbFreeCursorBuffers(rfbCursorPtr cursor)
+{
+   if(!cursor)
+      return;
+
+   if(cursor->cleanupRichSource) {
+      free(cursor->richSource);
+      free(cursor->alphaSource);
+      cursor->richSource = NULL;
+      cursor->alphaSource = NULL;
+      cursor->cleanupRichSource = FALSE;
+   }
+
+   if(cursor->cleanupSource) {
+      free(cursor->source);
+      cursor->source = NULL;
+      cursor->cleanupSource = FALSE;
+   }
+
+   if(cursor->cleanupMask) {
+      free(cursor->mask);
+      cursor->mask = NULL;
+      cursor->cleanupMask = FALSE;
+   }
+}
+
 void rfbFreeCursor(rfbCursorPtr cursor)
 {
    if(cursor) {
-       if(cursor->cleanupRichSource)
-       {
-         free(cursor->richSource);
-         free(cursor->alphaSource);
-       }
-       if(cursor->cleanupSource)
-        free(cursor->source);
-       if(cursor->cleanupMask)
-        free(cursor->mask);
+       rfbFreeCursorBuffers(cursor);
        if(cursor->cleanup)
         free(cursor);
-       else {
-	   cursor->cleanup=cursor->cleanupSource=cursor->cleanupMask
-	       =cursor->cleanupRichSource=FALSE;
-	   cursor->source=cursor->mask=cursor->richSource=NULL;
-	   cursor->alphaSource=NULL;
-       }
    }
-   
 }
 
 /* background and foregroud colour have to be set beforehand */
@@ -774,8 +785,7 @@ void rfbSetCursor(rfbScreenInfoPtr rfbScreen,rfbCursorPtr c)
 	  rfbRedrawAfterHideCursor(cl,NULL);
     rfbReleaseClientIterator(iterator);
 
-    if(rfbScreen->cursor->cleanup)
-	 rfbFreeCursor(rfbScreen->cursor);
+    rfbFreeCursor(rfbScreen->cursor);
   }
 
   rfbScreen->cursor = c;

--- a/src/libvncserver/main.c
+++ b/src/libvncserver/main.c
@@ -1168,8 +1168,7 @@ void rfbScreenCleanup(rfbScreenInfoPtr screen)
   FREE_SCREEN_MEMBER(underCursorBuffer);
   TINI_MUTEX(screen->cursorMutex);
 
-  if(screen->cursor != &myCursor)
-      rfbFreeCursor(screen->cursor);
+  rfbFreeCursor(screen->cursor);
 
 #ifdef LIBVNCSERVER_HAVE_LIBZ
 

--- a/src/libvncserver/rfbserver.c
+++ b/src/libvncserver/rfbserver.c
@@ -3143,6 +3143,7 @@ rfbProcessClientNormalMessage(rfbClientPtr cl)
                     clp->requestedDesktopSizeChange = rfbExtDesktopSize_OtherClientRequestedChange;
                 UNLOCK(clp->updateMutex);
             }
+            rfbReleaseClientIterator(iterator);
         }
         else
         {


### PR DESCRIPTION
Summary

Fixes the real client iterator leak reported by Svacer in the ExtendedDesktopSize success path and tightens cursor cleanup so lazily generated cursor buffers are released for both owned and non-owned cursor objects.

Details

- Release the rfbGetClientIterator() allocation after notifying other clients about a successful desktop size change.
- Factor cursor-owned buffer cleanup into a helper used by rfbFreeCursor().
- Allow rfbFreeCursor() to release owned cursor sub-buffers without clearing or corrupting caller-owned/static cursor fields.
- Call rfbFreeCursor() when replacing the current cursor, even if the cursor object itself is not owned by LibVNCServer.
- Call rfbFreeCursor() during screen cleanup for the default static cursor too; the cursor object is not freed, but any lazily generated source/richSource buffers are released.

This addresses the Svacer reports for cursor.c by making the cached buffers have explicit cleanup paths, including the default static cursor case.

Validation

Configured, built, and ran the test suite locally with:

```sh
cmake -S . -B build \
  -DCMAKE_BUILD_TYPE=Debug \
  -DWITH_TESTS=ON \
  -DWITH_EXAMPLES=OFF \
  -DWITH_GTK=OFF \
  -DWITH_SDL=OFF \
  -DWITH_QT=OFF \
  -DWITH_FFMPEG=OFF
cmake --build build --parallel
ctest --test-dir build --output-on-failure
```

Result: 5/5 tests passed.

Closes LibVNC/libvncserver#724