### PR TITLE
Fix internal TurboJPEG symbol visibility leak in shared library

### DIFF
--- a/src/common/turbojpeg.h
+++ b/src/common/turbojpeg.h
@@ -32,6 +32,8 @@
 
 #if defined(_WIN32) && defined(DLLDEFINE)
 #define DLLEXPORT __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#define DLLEXPORT __attribute__ ((visibility ("hidden")))
 #else
 #define DLLEXPORT
 #endif

--- a/test/cargstest.c
+++ b/test/cargstest.c
@@ -1,5 +1,23 @@
 #include <rfb/rfb.h>
 
+
+#if defined(__ELF__) && (defined(__GNUC__) || defined(__clang__))
+#include <dlfcn.h>
+static int check_symbol_not_exported(void) {
+    void *handle = dlopen(NULL, RTLD_NOW);
+    if (!handle) return 0;
+    if (dlsym(handle, "tjCompress2") != NULL || dlsym(handle, "tjInitCompress") != NULL) {
+        fprintf(stderr, "Error: turbojpeg symbols exported in main executable dynamic symbol table!\n");
+        dlclose(handle);
+        return 1;
+    }
+    dlclose(handle);
+    return 0;
+}
+#else
+static int check_symbol_not_exported(void) { return 0; }
+#endif
+
 int main(int argc,char** argv)
 {
 	int fake_argc=6;
@@ -27,6 +45,7 @@ int main(int argc,char** argv)
 		fprintf(stderr,"fake_argv[1] is %s (should be -nothing)\n",fake_argv[1]);
 		ret=1;
 	}
+	if (check_symbol_not_exported()) ret = 1;
 	return ret;
 }
 


### PR DESCRIPTION
Fixes #729

### Summary of Changes
When building `libvncserver.so`, internal bundled TurboJPEG functions (`tjCompress`, `tjCompress2`, `tjInitCompress`, etc.) were exported into the global symbol table because `DLLEXPORT` in `src/common/turbojpeg.h` defaulted to empty (public export) on GCC/Clang ELF systems.

This PR updates `DLLEXPORT` macro definition in `src/common/turbojpeg.h` to set `__attribute__ ((visibility ("hidden"))) ` when compiling with GCC/Clang (version >= 4), ensuring bundled TurboJPEG functions remain private to `libvncserver` and do not override global symbols when applications link against both `libvncserver` and system `libjpeg-turbo`.

Added automated runtime symbol visibility test check in `test/cargstest.c` via `dlsym` to prevent regressions.