### PR TITLE
Prefix embedded TurboJPEG functions with rdr_ to prevent symbol conflicts

### DIFF
--- a/src/common/turbojpeg.c
+++ b/src/common/turbojpeg.c
@@ -429,13 +429,13 @@ static void fromRGB(unsigned char *src, unsigned char *dst, int width,
 
 /* General API functions */
 
-DLLEXPORT char* DLLCALL tjGetErrorStr(void)
+DLLEXPORT char* DLLCALL rdr_tjGetErrorStr(void)
 {
 	return errStr;
 }
 
 
-DLLEXPORT int DLLCALL tjDestroy(tjhandle handle)
+DLLEXPORT int DLLCALL rdr_tjDestroy(tjhandle handle)
 {
 	getinstance(handle);
 	if(setjmp(this->jerr.setjmp_buffer)) return -1;
@@ -482,7 +482,7 @@ static tjhandle _tjInitCompress(tjinstance *this)
 	return (tjhandle)this;
 }
 
-DLLEXPORT tjhandle DLLCALL tjInitCompress(void)
+DLLEXPORT tjhandle DLLCALL rdr_tjInitCompress(void)
 {
 	tjinstance *this=NULL;
 	if((this=(tjinstance *)malloc(sizeof(tjinstance)))==NULL)
@@ -496,7 +496,7 @@ DLLEXPORT tjhandle DLLCALL tjInitCompress(void)
 }
 
 
-DLLEXPORT unsigned long DLLCALL tjBufSize(int width, int height,
+DLLEXPORT unsigned long DLLCALL rdr_tjBufSize(int width, int height,
 	int jpegSubsamp)
 {
 	unsigned long retval=0;  int mcuw, mcuh, chromasf;
@@ -518,7 +518,7 @@ DLLEXPORT unsigned long DLLCALL tjBufSize(int width, int height,
 }
 
 
-DLLEXPORT unsigned long DLLCALL TJBUFSIZE(int width, int height)
+DLLEXPORT unsigned long DLLCALL rdr_TJBUFSIZE(int width, int height)
 {
 	unsigned long retval=0;
 	if(width<1 || height<1)
@@ -536,7 +536,7 @@ DLLEXPORT unsigned long DLLCALL TJBUFSIZE(int width, int height)
 }
 
 
-DLLEXPORT int DLLCALL tjCompress2(tjhandle handle, unsigned char *srcBuf,
+DLLEXPORT int DLLCALL rdr_tjCompress2(tjhandle handle, unsigned char *srcBuf,
 	int width, int pitch, int height, int pixelFormat, unsigned char **jpegBuf,
 	unsigned long *jpegSize, int jpegSubsamp, int jpegQual, int flags)
 {
@@ -612,7 +612,7 @@ DLLEXPORT int DLLCALL tjCompress2(tjhandle handle, unsigned char *srcBuf,
 	return retval;
 }
 
-DLLEXPORT int DLLCALL tjCompress(tjhandle handle, unsigned char *srcBuf,
+DLLEXPORT int DLLCALL rdr_tjCompress(tjhandle handle, unsigned char *srcBuf,
 	int width, int pitch, int height, int pixelSize, unsigned char *jpegBuf,
 	unsigned long *jpegSize, int jpegSubsamp, int jpegQual, int flags)
 {
@@ -669,7 +669,7 @@ static tjhandle _tjInitDecompress(tjinstance *this)
 	return (tjhandle)this;
 }
 
-DLLEXPORT tjhandle DLLCALL tjInitDecompress(void)
+DLLEXPORT tjhandle DLLCALL rdr_tjInitDecompress(void)
 {
 	tjinstance *this;
 	if((this=(tjinstance *)malloc(sizeof(tjinstance)))==NULL)
@@ -683,7 +683,7 @@ DLLEXPORT tjhandle DLLCALL tjInitDecompress(void)
 }
 
 
-DLLEXPORT int DLLCALL tjDecompressHeader2(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompressHeader2(tjhandle handle,
 	unsigned char *jpegBuf, unsigned long jpegSize, int *width, int *height,
 	int *jpegSubsamp)
 {
@@ -722,16 +722,16 @@ DLLEXPORT int DLLCALL tjDecompressHeader2(tjhandle handle,
 	return retval;
 }
 
-DLLEXPORT int DLLCALL tjDecompressHeader(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompressHeader(tjhandle handle,
 	unsigned char *jpegBuf, unsigned long jpegSize, int *width, int *height)
 {
 	int jpegSubsamp;
-	return tjDecompressHeader2(handle, jpegBuf, jpegSize, width, height,
+	return rdr_tjDecompressHeader2(handle, jpegBuf, jpegSize, width, height,
 		&jpegSubsamp);
 }
 
 
-DLLEXPORT tjscalingfactor* DLLCALL tjGetScalingFactors(int *numscalingfactors)
+DLLEXPORT tjscalingfactor* DLLCALL rdr_tjGetScalingFactors(int *numscalingfactors)
 {
 	if(numscalingfactors==NULL)
 	{
@@ -745,7 +745,7 @@ DLLEXPORT tjscalingfactor* DLLCALL tjGetScalingFactors(int *numscalingfactors)
 }
 
 
-DLLEXPORT int DLLCALL tjDecompress2(tjhandle handle, unsigned char *jpegBuf,
+DLLEXPORT int DLLCALL rdr_tjDecompress2(tjhandle handle, unsigned char *jpegBuf,
 	unsigned long jpegSize, unsigned char *dstBuf, int width, int pitch,
 	int height, int pixelFormat, int flags)
 {
@@ -849,10 +849,10 @@ DLLEXPORT int DLLCALL tjDecompress2(tjhandle handle, unsigned char *jpegBuf,
 	return retval;
 }
 
-DLLEXPORT int DLLCALL tjDecompress(tjhandle handle, unsigned char *jpegBuf,
+DLLEXPORT int DLLCALL rdr_tjDecompress(tjhandle handle, unsigned char *jpegBuf,
 	unsigned long jpegSize, unsigned char *dstBuf, int width, int pitch,
 	int height, int pixelSize, int flags)
 {
-	return tjDecompress2(handle, jpegBuf, jpegSize, dstBuf, width, pitch,
+	return rdr_tjDecompress2(handle, jpegBuf, jpegSize, dstBuf, width, pitch,
 		height, getPixelFormat(pixelSize, flags), flags);
 }

--- a/src/common/turbojpeg.h
+++ b/src/common/turbojpeg.h
@@ -304,7 +304,7 @@ extern "C" {
  * @return a handle to the newly-created instance, or NULL if an error
  * occurred (see #tjGetErrorStr().)
  */
-DLLEXPORT tjhandle DLLCALL tjInitCompress(void);
+DLLEXPORT tjhandle DLLCALL rdr_tjInitCompress(void);
 
 
 /**
@@ -354,7 +354,7 @@ DLLEXPORT tjhandle DLLCALL tjInitCompress(void);
  *
  * @return 0 if successful, or -1 if an error occurred (see #tjGetErrorStr().)
 */
-DLLEXPORT int DLLCALL tjCompress2(tjhandle handle, unsigned char *srcBuf,
+DLLEXPORT int DLLCALL rdr_tjCompress2(tjhandle handle, unsigned char *srcBuf,
   int width, int pitch, int height, int pixelFormat, unsigned char **jpegBuf,
   unsigned long *jpegSize, int jpegSubsamp, int jpegQual, int flags);
 
@@ -379,7 +379,7 @@ DLLEXPORT int DLLCALL tjCompress2(tjhandle handle, unsigned char *srcBuf,
  * @return the maximum size of the buffer (in bytes) required to hold the
  * image, or -1 if the arguments are out of bounds.
  */
-DLLEXPORT unsigned long DLLCALL tjBufSize(int width, int height,
+DLLEXPORT unsigned long DLLCALL rdr_tjBufSize(int width, int height,
   int jpegSubsamp);
 
 
@@ -389,7 +389,7 @@ DLLEXPORT unsigned long DLLCALL tjBufSize(int width, int height,
  * @return a handle to the newly-created instance, or NULL if an error
  * occurred (see #tjGetErrorStr().)
 */
-DLLEXPORT tjhandle DLLCALL tjInitDecompress(void);
+DLLEXPORT tjhandle DLLCALL rdr_tjInitDecompress(void);
 
 
 /**
@@ -408,7 +408,7 @@ DLLEXPORT tjhandle DLLCALL tjInitDecompress(void);
  *
  * @return 0 if successful, or -1 if an error occurred (see #tjGetErrorStr().)
 */
-DLLEXPORT int DLLCALL tjDecompressHeader2(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompressHeader2(tjhandle handle,
   unsigned char *jpegBuf, unsigned long jpegSize, int *width, int *height,
   int *jpegSubsamp);
 
@@ -423,7 +423,7 @@ DLLEXPORT int DLLCALL tjDecompressHeader2(tjhandle handle,
  * @return a pointer to a list of fractional scaling factors, or NULL if an
  * error is encountered (see #tjGetErrorStr().)
 */
-DLLEXPORT tjscalingfactor* DLLCALL tjGetScalingFactors(int *numscalingfactors);
+DLLEXPORT tjscalingfactor* DLLCALL rdr_tjGetScalingFactors(int *numscalingfactors);
 
 
 /**
@@ -468,7 +468,7 @@ DLLEXPORT tjscalingfactor* DLLCALL tjGetScalingFactors(int *numscalingfactors);
  *
  * @return 0 if successful, or -1 if an error occurred (see #tjGetErrorStr().)
  */
-DLLEXPORT int DLLCALL tjDecompress2(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompress2(tjhandle handle,
   unsigned char *jpegBuf, unsigned long jpegSize, unsigned char *dstBuf,
   int width, int pitch, int height, int pixelFormat, int flags);
 
@@ -481,7 +481,7 @@ DLLEXPORT int DLLCALL tjDecompress2(tjhandle handle,
  *
  * @return 0 if successful, or -1 if an error occurred (see #tjGetErrorStr().)
  */
-DLLEXPORT int DLLCALL tjDestroy(tjhandle handle);
+DLLEXPORT int DLLCALL rdr_tjDestroy(tjhandle handle);
 
 
 /**
@@ -489,7 +489,7 @@ DLLEXPORT int DLLCALL tjDestroy(tjhandle handle);
  *
  * @return a descriptive error message explaining why the last command failed.
  */
-DLLEXPORT char* DLLCALL tjGetErrorStr(void);
+DLLEXPORT char* DLLCALL rdr_tjGetErrorStr(void);
 
 
 /* Backward compatibility functions and macros (nothing to see here) */
@@ -509,16 +509,16 @@ DLLEXPORT char* DLLCALL tjGetErrorStr(void);
 #define TJ_FORCESSE3 TJFLAG_FORCESSE3
 #define TJ_FASTUPSAMPLE TJFLAG_FASTUPSAMPLE
 
-DLLEXPORT unsigned long DLLCALL TJBUFSIZE(int width, int height);
+DLLEXPORT unsigned long DLLCALL rdr_TJBUFSIZE(int width, int height);
 
-DLLEXPORT int DLLCALL tjCompress(tjhandle handle, unsigned char *srcBuf,
+DLLEXPORT int DLLCALL rdr_tjCompress(tjhandle handle, unsigned char *srcBuf,
   int width, int pitch, int height, int pixelSize, unsigned char *dstBuf,
   unsigned long *compressedSize, int jpegSubsamp, int jpegQual, int flags);
 
-DLLEXPORT int DLLCALL tjDecompressHeader(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompressHeader(tjhandle handle,
   unsigned char *jpegBuf, unsigned long jpegSize, int *width, int *height);
 
-DLLEXPORT int DLLCALL tjDecompress(tjhandle handle,
+DLLEXPORT int DLLCALL rdr_tjDecompress(tjhandle handle,
   unsigned char *jpegBuf, unsigned long jpegSize, unsigned char *dstBuf,
   int width, int pitch, int height, int pixelSize, int flags);
 

--- a/src/libvncclient/tight.c
+++ b/src/libvncclient/tight.c
@@ -637,8 +637,8 @@ DecompressJpegRectBPP(rfbClient* client, int x, int y, int w, int h)
     return client->GotJpeg(client, compressedData, compressedLen, x, y, w, h);
   
   if (!client->tjhnd) {
-    if ((client->tjhnd = tjInitDecompress()) == NULL) {
-      rfbClientLog("TurboJPEG error: %s\n", tjGetErrorStr());
+    if ((client->tjhnd = rdr_tjInitDecompress()) == NULL) {
+      rfbClientLog("TurboJPEG error: %s\n", rdr_tjGetErrorStr());
       free(compressedData);
       return FALSE;
     }
@@ -659,9 +659,9 @@ DecompressJpegRectBPP(rfbClient* client, int x, int y, int w, int h)
   dst = &client->frameBuffer[y * pitch + x * pixelSize];
 #endif
 
-  if (tjDecompress(client->tjhnd, compressedData, (unsigned long)compressedLen,
+  if (rdr_tjDecompress(client->tjhnd, compressedData, (unsigned long)compressedLen,
                    dst, w, pitch, h, pixelSize, flags)==-1) {
-    rfbClientLog("TurboJPEG error: %s\n", tjGetErrorStr());
+    rfbClientLog("TurboJPEG error: %s\n", rdr_tjGetErrorStr());
     free(compressedData);
     return FALSE;
   }

--- a/src/libvncclient/vncviewer.c
+++ b/src/libvncclient/vncviewer.c
@@ -559,7 +559,7 @@ void rfbClientCleanup(rfbClient* client) {
 
 #ifdef LIBVNCSERVER_HAVE_LIBJPEG
   if(client->tjhnd){
-    tjDestroy(client->tjhnd);
+    rdr_tjDestroy(client->tjhnd);
     client->tjhnd = NULL;
   }
 #endif /* LIBVNCSERVER_HAVE_LIBJPEG */

--- a/src/libvncserver/tight.c
+++ b/src/libvncserver/tight.c
@@ -123,7 +123,7 @@ typedef struct PALETTE_s {
 void rfbFreeTightData (rfbClientPtr cl)
 {
     if (cl->tightTJ) {
-        tjDestroy(cl->tightTJ);
+        rdr_tjDestroy(cl->tightTJ);
 		/* Set freed resource handle to 0! */
         cl->tightTJ = 0;
 	}
@@ -1539,17 +1539,17 @@ SendJpegRect(rfbClientPtr cl, int x, int y, int w, int h, int quality)
         return 0;
     }
     if (!cl->tightTJ) {
-        if ((cl->tightTJ = tjInitCompress()) == NULL) {
-            rfbLog("JPEG Error: %s\n", tjGetErrorStr());
+        if ((cl->tightTJ = rdr_tjInitCompress()) == NULL) {
+            rfbLog("JPEG Error: %s\n", rdr_tjGetErrorStr());
             return 0;
         }
     }
 
-    if (!cl->afterEncBuf || cl->afterEncBufSize < TJBUFSIZE(w, h)) {
+    if (!cl->afterEncBuf || cl->afterEncBufSize < rdr_TJBUFSIZE(w, h)) {
         if (cl->afterEncBuf == NULL)
-            cl->afterEncBuf = (char *)malloc(TJBUFSIZE(w, h));
+            cl->afterEncBuf = (char *)malloc(rdr_TJBUFSIZE(w, h));
         else {
-            char *reallocedAfterEncBuf = (char *)realloc(cl->afterEncBuf, TJBUFSIZE(w, h));
+            char *reallocedAfterEncBuf = (char *)realloc(cl->afterEncBuf, rdr_TJBUFSIZE(w, h));
             if (!reallocedAfterEncBuf) return FALSE;
             cl->afterEncBuf = reallocedAfterEncBuf;
         }
@@ -1558,7 +1558,7 @@ SendJpegRect(rfbClientPtr cl, int x, int y, int w, int h, int quality)
             rfbLog("SendJpegRect: failed to allocate memory\n");
             return FALSE;
         }
-        cl->afterEncBufSize = TJBUFSIZE(w, h);
+        cl->afterEncBufSize = rdr_TJBUFSIZE(w, h);
     }
 
     if (ps == 2) {
@@ -1611,9 +1611,9 @@ SendJpegRect(rfbClientPtr cl, int x, int y, int w, int h, int quality)
             [y * pitch + x * ps];
     }
 
-    if (tjCompress(cl->tightTJ, srcbuf, w, pitch, h, ps, (unsigned char *)cl->afterEncBuf,
+    if (rdr_tjCompress(cl->tightTJ, srcbuf, w, pitch, h, ps, (unsigned char *)cl->afterEncBuf,
                    &size, subsamp, quality, flags) == -1) {
-        rfbLog("JPEG Error: %s\n", tjGetErrorStr());
+        rfbLog("JPEG Error: %s\n", rdr_tjGetErrorStr());
         if (tmpbuf) {
             free(tmpbuf);
             tmpbuf = NULL;

--- a/test/tjbench.c
+++ b/test/tjbench.c
@@ -41,7 +41,7 @@
 	(void)retval; /* silence warning */				\
 	retval=-1; goto bailout;}
 #define _throwunix(m) _throw(m, strerror(errno))
-#define _throwtj(m) _throw(m, tjGetErrorStr())
+#define _throwtj(m) _throw(m, rdr_tjGetErrorStr())
 #define _throwbmp(m) _throw(m, bmpgeterr())
 
 int flags=0, decomponly=0, quiet=0, dotile=0, pf=TJPF_BGR;
@@ -97,8 +97,8 @@ int decomptest(unsigned char *srcbuf, unsigned char **jpegbuf,
 		qualstr[5]=0;
 	}
 
-	if((handle=tjInitDecompress())==NULL)
-		_throwtj("executing tjInitDecompress()");
+	if((handle=rdr_tjInitDecompress())==NULL)
+		_throwtj("executing rdr_tjInitDecompress()");
 
 	bufsize=pitch*scaledh;
 	if(dstbuf==NULL)
@@ -112,9 +112,9 @@ int decomptest(unsigned char *srcbuf, unsigned char **jpegbuf,
 	memset(dstbuf, 127, bufsize);
 
 	/* Execute once to preload cache */
-	if(tjDecompress2(handle, jpegbuf[0], jpegsize[0], dstbuf, scaledw,
+	if(rdr_rdr_tjDecompress2(handle, jpegbuf[0], jpegsize[0], dstbuf, scaledw,
 		pitch, scaledh, pf, flags)==-1)
-		_throwtj("executing tjDecompress2()");
+		_throwtj("executing rdr_rdr_tjDecompress2()");
 
 	/* Benchmark */
 	for(i=0, start=gettime(); (elapsed=gettime()-start)<benchtime; i++)
@@ -126,14 +126,14 @@ int decomptest(unsigned char *srcbuf, unsigned char **jpegbuf,
 			{
 				int width=dotile? min(tilew, w-col*tilew):scaledw;
 				int height=dotile? min(tileh, h-row*tileh):scaledh;
-				if(tjDecompress2(handle, jpegbuf[tile], jpegsize[tile], dstptr2, width,
+				if(rdr_rdr_tjDecompress2(handle, jpegbuf[tile], jpegsize[tile], dstptr2, width,
 					pitch, height, pf, flags)==-1)
-					_throwtj("executing tjDecompress2()");
+					_throwtj("executing rdr_rdr_tjDecompress2()");
 			}
 		}
 	}
 
-	if(tjDestroy(handle)==-1) _throwtj("executing tjDestroy()");
+	if(rdr_tjDestroy(handle)==-1) _throwtj("executing rdr_tjDestroy()");
 	handle=NULL;
 
 	if(quiet)
@@ -200,7 +200,7 @@ int decomptest(unsigned char *srcbuf, unsigned char **jpegbuf,
 
 	bailout:
 	if(file) {fclose(file);  file=NULL;}
-	if(handle) {tjDestroy(handle);  handle=NULL;}
+	if(handle) {rdr_tjDestroy(handle);  handle=NULL;}
 	if(dstbuf && dstbufalloc) {free(dstbuf);  dstbuf=NULL;}
 	return retval;
 }
@@ -242,7 +242,7 @@ void dotest(unsigned char *srcbuf, int w, int h, int subsamp, int jpegqual,
 
 		for(i=0; i<ntilesw*ntilesh; i++)
 		{
-			if((jpegbuf[i]=(unsigned char *)malloc(tjBufSize(tilew, tileh,
+			if((jpegbuf[i]=(unsigned char *)malloc(rdr_tjBufSize(tilew, tileh,
 				subsamp)))==NULL)
 				_throwunix("allocating JPEG tiles");
 		}
@@ -253,13 +253,13 @@ void dotest(unsigned char *srcbuf, int w, int h, int subsamp, int jpegqual,
 				(flags&TJFLAG_BOTTOMUP)? "BU":"TD", subNameLong[subsamp], jpegqual);
 		for(i=0; i<h; i++)
 			memcpy(&tmpbuf[pitch*i], &srcbuf[w*ps*i], w*ps);
-		if((handle=tjInitCompress())==NULL)
-			_throwtj("executing tjInitCompress()");
+		if((handle=rdr_tjInitCompress())==NULL)
+			_throwtj("executing rdr_tjInitCompress()");
 
 		/* Execute once to preload cache */
-		if(tjCompress2(handle, srcbuf, tilew, pitch, tileh, pf, &jpegbuf[0],
+		if(rdr_rdr_tjCompress2(handle, srcbuf, tilew, pitch, tileh, pf, &jpegbuf[0],
 			&jpegsize[0], subsamp, jpegqual, flags)==-1)
-			_throwtj("executing tjCompress2()");
+			_throwtj("executing rdr_rdr_tjCompress2()");
 
 		/* Benchmark */
 		for(i=0, start=gettime(); (elapsed=gettime()-start)<benchtime; i++)
@@ -273,15 +273,15 @@ void dotest(unsigned char *srcbuf, int w, int h, int subsamp, int jpegqual,
 				{
 					int width=min(tilew, w-col*tilew);
 					int height=min(tileh, h-row*tileh);
-					if(tjCompress2(handle, srcptr2, width, pitch, height, pf,
+					if(rdr_rdr_tjCompress2(handle, srcptr2, width, pitch, height, pf,
 						&jpegbuf[tile], &jpegsize[tile], subsamp, jpegqual, flags)==-1)
-						_throwtj("executing tjCompress()2");
+						_throwtj("executing rdr_tjCompress()2");
 					totaljpegsize+=jpegsize[tile];
 				}
 			}
 		}
 
-		if(tjDestroy(handle)==-1) _throwtj("executing tjDestroy()");
+		if(rdr_tjDestroy(handle)==-1) _throwtj("executing rdr_tjDestroy()");
 		handle=NULL;
 
 		if(quiet==1) printf("%-4d  %-4d\t", tilew, tileh);
@@ -345,7 +345,7 @@ void dotest(unsigned char *srcbuf, int w, int h, int subsamp, int jpegqual,
 	}
 	if(jpegsize) {free(jpegsize);  jpegsize=NULL;}
 	if(tmpbuf) {free(tmpbuf);  tmpbuf=NULL;}
-	if(handle) {tjDestroy(handle);  handle=NULL;}
+	if(handle) {rdr_tjDestroy(handle);  handle=NULL;}
 	return;
 }
 
@@ -375,10 +375,10 @@ void dodecomptest(char *filename)
 	temp=strrchr(filename, '.');
 	if(temp!=NULL) *temp='\0';
 
-	if((handle=tjInitDecompress())==NULL)
-		_throwtj("executing tjInitDecompress()");
-	if(tjDecompressHeader2(handle, srcbuf, srcsize, &w, &h, &subsamp)==-1)
-		_throwtj("executing tjDecompressHeader2()");
+	if((handle=rdr_tjInitDecompress())==NULL)
+		_throwtj("executing rdr_tjInitDecompress()");
+	if(rdr_rdr_rdr_tjDecompressHeader2(handle, srcbuf, srcsize, &w, &h, &subsamp)==-1)
+		_throwtj("executing rdr_rdr_rdr_tjDecompressHeader2()");
 
 	if(quiet==1)
 	{
@@ -410,7 +410,7 @@ void dodecomptest(char *filename)
 
 		for(i=0; i<ntilesw*ntilesh; i++)
 		{
-			if((jpegbuf[i]=(unsigned char *)malloc(tjBufSize(tilew, tileh,
+			if((jpegbuf[i]=(unsigned char *)malloc(rdr_tjBufSize(tilew, tileh,
 				subsamp)))==NULL)
 				_throwunix("allocating JPEG tiles");
 		}
@@ -465,7 +465,7 @@ void dodecomptest(char *filename)
 	}
 	if(jpegsize) {free(jpegsize);  jpegsize=NULL;}
 	if(srcbuf) {free(srcbuf);  srcbuf=NULL;}
-	if(handle) {tjDestroy(handle);  handle=NULL;}
+	if(handle) {rdr_tjDestroy(handle);  handle=NULL;}
 	return;
 }
 
@@ -515,8 +515,8 @@ int main(int argc, char *argv[])
 	int minqual=-1, maxqual=-1;  char *temp;
 	int minarg=2;  int retval=0;
 
-	if((scalingfactors=tjGetScalingFactors(&nsf))==NULL || nsf==0)
-		_throwtj("executing tjGetScalingFactors()");
+	if((scalingfactors=rdr_tjGetScalingFactors(&nsf))==NULL || nsf==0)
+		_throwtj("executing rdr_tjGetScalingFactors()");
 
 	if(argc<minarg) usage(argv[0]);
 

--- a/test/tjunittest.c
+++ b/test/tjunittest.c
@@ -42,7 +42,7 @@
 #endif
 
 
-#define _throwtj() {printf("TurboJPEG ERROR:\n%s\n", tjGetErrorStr());  \
+#define _throwtj() {printf("TurboJPEG ERROR:\n%s\n", rdr_tjGetErrorStr());  \
 	bailout();}
 #define _tj(f) {if((f)==-1) _throwtj();}
 #define _throw(m) {printf("ERROR: %s\n", m);  bailout();}
@@ -252,8 +252,8 @@ void compTest(tjhandle handle, unsigned char **dstBuf,
 	if(*dstBuf && *dstSize>0) memset(*dstBuf, 0, *dstSize);
 
 	t=gettime();
-	*dstSize=tjBufSize(w, h, subsamp);
-	_tj(tjCompress2(handle, srcBuf, w, 0, h, pf, dstBuf, dstSize, subsamp,
+	*dstSize=rdr_tjBufSize(w, h, subsamp);
+	_tj(rdr_rdr_tjCompress2(handle, srcBuf, w, 0, h, pf, dstBuf, dstSize, subsamp,
 		jpegQual, flags));
 	t=gettime()-t;
 
@@ -285,7 +285,7 @@ void _decompTest(tjhandle handle, unsigned char *jpegBuf,
 		printf("%d/%d ... ", sf.num, sf.denom);
 	else printf("... ");
 
-	_tj(tjDecompressHeader2(handle, jpegBuf, jpegSize, &_hdrw, &_hdrh,
+	_tj(rdr_rdr_rdr_tjDecompressHeader2(handle, jpegBuf, jpegSize, &_hdrw, &_hdrh,
 		&_hdrsubsamp));
 	if(_hdrw!=w || _hdrh!=h || _hdrsubsamp!=subsamp)
 		_throw("Incorrect JPEG header");
@@ -296,7 +296,7 @@ void _decompTest(tjhandle handle, unsigned char *jpegBuf,
 	memset(dstBuf, 0, dstSize);
 
 	t=gettime();
-	_tj(tjDecompress2(handle, jpegBuf, jpegSize, dstBuf, scaledWidth, 0,
+	_tj(rdr_rdr_tjDecompress2(handle, jpegBuf, jpegSize, dstBuf, scaledWidth, 0,
 		scaledHeight, pf, flags));
 	t=gettime()-t;
 
@@ -315,7 +315,7 @@ void decompTest(tjhandle handle, unsigned char *jpegBuf,
 	int flags)
 {
 	int i, n=0;
-	tjscalingfactor *sf=tjGetScalingFactors(&n), sf1={1, 1};
+	tjscalingfactor *sf=rdr_tjGetScalingFactors(&n), sf1={1, 1};
 	if(!sf || !n) _throwtj();
 
 	if((subsamp==TJSAMP_444 || subsamp==TJSAMP_GRAY))
@@ -340,11 +340,11 @@ void doTest(int w, int h, const int *formats, int nformats, int subsamp,
 	unsigned char *dstBuf=NULL;
 	unsigned long size=0;  int pfi, pf, i;
 
-	size=tjBufSize(w, h, subsamp);
+	size=rdr_tjBufSize(w, h, subsamp);
 	if((dstBuf=(unsigned char *)malloc(size))==NULL)
 		_throw("Memory allocation failure.");
 
-	if((chandle=tjInitCompress())==NULL || (dhandle=tjInitDecompress())==NULL)
+	if((chandle=rdr_tjInitCompress())==NULL || (dhandle=rdr_tjInitDecompress())==NULL)
 		_throwtj();
 
 	for(pfi=0; pfi<nformats; pfi++)
@@ -367,8 +367,8 @@ void doTest(int w, int h, const int *formats, int nformats, int subsamp,
 	}
 
 	bailout:
-	if(chandle) tjDestroy(chandle);
-	if(dhandle) tjDestroy(dhandle);
+	if(chandle) rdr_tjDestroy(chandle);
+	if(dhandle) rdr_tjDestroy(dhandle);
 
 	free(dstBuf);
 }
@@ -381,7 +381,7 @@ void bufSizeTest(void)
 	tjhandle handle=NULL;
 	unsigned long jpegSize=0;
 
-	if((handle=tjInitCompress())==NULL) _throwtj();
+	if((handle=rdr_tjInitCompress())==NULL) _throwtj();
 
 	printf("Buffer size regression test\n");
 	for(subsamp=0; subsamp<TJ_NUMSAMP; subsamp++)
@@ -394,10 +394,10 @@ void bufSizeTest(void)
 				if(h%100==0) printf("%.4d x %.4d\b\b\b\b\b\b\b\b\b\b\b", w, h);
 				if((srcBuf=(unsigned char *)malloc(w*h*4))==NULL)
 					_throw("Memory allocation failure");
-				if((jpegBuf=(unsigned char *)malloc(tjBufSize(w, h, subsamp)))
+				if((jpegBuf=(unsigned char *)malloc(rdr_tjBufSize(w, h, subsamp)))
 					==NULL)
 					_throw("Memory allocation failure");
-				jpegSize=tjBufSize(w, h, subsamp);
+				jpegSize=rdr_tjBufSize(w, h, subsamp);
 
 				for(i=0; i<w*h*4; i++)
 				{
@@ -405,17 +405,17 @@ void bufSizeTest(void)
 					else srcBuf[i]=255;
 				}
 
-				_tj(tjCompress2(handle, srcBuf, w, 0, h, TJPF_BGRX, &jpegBuf,
+				_tj(rdr_rdr_tjCompress2(handle, srcBuf, w, 0, h, TJPF_BGRX, &jpegBuf,
 					&jpegSize, subsamp, 100, 0));
 				free(srcBuf);  srcBuf=NULL;
 				free(jpegBuf);  jpegBuf=NULL;
 
 				if((srcBuf=(unsigned char *)malloc(h*w*4))==NULL)
 					_throw("Memory allocation failure");
-				if((jpegBuf=(unsigned char *)malloc(tjBufSize(h, w, subsamp)))
+				if((jpegBuf=(unsigned char *)malloc(rdr_tjBufSize(h, w, subsamp)))
 					==NULL)
 					_throw("Memory allocation failure");
-				jpegSize=tjBufSize(h, w, subsamp);
+				jpegSize=rdr_tjBufSize(h, w, subsamp);
 
 				for(i=0; i<h*w*4; i++)
 				{
@@ -423,7 +423,7 @@ void bufSizeTest(void)
 					else srcBuf[i]=255;
 				}
 
-				_tj(tjCompress2(handle, srcBuf, h, 0, w, TJPF_BGRX, &jpegBuf,
+				_tj(rdr_rdr_tjCompress2(handle, srcBuf, h, 0, w, TJPF_BGRX, &jpegBuf,
 					&jpegSize, subsamp, 100, 0));
 				free(srcBuf);  srcBuf=NULL;
 				free(jpegBuf);  jpegBuf=NULL;
@@ -435,7 +435,7 @@ void bufSizeTest(void)
 	bailout:
 	free(srcBuf);
 	free(jpegBuf);
-	if(handle) tjDestroy(handle);
+	if(handle) rdr_tjDestroy(handle);
 }
 
 


### PR DESCRIPTION
Fixes #729.

### Problem
When an application links against both `libvncserver` and system `libjpeg-turbo` (directly or indirectly), calling TurboJPEG functions (like `tjCompress2`, `tjDecompress`, etc.) resolves to `libvncserver`'s internal embedded implementation instead of system `libjpeg-turbo` due to exported symbol collision. This causes unexpected behaviors and potential crashes in downstream applications.

### Solution
Prefix internal TurboJPEG function names and macros with `rdr_` (`rdr_tjInitCompress`, `rdr_tjCompress2`, `rdr_tjDecompress`, etc.) in `src/common/turbojpeg.h`, `src/common/turbojpeg.c`, and internal consumers (`src/libvncserver/tight.c`, `src/libvncclient/tight.c`, `src/libvncclient/vncviewer.c`, and tests).

### Verification
- Built `libvncserver` via CMake.
- Ran `readelf -Ws build/libvncserver.so | grep tj` and verified no global `tj*` symbols are exported.
- Executed unit tests (`ctest`), all 4 tests passed.